### PR TITLE
THO-364 QoL Improvements artist feedback

### DIFF
--- a/SobrassadaEngine/FileSystem/Importers/SceneImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/SceneImporter.cpp
@@ -57,7 +57,7 @@ namespace SceneImporter
                 matIndex = primitive.material;
                 if (matIndex == -1)
                 {
-                    GLOG("Material index invalid for mesh: %s", name.c_str());
+                    matUID = DEFAULT_MATERIAL_UID;
                 }
                 else if (matIndices.find(matIndex) == matIndices.end())
                 {

--- a/SobrassadaEngine/Modules/SceneModule.cpp
+++ b/SobrassadaEngine/Modules/SceneModule.cpp
@@ -131,15 +131,26 @@ update_status SceneModule::PostUpdate(float deltaTime)
 
         // CTRL+D -> Duplicate selected game object
         if (keyboard[SDL_SCANCODE_LCTRL] && keyboard[SDL_SCANCODE_D] == KeyState::KEY_DOWN &&
-            !loadedScene->IsMultiselecting() && loadedScene->GetGameObjectRootUID() != loadedScene->GetSelectedGameObjectUID())
+            !loadedScene->IsMultiselecting() &&
+            loadedScene->GetGameObjectRootUID() != loadedScene->GetSelectedGameObjectUID())
         {
-            GameObject* gameObjectToClone = loadedScene->GetSelectedGameObject();
+            GameObject* gameObjectToClone       = loadedScene->GetSelectedGameObject();
             GameObject* gameObjectToCloneParent = loadedScene->GetGameObjectByUID(gameObjectToClone->GetParent());
 
-            GameObject* clonedGameObject  = new GameObject(gameObjectToClone->GetParent(), gameObjectToClone);
+            GameObject* clonedGameObject        = new GameObject(gameObjectToClone->GetParent(), gameObjectToClone);
 
             gameObjectToCloneParent->AddChildren(clonedGameObject->GetUID());
             loadedScene->AddGameObject(clonedGameObject->GetUID(), clonedGameObject);
+        }
+
+        // Delete -> Delete selected game object
+        if (keyboard[SDL_SCANCODE_DELETE] == KeyState::KEY_DOWN &&
+            loadedScene->GetGameObjectRootUID() != loadedScene->GetSelectedGameObjectUID())
+        {
+            if (loadedScene->IsMultiselecting()) loadedScene->DeleteMultiselection();
+            else loadedScene->RemoveGameObjectHierarchy(loadedScene->GetSelectedGameObjectUID());
+
+            loadedScene->SetSelectedGameObject(loadedScene->GetGameObjectRootUID());
         }
 
         // CHECKING FOR UPDATED STATIC AND DYNAMIC OBJECTS

--- a/SobrassadaEngine/Modules/SceneModule.cpp
+++ b/SobrassadaEngine/Modules/SceneModule.cpp
@@ -186,7 +186,7 @@ update_status SceneModule::PostUpdate(float deltaTime)
                 loadedScene->AddGameObject(clonedGameObject->GetUID(), clonedGameObject);
             }
 
-            // ITERATE OVER ALL GAME OBJECTS TO CHECK IF ANY REMMAPING IS NEEDED
+            // ITERATE OVER ALL GAME OBJECTS TO CHECK IF ANY REMAPING IS NEEDED
             for (int i = 0; i < createdGameObjects.size(); ++i)
             {
                 MeshComponent* originalMeshComp = originalGameObjects[i]->GetMeshComponent();
@@ -211,8 +211,6 @@ update_status SceneModule::PostUpdate(float deltaTime)
                 AnimationComponent* animComp = createdGameObjects[i]->GetAnimationComponent();
                 if (animComp) animComp->SetBoneMapping();
             }
-
-            int x = 0;
         }
 
         // Delete -> Delete selected game object

--- a/SobrassadaEngine/Modules/SceneModule.cpp
+++ b/SobrassadaEngine/Modules/SceneModule.cpp
@@ -162,12 +162,13 @@ update_status SceneModule::PostUpdate(float deltaTime)
                 gameObjectToClone = loadedScene->GetGameObjectByUID(currentGameObjectPair.second);
                 gameObjectToCloneParent = loadedScene->GetGameObjectByUID(currentGameObjectPair.first);
 
+                clonedGameObject = new GameObject(currentGameObjectPair.first, gameObjectToClone);
+                
                 for (UID child : gameObjectToClone->GetChildren())
                 {
-                    gameObjectsToClone.push(std::make_pair(gameObjectToClone->GetUID(), child));
+                    gameObjectsToClone.push(std::make_pair(clonedGameObject->GetUID(), child));
                 }
 
-                clonedGameObject = new GameObject(currentGameObjectPair.first, gameObjectToClone);
 
                 gameObjectToCloneParent->AddChildren(clonedGameObject->GetUID());
                 loadedScene->AddGameObject(clonedGameObject->GetUID(), clonedGameObject);
@@ -179,7 +180,8 @@ update_status SceneModule::PostUpdate(float deltaTime)
             loadedScene->GetGameObjectRootUID() != loadedScene->GetSelectedGameObjectUID())
         {
             if (loadedScene->IsMultiselecting()) loadedScene->DeleteMultiselection();
-            else loadedScene->RemoveGameObjectHierarchy(loadedScene->GetSelectedGameObjectUID());
+            else 
+                loadedScene->RemoveGameObjectHierarchy(loadedScene->GetSelectedGameObjectUID());
 
             loadedScene->SetSelectedGameObject(loadedScene->GetGameObjectRootUID());
         }

