### PR TITLE
Task/lg load gltf default material THO-380 THO-381

### DIFF
--- a/SobrassadaEngine/FileSystem/Importers/MeshImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/MeshImporter.cpp
@@ -20,7 +20,7 @@ namespace MeshImporter
 
     UID ImportMesh(
         const tinygltf::Model& model, const tinygltf::Mesh& mesh, const tinygltf::Primitive& primitive,
-        const std::string& name, const char* sourceFilePath, const std::string& targetFilePath, UID sourceUID,
+        const std::string& name, const float4x4& meshTransform, const char* sourceFilePath, const std::string& targetFilePath, UID sourceUID,
         UID defaultMatUID
     )
     {
@@ -317,11 +317,7 @@ namespace MeshImporter
         {
             UID meshUID           = GenerateUID();
             finalMeshUID          = App->GetLibraryModule()->AssignFiletypeUID(meshUID, FileType::Mesh);
-
-            std::string nameNoExt = name;
-            if (!name.empty()) nameNoExt.pop_back(); // remove last character (number)
-            const float4x4& meshTransform = GetMeshDefaultTransform(model, nameNoExt);
-
+            
             std::string assetPath         = ASSETS_PATH + FileSystem::GetFileNameWithExtension(sourceFilePath);
             MetaMesh meta(finalMeshUID, assetPath, generateTangents, meshTransform, defaultMatUID);
             meta.Save(name, assetPath);

--- a/SobrassadaEngine/FileSystem/Importers/MeshImporter.h
+++ b/SobrassadaEngine/FileSystem/Importers/MeshImporter.h
@@ -26,7 +26,7 @@ namespace MeshImporter
 {
     UID ImportMesh(
         const tinygltf::Model& model, const tinygltf::Mesh& mesh, const tinygltf::Primitive& primitive,
-        const std::string& name, const char* filePath, const std::string& targetFilePath, UID sourceUID = INVALID_UID, UID defaultMatUID = INVALID_UID
+        const std::string& name, const float4x4& meshTransform, const char* filePath, const std::string& targetFilePath, UID sourceUID = INVALID_UID, UID defaultMatUID = INVALID_UID
     );
     const float4x4 GetMeshDefaultTransform(const tinygltf::Model& model, const std::string& name);
     const float4x4 GetNodeTransform(const tinygltf::Node& node);

--- a/SobrassadaEngine/FileSystem/Importers/SceneImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/SceneImporter.cpp
@@ -45,18 +45,20 @@ namespace SceneImporter
         
         for (const tinygltf::Node& srcNode : model.nodes)
         {
-            int n = 0;
             int matIndex = -1;
-            std::vector<std::pair<UID, UID>> primitives;
 
             if (srcNode.mesh >= 0 && srcNode.mesh < model.meshes.size())
             {
+                std::vector<std::pair<UID, UID>> primitives;
+                
                 const tinygltf::Mesh& srcMesh = model.meshes[srcNode.mesh];
                 const float4x4& defaultTransform = MeshImporter::GetNodeTransform(srcNode);
+                int primitiveCounter = 0;
 
                 for (const auto& primitive : srcMesh.primitives)
                 {
                     std::string name = srcNode.name + "_" + srcMesh.name;
+                    if (primitiveCounter > 0) name += "_" + std::to_string(primitiveCounter);
 
                     UID matUID   = INVALID_UID;
                     matIndex = primitive.material;
@@ -76,7 +78,7 @@ namespace SceneImporter
                 
                     const UID meshUID      = MeshImporter::ImportMesh(model, srcMesh, primitive, name, defaultTransform,
                         filePath, targetFilePath, INVALID_UID, matUID);
-                    n++;
+                    primitiveCounter++;
                 
                     primitives.emplace_back(meshUID, matUID);
                     GLOG("New primitive with mesh UID: %d and Material UID: %d", meshUID, matUID);

--- a/SobrassadaEngine/FileSystem/Importers/SceneImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/SceneImporter.cpp
@@ -81,9 +81,9 @@ namespace SceneImporter
                     primitives.emplace_back(meshUID, matUID);
                     GLOG("New primitive with mesh UID: %d and Material UID: %d", meshUID, matUID);
                 }
+                
+                gltfMeshes.push_back(primitives);
             }
-            
-            gltfMeshes.push_back(primitives);
         }
 
         GLOG("Total .gltf meshes: %d", gltfMeshes.size());

--- a/SobrassadaEngine/Modules/EditorUIModule.cpp
+++ b/SobrassadaEngine/Modules/EditorUIModule.cpp
@@ -970,6 +970,7 @@ T EditorUIModule::RenderResourceSelectDialog(
                         if (ImGui::Selectable(valuePair.first.c_str(), false))
                         {
                             result = valuePair.second;
+                            memset(searchTextResource, 0, sizeof searchTextResource);
                             ImGui::CloseCurrentPopup();
                         }
                     }

--- a/SobrassadaEngine/Scene/Components/Standalone/MeshComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/MeshComponent.cpp
@@ -206,12 +206,10 @@ void MeshComponent::AddMesh(UID resource, bool updateParent)
 
 void MeshComponent::AddMaterial(UID resource)
 {
-    bool isMaterialInvalid = false;
 
     if (resource == INVALID_UID || App->GetResourcesModule()->RequestResource(resource) == nullptr)
     {
         resource = DEFAULT_MATERIAL_UID;
-        isMaterialInvalid = true;
     }
 
     if (currentMaterial != nullptr && currentMaterial->GetUID() == resource) return;
@@ -223,8 +221,6 @@ void MeshComponent::AddMaterial(UID resource)
         App->GetResourcesModule()->ReleaseResource(currentMaterial);
         currentMaterial     = newMaterial;
         currentMaterialName = currentMaterial->GetName();
-
-        if (isMaterialInvalid) newMaterial->ChangeFallBackTexture();
 
         if (batch) BatchEditorMode();
     }


### PR DESCRIPTION
This pr contains necessary adaptions to correctly import artist gltfs
Main changes:

Fixed issue when loading gltfs without material (Default materials diffuse texture is not changed anymore to the fallback texture)
GLTF loading is now based on nodes rather than meshes. The nodes are iterated and load their assigned meshes and primitives. That solves an issue we had when loading default transforms (It needed the name of the node and mesh to be the same which was not the case for artist gltfs)

For testing: Import gltfs and see if everything works as previously
