### PR TITLE
THO-387 Duplication in multiselect in VS2 merge 0.3.3 crashes if colliders

### DIFF
--- a/SobrassadaEngine/Modules/SceneModule.cpp
+++ b/SobrassadaEngine/Modules/SceneModule.cpp
@@ -227,13 +227,16 @@ void SceneModule::HandleRaycast(const KeyState* mouseButtons, const KeyState* ke
 void SceneModule::HandleObjectDuplication()
 {
     std::vector<std::pair<UID, UID>> objectsToDuplicate; // GAME OBJECT | GAME OBJECT PARENT
+    std::map<UID, UID> remappingTable;                   // Reference UID | New GameObject UID
 
     if (loadedScene->IsMultiselecting())
     {
         const std::map<UID, UID> selectedGameObjects = loadedScene->GetMultiselectedObjects();
 
         for (auto& childToDuplicate : selectedGameObjects)
+        {
             objectsToDuplicate.push_back(childToDuplicate);
+        }
     }
     else
     {
@@ -244,7 +247,6 @@ void SceneModule::HandleObjectDuplication()
 
     for (int indexToDuplicate = 0; indexToDuplicate < objectsToDuplicate.size(); ++indexToDuplicate)
     {
-        std::map<UID, UID> remappingTable; // Reference UID | New GameObject UID
         std::vector<GameObject*> createdGameObjects;
         std::vector<GameObject*> originalGameObjects;
 
@@ -318,6 +320,18 @@ void SceneModule::HandleObjectDuplication()
 
             AnimationComponent* animComp = createdGameObjects[i]->GetAnimationComponent();
             if (animComp) animComp->SetBoneMapping();
+        }
+    }
+
+    if (loadedScene->IsMultiselecting())
+    {
+        const std::map<UID, MobilitySettings> originalObjectMobility = loadedScene->GetMultiselectedObjectsMobility();
+
+        for (int i = 0; i < objectsToDuplicate.size(); ++i)
+        {
+            MobilitySettings originalMobility = originalObjectMobility.find(objectsToDuplicate[i].first)->second;
+            loadedScene->GetGameObjectByUID(remappingTable[objectsToDuplicate[i].first])
+                ->UpdateMobilityHierarchy(originalMobility);
         }
     }
 }

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
@@ -850,15 +850,19 @@ void GameObject::UpdateMobilityHierarchy(MobilitySettings type)
         if (visitedGameObjects.find(currentUID) == visitedGameObjects.end())
         {
             visitedGameObjects.insert(currentUID);
+
             GameObject* currentGameObject = App->GetSceneModule()->GetScene()->GetGameObjectByUID(currentUID);
+            if (currentGameObject)
+            {
+                currentGameObject->SetMobility(type);
+                App->GetSceneModule()->AddGameObjectToUpdate(currentGameObject);
 
-            currentGameObject->SetMobility(type);
-            App->GetSceneModule()->AddGameObjectToUpdate(currentGameObject);
+                for (UID childID : currentGameObject->GetChildren())
+                    toVisitGameObjects.push(childID);
 
-            for (UID childID : currentGameObject->GetChildren())
-                toVisitGameObjects.push(childID);
-
-            if (currentGameObject->GetParent() != sceneRootUID) toVisitGameObjects.push(currentGameObject->GetParent());
+                if (currentGameObject->GetParent() != sceneRootUID)
+                    toVisitGameObjects.push(currentGameObject->GetParent());
+            }
         }
     }
 

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.h
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.h
@@ -113,7 +113,6 @@ class SOBRASADA_API_ENGINE GameObject
     bool IsEnabled() const { return enabled; }
     void SetEnabled(bool state) { enabled = state; }
 
-
   private:
     void DrawNodes() const;
     void OnDrawConnectionsToggle();

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -775,6 +775,7 @@ void Scene::DeleteMultiselection()
         RemoveGameObjectHierarchy(pairGameObject.first);
     }
     selectedGameObjects.clear();
+    selectedGameObjectsMobility.clear();
     ClearGameObjectsToUpdate();
 }
 

--- a/SobrassadaEngine/Scene/Scene.h
+++ b/SobrassadaEngine/Scene/Scene.h
@@ -18,6 +18,7 @@ class ResourcePrefab;
 class Quadtree;
 class CameraComponent;
 enum class SaveMode;
+enum MobilitySettings;
 
 class Scene
 {
@@ -99,6 +100,10 @@ class Scene
     UID GetMultiselectUID() const;
     GameObject* GetMultiselectParent() { return multiSelectParent; }
     const std::map<UID, UID>& GetMultiselectedObjects() const { return selectedGameObjects; }
+    const std::map<UID, MobilitySettings>& GetMultiselectedObjectsMobility() const
+    {
+        return selectedGameObjectsMobility;
+    }
 
     void SetSelectedGameObject(UID newSelectedGameObject) { selectedGameObjectUID = newSelectedGameObject; };
 
@@ -108,7 +113,6 @@ class Scene
     void SetDynamicModified() { dynamicModified = true; }
     void SetMultiselectPosition(const float3& newPosition);
     template <typename T> std::vector<T*> GetEnabledComponentsOfType() const;
-
 
   private:
     void CreateStaticSpatialDataStruct();
@@ -145,4 +149,5 @@ class Scene
 
     GameObject* multiSelectParent = nullptr;
     std::map<UID, UID> selectedGameObjects;
+    std::map<UID, MobilitySettings> selectedGameObjectsMobility;
 };


### PR DESCRIPTION
The title explains, also there is a bug that the mobility settings of duplicated game objects are wrong.

To test: Create dynamic and static game object, multiselect them and start duplicating, check they mantain their mobility setting.