--- a/SobrassadaEngine/Modules/SceneModule.cpp
+++ b/SobrassadaEngine/Modules/SceneModule.cpp
@@ -10,11 +10,11 @@
 #include "ImGuizmo.h"
 #include "InputModule.h"
 #include "LibraryModule.h"
+#include "PathfinderModule.h"
 #include "PhysicsModule.h"
 #include "ProjectModule.h"
 #include "RaycastController.h"
 #include "ResourcesModule.h"
-#include "PathfinderModule.h"
 
 #include <SDL_mouse.h>
 #ifdef OPTICK
@@ -86,11 +86,14 @@ update_status SceneModule::PostUpdate(float deltaTime)
 {
     if (App->GetProjectModule()->IsProjectLoaded())
     {
+
+        const KeyState* mouseButtons = App->GetInputModule()->GetMouseButtons();
+        const KeyState* keyboard     = App->GetInputModule()->GetKeyboard();
+
         // CAST RAY WHEN LEFT CLICK IS RELEASED
         if (GetDoMouseInputsScene() && !ImGuizmo::IsUsingAny())
         {
-            const KeyState* mouseButtons = App->GetInputModule()->GetMouseButtons();
-            const KeyState* keyboard     = App->GetInputModule()->GetKeyboard();
+
             if (mouseButtons[SDL_BUTTON_LEFT - 1] == KeyState::KEY_DOWN && !keyboard[SDL_SCANCODE_LALT])
             {
                 GameObject* selectedObject = RaycastController::GetRayIntersectionTrees<Octree, Quadtree>(
@@ -106,11 +109,16 @@ update_status SceneModule::PostUpdate(float deltaTime)
 
         if (GetDoInputsGame())
         {
-            const KeyState* mouseButtons = App->GetInputModule()->GetMouseButtons();
             if (mouseButtons[SDL_BUTTON_LEFT - 1] == KeyState::KEY_DOWN)
             {
                 App->GetPathfinderModule()->HandleClickNavigation();
             }
+        }
+
+        // CTRL+D -> Duplicate selected game object
+        if (keyboard[SDL_SCANCODE_LCTRL] && keyboard[SDL_SCANCODE_D] == KeyState::KEY_DOWN)
+        {
+            // GameObject* clonedGameObject = new GameObject()
         }
 
         // CHECKING FOR UPDATED STATIC AND DYNAMIC OBJECTS

--- a/SobrassadaEngine/Modules/SceneModule.cpp
+++ b/SobrassadaEngine/Modules/SceneModule.cpp
@@ -20,8 +20,8 @@
 
 #include <SDL_mouse.h>
 #include <map>
-#include <tuple>
 #include <queue>
+#include <tuple>
 #ifdef OPTICK
 #include "optick.h"
 #endif
@@ -96,35 +96,7 @@ update_status SceneModule::PostUpdate(float deltaTime)
         const KeyState* keyboard     = App->GetInputModule()->GetKeyboard();
 
         // CAST RAY WHEN LEFT CLICK IS RELEASED
-        if (GetDoMouseInputsScene() && !ImGuizmo::IsUsingAny())
-        {
-
-            if (mouseButtons[SDL_BUTTON_LEFT - 1] == KeyState::KEY_DOWN && !keyboard[SDL_SCANCODE_LALT] &&
-                keyboard[SDL_SCANCODE_LSHIFT])
-            {
-                GameObject* selectedObject = RaycastController::GetRayIntersectionTrees<Octree, Quadtree>(
-                    App->GetCameraModule()->CastCameraRay(), loadedScene->GetOctree(), loadedScene->GetDynamicTree()
-                );
-
-                if (selectedObject != nullptr)
-                {
-                    if (!loadedScene->IsMultiselecting())
-                        loadedScene->SetMultiselectPosition(selectedObject->GetPosition());
-
-                    loadedScene->AddGameObjectToSelection(selectedObject->GetUID(), selectedObject->GetParent());
-                }
-            }
-            else if (mouseButtons[SDL_BUTTON_LEFT - 1] == KeyState::KEY_DOWN && !keyboard[SDL_SCANCODE_LALT])
-            {
-                GameObject* selectedObject = RaycastController::GetRayIntersectionTrees<Octree, Quadtree>(
-                    App->GetCameraModule()->CastCameraRay(), loadedScene->GetOctree(), loadedScene->GetDynamicTree()
-                );
-
-                if (selectedObject != nullptr) loadedScene->SetSelectedGameObject(selectedObject->GetUID());
-
-                loadedScene->ClearObjectSelection();
-            }
-        }
+        if (GetDoMouseInputsScene() && !ImGuizmo::IsUsingAny()) HandleRaycast(mouseButtons, keyboard);
 
         if (GetDoInputsGame())
         {
@@ -137,130 +109,17 @@ update_status SceneModule::PostUpdate(float deltaTime)
         // CTRL+D -> Duplicate selected game object
         if (keyboard[SDL_SCANCODE_LCTRL] && keyboard[SDL_SCANCODE_D] == KeyState::KEY_DOWN &&
             loadedScene->GetGameObjectRootUID() != loadedScene->GetSelectedGameObjectUID())
-        {
-
-            std::vector<std::pair<UID, UID>> objectsToDuplicate; // GAME OBJECT | GAME OBJECT PARENT
-
-            if (loadedScene->IsMultiselecting())
-            {
-                const std::map<UID, UID> selectedGameObjects = loadedScene->GetMultiselectedObjects();
-
-                for (auto& childToDuplicate : selectedGameObjects)
-                    objectsToDuplicate.push_back(childToDuplicate);
-            }
-            else
-            {
-                objectsToDuplicate.push_back(
-                    {loadedScene->GetSelectedGameObject()->GetUID(), loadedScene->GetSelectedGameObject()->GetParent()}
-                );
-            }
-
-            for (int indexToDuplicate = 0; indexToDuplicate < objectsToDuplicate.size(); ++indexToDuplicate)
-            {
-                std::map<UID, UID> remappingTable; // Reference UID | New GameObject UID
-                std::vector<GameObject*> createdGameObjects;
-                std::vector<GameObject*> originalGameObjects;
-
-                GameObject* gameObjectToClone =
-                    loadedScene->GetGameObjectByUID(objectsToDuplicate[indexToDuplicate].first);
-                GameObject* gameObjectToCloneParent =
-                    loadedScene->GetGameObjectByUID(objectsToDuplicate[indexToDuplicate].second);
-
-                GameObject* clonedGameObject = new GameObject(gameObjectToClone->GetParent(), gameObjectToClone);
-
-                remappingTable.insert({gameObjectToClone->GetUID(), clonedGameObject->GetUID()});
-                createdGameObjects.push_back(clonedGameObject);
-                originalGameObjects.push_back(gameObjectToClone);
-
-                gameObjectToCloneParent->AddChildren(clonedGameObject->GetUID());
-                loadedScene->AddGameObject(clonedGameObject->GetUID(), clonedGameObject);
-
-                // CREATE DOWARDS HIERARCHY, FIRST ADD ALL CHILDREN (Parent, ChildrenUID)
-                std::queue<std::pair<UID, UID>> gameObjectsToClone;
-
-                for (UID child : gameObjectToClone->GetChildren())
-                {
-                    gameObjectsToClone.push(std::make_pair(clonedGameObject->GetUID(), child));
-                }
-
-                Scene* scene = App->GetSceneModule()->GetScene();
-
-                while (!gameObjectsToClone.empty())
-                {
-                    std::pair<UID, UID> currentGameObjectPair = gameObjectsToClone.front();
-                    gameObjectsToClone.pop();
-
-                    gameObjectToClone       = loadedScene->GetGameObjectByUID(currentGameObjectPair.second);
-                    gameObjectToCloneParent = loadedScene->GetGameObjectByUID(currentGameObjectPair.first);
-
-                    clonedGameObject        = new GameObject(currentGameObjectPair.first, gameObjectToClone);
-
-                    remappingTable.insert({gameObjectToClone->GetUID(), clonedGameObject->GetUID()});
-                    createdGameObjects.push_back(clonedGameObject);
-                    originalGameObjects.push_back(gameObjectToClone);
-
-                    for (UID child : gameObjectToClone->GetChildren())
-                    {
-                        gameObjectsToClone.push(std::make_pair(clonedGameObject->GetUID(), child));
-                    }
-
-                    gameObjectToCloneParent->AddChildren(clonedGameObject->GetUID());
-                    loadedScene->AddGameObject(clonedGameObject->GetUID(), clonedGameObject);
-                }
-
-                // ITERATE OVER ALL GAME OBJECTS TO CHECK IF ANY REMAPING IS NEEDED
-                for (int i = 0; i < createdGameObjects.size(); ++i)
-                {
-                    MeshComponent* originalMeshComp = originalGameObjects[i]->GetMeshComponent();
-                    if (originalMeshComp && originalMeshComp->GetHasBones())
-                    {
-                        // Remap the bones references
-                        const std::vector<UID>& bones = originalMeshComp->GetBones();
-                        std::vector<UID> newBonesUIDs;
-                        std::vector<GameObject*> newBonesObjects;
-
-                        for (const UID bone : bones)
-                        {
-                            const UID uid = remappingTable.find(bone)->second;
-                            newBonesUIDs.push_back(uid);
-                            newBonesObjects.push_back(loadedScene->GetGameObjectByUID(uid));
-                        }
-
-                        MeshComponent* newMesh = createdGameObjects[i]->GetMeshComponent();
-                        newMesh->SetBones(newBonesObjects, newBonesUIDs);
-                    }
-
-                    AnimationComponent* animComp = createdGameObjects[i]->GetAnimationComponent();
-                    if (animComp) animComp->SetBoneMapping();
-                }
-            }
-        }
+            HandleObjectDuplication();
 
         // Delete -> Delete selected game object
         if (keyboard[SDL_SCANCODE_DELETE] == KeyState::KEY_DOWN &&
             loadedScene->GetGameObjectRootUID() != loadedScene->GetSelectedGameObjectUID())
-        {
-            if (loadedScene->IsMultiselecting()) loadedScene->DeleteMultiselection();
-            else loadedScene->RemoveGameObjectHierarchy(loadedScene->GetSelectedGameObjectUID());
-
-            loadedScene->SetSelectedGameObject(loadedScene->GetGameObjectRootUID());
-        }
+            HandleObjectDeletion();
 
         // CHECKING FOR UPDATED STATIC AND DYNAMIC OBJECTS
         GizmoDragState currentGizmoState = App->GetEditorUIModule()->GetImGuizmoDragState();
         if (currentGizmoState == GizmoDragState::RELEASED || currentGizmoState == GizmoDragState::IDLE)
-        {
-            if (loadedScene->IsStaticModified())
-            {
-                loadedScene->UpdateStaticSpatialStructure();
-            }
-            if (loadedScene->IsDynamicModified())
-            {
-                loadedScene->UpdateDynamicSpatialStructure();
-            }
-
-            loadedScene->UpdateGameObjects();
-        }
+            HandleTreesUpdates();
 
         // IF SCENE NOT FOCUSED AND WAS MULTISELECTING RELEASE
         if (loadedScene->IsMultiselecting() && !loadedScene->IsSceneFocused()) loadedScene->ClearObjectSelection();
@@ -335,4 +194,152 @@ void SceneModule::SwitchPlayMode(bool play)
     {
         if (App->GetLibraryModule()->SaveScene("", SaveMode::SavePlayMode)) inPlayMode = true;
     }
+}
+
+void SceneModule::HandleRaycast(const KeyState* mouseButtons, const KeyState* keyboard)
+{
+    if (mouseButtons[SDL_BUTTON_LEFT - 1] == KeyState::KEY_DOWN && !keyboard[SDL_SCANCODE_LALT] &&
+        keyboard[SDL_SCANCODE_LSHIFT])
+    {
+        GameObject* selectedObject = RaycastController::GetRayIntersectionTrees<Octree, Quadtree>(
+            App->GetCameraModule()->CastCameraRay(), loadedScene->GetOctree(), loadedScene->GetDynamicTree()
+        );
+
+        if (selectedObject != nullptr)
+        {
+            if (!loadedScene->IsMultiselecting()) loadedScene->SetMultiselectPosition(selectedObject->GetPosition());
+
+            loadedScene->AddGameObjectToSelection(selectedObject->GetUID(), selectedObject->GetParent());
+        }
+    }
+    else if (mouseButtons[SDL_BUTTON_LEFT - 1] == KeyState::KEY_DOWN && !keyboard[SDL_SCANCODE_LALT])
+    {
+        GameObject* selectedObject = RaycastController::GetRayIntersectionTrees<Octree, Quadtree>(
+            App->GetCameraModule()->CastCameraRay(), loadedScene->GetOctree(), loadedScene->GetDynamicTree()
+        );
+
+        if (selectedObject != nullptr) loadedScene->SetSelectedGameObject(selectedObject->GetUID());
+
+        loadedScene->ClearObjectSelection();
+    }
+}
+
+void SceneModule::HandleObjectDuplication()
+{
+    std::vector<std::pair<UID, UID>> objectsToDuplicate; // GAME OBJECT | GAME OBJECT PARENT
+
+    if (loadedScene->IsMultiselecting())
+    {
+        const std::map<UID, UID> selectedGameObjects = loadedScene->GetMultiselectedObjects();
+
+        for (auto& childToDuplicate : selectedGameObjects)
+            objectsToDuplicate.push_back(childToDuplicate);
+    }
+    else
+    {
+        objectsToDuplicate.push_back(
+            {loadedScene->GetSelectedGameObject()->GetUID(), loadedScene->GetSelectedGameObject()->GetParent()}
+        );
+    }
+
+    for (int indexToDuplicate = 0; indexToDuplicate < objectsToDuplicate.size(); ++indexToDuplicate)
+    {
+        std::map<UID, UID> remappingTable; // Reference UID | New GameObject UID
+        std::vector<GameObject*> createdGameObjects;
+        std::vector<GameObject*> originalGameObjects;
+
+        GameObject* gameObjectToClone = loadedScene->GetGameObjectByUID(objectsToDuplicate[indexToDuplicate].first);
+        GameObject* gameObjectToCloneParent =
+            loadedScene->GetGameObjectByUID(objectsToDuplicate[indexToDuplicate].second);
+
+        GameObject* clonedGameObject = new GameObject(gameObjectToClone->GetParent(), gameObjectToClone);
+
+        remappingTable.insert({gameObjectToClone->GetUID(), clonedGameObject->GetUID()});
+        createdGameObjects.push_back(clonedGameObject);
+        originalGameObjects.push_back(gameObjectToClone);
+
+        gameObjectToCloneParent->AddChildren(clonedGameObject->GetUID());
+        loadedScene->AddGameObject(clonedGameObject->GetUID(), clonedGameObject);
+
+        // CREATE DOWARDS HIERARCHY, FIRST ADD ALL CHILDREN (Parent, ChildrenUID)
+        std::queue<std::pair<UID, UID>> gameObjectsToClone;
+
+        for (UID child : gameObjectToClone->GetChildren())
+        {
+            gameObjectsToClone.push(std::make_pair(clonedGameObject->GetUID(), child));
+        }
+
+        Scene* scene = App->GetSceneModule()->GetScene();
+
+        while (!gameObjectsToClone.empty())
+        {
+            std::pair<UID, UID> currentGameObjectPair = gameObjectsToClone.front();
+            gameObjectsToClone.pop();
+
+            gameObjectToClone       = loadedScene->GetGameObjectByUID(currentGameObjectPair.second);
+            gameObjectToCloneParent = loadedScene->GetGameObjectByUID(currentGameObjectPair.first);
+
+            clonedGameObject        = new GameObject(currentGameObjectPair.first, gameObjectToClone);
+
+            remappingTable.insert({gameObjectToClone->GetUID(), clonedGameObject->GetUID()});
+            createdGameObjects.push_back(clonedGameObject);
+            originalGameObjects.push_back(gameObjectToClone);
+
+            for (UID child : gameObjectToClone->GetChildren())
+            {
+                gameObjectsToClone.push(std::make_pair(clonedGameObject->GetUID(), child));
+            }
+
+            gameObjectToCloneParent->AddChildren(clonedGameObject->GetUID());
+            loadedScene->AddGameObject(clonedGameObject->GetUID(), clonedGameObject);
+        }
+
+        // ITERATE OVER ALL GAME OBJECTS TO CHECK IF ANY REMAPING IS NEEDED
+        for (int i = 0; i < createdGameObjects.size(); ++i)
+        {
+            MeshComponent* originalMeshComp = originalGameObjects[i]->GetMeshComponent();
+            if (originalMeshComp && originalMeshComp->GetHasBones())
+            {
+                // Remap the bones references
+                const std::vector<UID>& bones = originalMeshComp->GetBones();
+                std::vector<UID> newBonesUIDs;
+                std::vector<GameObject*> newBonesObjects;
+
+                for (const UID bone : bones)
+                {
+                    const UID uid = remappingTable.find(bone)->second;
+                    newBonesUIDs.push_back(uid);
+                    newBonesObjects.push_back(loadedScene->GetGameObjectByUID(uid));
+                }
+
+                MeshComponent* newMesh = createdGameObjects[i]->GetMeshComponent();
+                newMesh->SetBones(newBonesObjects, newBonesUIDs);
+            }
+
+            AnimationComponent* animComp = createdGameObjects[i]->GetAnimationComponent();
+            if (animComp) animComp->SetBoneMapping();
+        }
+    }
+}
+
+void SceneModule::HandleObjectDeletion()
+{
+    if (loadedScene->IsMultiselecting()) loadedScene->DeleteMultiselection();
+    else loadedScene->RemoveGameObjectHierarchy(loadedScene->GetSelectedGameObjectUID());
+
+    loadedScene->SetSelectedGameObject(loadedScene->GetGameObjectRootUID());
+}
+
+void SceneModule::HandleTreesUpdates()
+{
+    if (loadedScene->IsStaticModified())
+    {
+        loadedScene->UpdateStaticSpatialStructure();
+    }
+    if (loadedScene->IsDynamicModified())
+    {
+        loadedScene->UpdateDynamicSpatialStructure();
+    }
+
+    loadedScene->UpdateGameObjects();
 }

--- a/SobrassadaEngine/Modules/SceneModule.cpp
+++ b/SobrassadaEngine/Modules/SceneModule.cpp
@@ -94,7 +94,8 @@ update_status SceneModule::PostUpdate(float deltaTime)
         if (GetDoMouseInputsScene() && !ImGuizmo::IsUsingAny())
         {
 
-            if (mouseButtons[SDL_BUTTON_LEFT - 1] == KeyState::KEY_DOWN && !keyboard[SDL_SCANCODE_LALT])
+            if (mouseButtons[SDL_BUTTON_LEFT - 1] == KeyState::KEY_DOWN && !keyboard[SDL_SCANCODE_LALT] &&
+                keyboard[SDL_SCANCODE_LSHIFT])
             {
                 GameObject* selectedObject = RaycastController::GetRayIntersectionTrees<Octree, Quadtree>(
                     App->GetCameraModule()->CastCameraRay(), loadedScene->GetOctree(), loadedScene->GetDynamicTree()
@@ -129,9 +130,16 @@ update_status SceneModule::PostUpdate(float deltaTime)
         }
 
         // CTRL+D -> Duplicate selected game object
-        if (keyboard[SDL_SCANCODE_LCTRL] && keyboard[SDL_SCANCODE_D] == KeyState::KEY_DOWN)
+        if (keyboard[SDL_SCANCODE_LCTRL] && keyboard[SDL_SCANCODE_D] == KeyState::KEY_DOWN &&
+            !loadedScene->IsMultiselecting() && loadedScene->GetGameObjectRootUID() != loadedScene->GetSelectedGameObjectUID())
         {
-            // GameObject* clonedGameObject = new GameObject()
+            GameObject* gameObjectToClone = loadedScene->GetSelectedGameObject();
+            GameObject* gameObjectToCloneParent = loadedScene->GetGameObjectByUID(gameObjectToClone->GetParent());
+
+            GameObject* clonedGameObject  = new GameObject(gameObjectToClone->GetParent(), gameObjectToClone);
+
+            gameObjectToCloneParent->AddChildren(clonedGameObject->GetUID());
+            loadedScene->AddGameObject(clonedGameObject->GetUID(), clonedGameObject);
         }
 
         // CHECKING FOR UPDATED STATIC AND DYNAMIC OBJECTS

--- a/SobrassadaEngine/Modules/SceneModule.h
+++ b/SobrassadaEngine/Modules/SceneModule.h
@@ -6,6 +6,7 @@
 #include "rapidjson/document.h"
 
 class GameObject;
+enum KeyState;
 
 class SceneModule : public Module
 {
@@ -41,6 +42,12 @@ class SceneModule : public Module
     bool GetInPlayMode() const { return inPlayMode; }
 
     void AddGameObjectToUpdate(GameObject* gameObject) { loadedScene->AddGameObjectToUpdate(gameObject); };
+
+  private:
+    void HandleRaycast(const KeyState* mouseButtons, const KeyState* keyboard);
+    void HandleObjectDuplication();
+    void HandleObjectDeletion();
+    void HandleTreesUpdates();
 
   private:
     Scene* loadedScene = nullptr;

--- a/SobrassadaEngine/Scene/Components/Standalone/AnimationComponent.h
+++ b/SobrassadaEngine/Scene/Components/Standalone/AnimationComponent.h
@@ -34,12 +34,11 @@ class AnimationComponent : public Component
     UID GetAnimationResource() const { GLOG("Resource AnimUID  is: %d", resource) return resource; }
     ResourceAnimation* GetCurrentAnimation() const { return currentAnimResource; }
     AnimController* GetAnimationController() { return animController; }
-    std::unordered_map<std::string, GameObject*> GetBoneMapping() const { return boneMapping; }
+    const std::unordered_map<std::string, GameObject*>& GetBoneMapping() const { return boneMapping; }
 
     void SetAnimationResource(UID animResource);
 
     void SetBoneMapping();
-  private:
 
   private:
     UID resource                           = INVALID_UID;

--- a/SobrassadaEngine/Scene/Components/Standalone/AnimationComponent.h
+++ b/SobrassadaEngine/Scene/Components/Standalone/AnimationComponent.h
@@ -38,8 +38,8 @@ class AnimationComponent : public Component
 
     void SetAnimationResource(UID animResource);
 
-  private:
     void SetBoneMapping();
+  private:
 
   private:
     UID resource                           = INVALID_UID;

--- a/SobrassadaEngine/Scene/Components/Standalone/MeshComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/MeshComponent.cpp
@@ -107,6 +107,7 @@ void MeshComponent::Clone(const Component* other)
         modelUID     = otherMesh->modelUID;
         skinIndex    = otherMesh->skinIndex;
         bindMatrices = otherMesh->bindMatrices;
+        hasBones     = otherMesh->hasBones;
     }
     else
     {

--- a/SobrassadaEngine/Scene/Components/Standalone/Physics/CapsuleColliderComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/Physics/CapsuleColliderComponent.cpp
@@ -96,6 +96,24 @@ void CapsuleColliderComponent::Save(rapidjson::Value& targetState, rapidjson::Do
 
 void CapsuleColliderComponent::Clone(const Component* other)
 {
+    if (other->GetType() == COMPONENT_CAPSULE_COLLIDER)
+    {
+        const CapsuleColliderComponent* capsule = static_cast<const CapsuleColliderComponent*>(other);
+
+        generateCallback                        = capsule->generateCallback;
+        freezeRotation                          = capsule->freezeRotation;
+        fitToSize                               = capsule->fitToSize;
+        mass                                    = capsule->mass;
+        centerOffset                            = capsule->centerOffset;
+        centerRotation                          = capsule->centerRotation;
+        radius                                  = capsule->radius;
+        length                                  = capsule->length;
+        colliderType                            = capsule->colliderType;
+        layer                                   = capsule->layer;
+
+        if (rigidBody) App->GetPhysicsModule()->UpdateCapsuleRigidBody(this);
+        else App->GetPhysicsModule()->CreateCapsuleRigidBody(this);
+    }
 }
 
 void CapsuleColliderComponent::RenderEditorInspector()

--- a/SobrassadaEngine/Scene/Components/Standalone/Physics/CubeColliderComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/Physics/CubeColliderComponent.cpp
@@ -101,6 +101,23 @@ void CubeColliderComponent::Save(rapidjson::Value& targetState, rapidjson::Docum
 
 void CubeColliderComponent::Clone(const Component* other)
 {
+    if (other->GetType() == COMPONENT_CUBE_COLLIDER)
+    {
+        const CubeColliderComponent* cube = static_cast<const CubeColliderComponent*>(other);
+
+        generateCallback                  = cube->generateCallback;
+        freezeRotation                    = cube->freezeRotation;
+        fitToSize                         = cube->fitToSize;
+        mass                              = cube->mass;
+        centerOffset                      = cube->centerOffset;
+        centerRotation                    = cube->centerRotation;
+        size                              = cube->size;
+        colliderType                      = cube->colliderType;
+        layer                             = cube->layer;
+
+        if (rigidBody) App->GetPhysicsModule()->UpdateCubeRigidBody(this);
+        else App->GetPhysicsModule()->CreateCubeRigidBody(this);
+    }
 }
 
 void CubeColliderComponent::RenderEditorInspector()

--- a/SobrassadaEngine/Scene/Components/Standalone/Physics/SphereColliderComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/Physics/SphereColliderComponent.cpp
@@ -94,6 +94,23 @@ void SphereColliderComponent::Save(rapidjson::Value& targetState, rapidjson::Doc
 
 void SphereColliderComponent::Clone(const Component* other)
 {
+    if (other->GetType() == COMPONENT_SPHERE_COLLIDER)
+    {
+        const SphereColliderComponent* sphere = static_cast<const SphereColliderComponent*>(other);
+
+        generateCallback                      = sphere->generateCallback;
+        freezeRotation                        = sphere->freezeRotation;
+        mass                                  = sphere->mass;
+        centerOffset                          = sphere->centerOffset;
+        centerRotation                        = sphere->centerRotation;
+        radius                                = sphere->radius;
+        colliderType                          = sphere->colliderType;
+        layer                                 = sphere->layer;
+        fitToSize                             = sphere->fitToSize;
+
+        if (rigidBody) App->GetPhysicsModule()->UpdateSphereRigidBody(this);
+        else App->GetPhysicsModule()->CreateSphereRigidBody(this);
+    }
 }
 
 void SphereColliderComponent::RenderEditorInspector()

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
@@ -62,6 +62,7 @@ GameObject::GameObject(UID parentUID, GameObject* refObject)
     position         = refObject->position;
     rotation         = refObject->rotation;
     scale            = refObject->scale;
+    prefabUID        = refObject->prefabUID;
 
     // Must make a copy of each manually
     for (const auto& component : refObject->components)
@@ -838,6 +839,9 @@ void GameObject::UpdateMobilityHierarchy(MobilitySettings type)
             if (currentGameObject->GetParent() != sceneRootUID) toVisitGameObjects.push(currentGameObject->GetParent());
         }
     }
+
+    App->GetSceneModule()->GetScene()->SetStaticModified();
+    App->GetSceneModule()->GetScene()->SetDynamicModified();
 }
 
 bool GameObject::CreateComponent(const ComponentType componentType)

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
@@ -83,7 +83,8 @@ GameObject::GameObject(UID parentUID, GameObject* refObject)
 
         GameObject* otherGameObject = scene->GetGameObjectByUID(currentGameObjectPair.second);
 
-        GameObject* newClone        = new GameObject(uid ,otherGameObject);
+        GameObject* newClone        = new GameObject(currentGameObjectPair.first, otherGameObject);
+        AddChildren(newClone->uid);
         scene->AddGameObject(newClone->GetUID(), newClone);
     }
 

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
@@ -6,14 +6,14 @@
 #include "EditorUIModule.h"
 #include "PrefabManager.h"
 #include "SceneModule.h"
-#include "Standalone/MeshComponent.h"
 #include "Standalone/AnimationComponent.h"
+#include "Standalone/MeshComponent.h"
 #include "Standalone/UI/Transform2DComponent.h"
 
 #include "imgui.h"
+#include <queue>
 #include <set>
 #include <stack>
-#include <queue>
 
 GameObject::GameObject(const std::string& name) : name(name)
 {

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.h
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.h
@@ -92,14 +92,13 @@ class SOBRASADA_API_ENGINE GameObject
 
     MeshComponent* GetMeshComponent() const;
 
-   AnimationComponent* GetAnimationComponent() const;
+    AnimationComponent* GetAnimationComponent() const;
 
     const float3& GetPosition() const { return position; }
     const float3& GetRotation() const { return rotation; }
     const float3& GetScale() const { return scale; }
     AABB GetHierarchyAABB();
 
-    
     void SetLocalTransform(const float4x4& newTransform);
     void DrawGizmos() const;
 
@@ -110,7 +109,6 @@ class SOBRASADA_API_ENGINE GameObject
     void OnTransformUpdated();
     void SetPosition(float3& newPosition) { position = newPosition; };
     void SetWillUpdate(bool willUpdate) { this->willUpdate = willUpdate; };
-
 
   private:
     void DrawNodes() const;

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -576,7 +576,7 @@ void Scene::RenderHierarchyUI(bool& hierarchyMenu)
 void Scene::RemoveGameObjectHierarchy(UID gameObjectUID)
 {
     // TODO: Change when filesystem defined
-    if (!gameObjectsContainer.count(gameObjectUID) || gameObjectUID == gameObjectRootUID) return;
+    if (!gameObjectsContainer.count(gameObjectUID) || gameObjectUID == gameObjectRootUID || gameObjectUID == multiSelectParent->GetUID()) return;
 
     std::stack<UID> toDelete;
     toDelete.push(gameObjectUID);
@@ -725,7 +725,7 @@ void Scene::DeleteMultiselection()
 
         selectedGameObjectParent->RemoveGameObject(pairGameObject.first);
         selectedGameObjectParent->UpdateTransformForGOBranch();
-        
+
         RemoveGameObjectHierarchy(pairGameObject.first);
     }
     selectedGameObjects.clear();
@@ -897,10 +897,8 @@ void Scene::LoadModel(const UID modelUID)
 
                 if (currentParentIndex == -1)
                 {
-                    GameObject* rootObject = new GameObject(
-                        GetGameObjectRootUID(), currentNodeData.name,
-                        gameObjectsUID[currentNodeIndex]
-                    );
+                    GameObject* rootObject =
+                        new GameObject(GetGameObjectRootUID(), currentNodeData.name, gameObjectsUID[currentNodeIndex]);
                     rootObject->SetLocalTransform(currentNodeData.transform);
                     // Add the gameObject to the rootObject
                     GetGameObjectByUID(GetGameObjectRootUID())->AddGameObject(rootObject->GetUID());

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -651,6 +651,11 @@ void Scene::UpdateGameObjects()
     gameObjectsToUpdate.clear();
 }
 
+void Scene::ClearGameObjectsToUpdate()
+{
+    gameObjectsToUpdate.clear();
+}
+
 void Scene::AddGameObjectToSelection(UID gameObject, UID gameObjectParent)
 {
     auto pairResult = selectedGameObjects.insert({gameObject, gameObjectParent});
@@ -723,8 +728,8 @@ void Scene::DeleteMultiselection()
         
         RemoveGameObjectHierarchy(pairGameObject.first);
     }
-
     selectedGameObjects.clear();
+    ClearGameObjectsToUpdate();
 }
 
 const std::vector<Component*> Scene::GetAllComponents() const

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -898,7 +898,7 @@ void Scene::LoadModel(const UID modelUID)
                 if (currentParentIndex == -1)
                 {
                     GameObject* rootObject = new GameObject(
-                        GetGameObjectRootUID(), App->GetLibraryModule()->GetResourceName(modelUID),
+                        GetGameObjectRootUID(), currentNodeData.name,
                         gameObjectsUID[currentNodeIndex]
                     );
                     rootObject->SetLocalTransform(currentNodeData.transform);

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -173,7 +173,7 @@ void Scene::Save(
 
     for (auto it = gameObjectsContainer.begin(); it != gameObjectsContainer.end(); ++it)
     {
-        if (it->second != nullptr)
+        if (it->second != nullptr && it->second != multiSelectParent)
         {
             rapidjson::Value goJSON(rapidjson::kObjectType);
 
@@ -773,7 +773,7 @@ void Scene::CreateStaticSpatialDataStruct()
 
         if (!objectIterator.second->IsStatic()) continue;
         if (objectIterator.second->GetUID() == gameObjectRootUID) continue;
-        if (!objectBB.IsFinite() || objectBB.IsDegenerate()) continue;
+        if (!objectBB.IsFinite() || objectBB.IsDegenerate() || objectBB.Size().IsZero()) continue;
 
         sceneOctree->InsertElement(objectIterator.second);
     }
@@ -793,7 +793,7 @@ void Scene::CreateDynamicSpatialDataStruct()
 
         if (objectIterator.second->IsStatic()) continue;
         if (objectIterator.second->GetUID() == gameObjectRootUID) continue;
-        if (!objectBB.IsFinite() || objectBB.IsDegenerate()) continue;
+        if (!objectBB.IsFinite() || objectBB.IsDegenerate() || objectBB.Size().IsZero()) continue;
 
         dynamicTree->InsertElement(objectIterator.second);
     }

--- a/SobrassadaEngine/Scene/Scene.h
+++ b/SobrassadaEngine/Scene/Scene.h
@@ -71,6 +71,7 @@ class Scene
     UID GetSceneUID() const { return sceneUID; }
     UID GetGameObjectRootUID() const { return gameObjectRootUID; }
     GameObject* GetSelectedGameObject() { return GetGameObjectByUID(selectedGameObjectUID); }
+    UID GetSelectedGameObjectUID() const { return selectedGameObjectUID; }
 
     const std::unordered_map<UID, GameObject*>& GetAllGameObjects() const { return gameObjectsContainer; }
     const std::vector<Component*> GetAllComponents() const;

--- a/SobrassadaEngine/Scene/Scene.h
+++ b/SobrassadaEngine/Scene/Scene.h
@@ -97,6 +97,7 @@ class Scene
     Quadtree* GetDynamicTree() const { return dynamicTree; }
     UID GetMultiselectUID() const;
     GameObject* GetMultiselectParent() { return multiSelectParent; }
+    const std::map<UID, UID>& GetMultiselectedObjects() const { return selectedGameObjects; }
 
     void SetSelectedGameObject(UID newSelectedGameObject) { selectedGameObjectUID = newSelectedGameObject; };
 

--- a/SobrassadaEngine/Scene/Scene.h
+++ b/SobrassadaEngine/Scene/Scene.h
@@ -63,6 +63,7 @@ class Scene
 
     void AddGameObjectToUpdate(GameObject* gameObject);
     void UpdateGameObjects();
+    void ClearGameObjectsToUpdate();
 
     void AddGameObjectToSelection(UID gameObject, UID gameObjectParent);
     void ClearObjectSelection();

--- a/SobrassadaEngine/Scene/Scene.h
+++ b/SobrassadaEngine/Scene/Scene.h
@@ -66,6 +66,7 @@ class Scene
 
     void AddGameObjectToSelection(UID gameObject, UID gameObjectParent);
     void ClearObjectSelection();
+    void DeleteMultiselection();
 
     const std::string& GetSceneName() const { return sceneName; }
     UID GetSceneUID() const { return sceneUID; }
@@ -94,6 +95,7 @@ class Scene
     Octree* GetOctree() const { return sceneOctree; }
     Quadtree* GetDynamicTree() const { return dynamicTree; }
     UID GetMultiselectUID() const;
+    GameObject* GetMultiselectParent() { return multiSelectParent; }
 
     void SetSelectedGameObject(UID newSelectedGameObject) { selectedGameObjectUID = newSelectedGameObject; };
 


### PR DESCRIPTION
Adds hability to copy and delete game objects even inside a multiselection.

Also now nodes in Models have their node name instead of the filename (reinport them before testing)

If you want to delete in multiselection use the hotkey, if you try to delete with the button the multiselection  is cleared to avoid further bugs with other options in the engine.