### PR TITLE
Engine functions while playing THO-232

### DIFF
--- a/SobrassadaEngine/Main.cpp
+++ b/SobrassadaEngine/Main.cpp
@@ -9,8 +9,6 @@
 #include "optick.h"
 #endif
 
-#include <memory>
-
 extern "C"
 {
     _declspec(dllexport) DWORD NvOptimusEnablement                = 1;

--- a/SobrassadaEngine/Modules/CameraModule.cpp
+++ b/SobrassadaEngine/Modules/CameraModule.cpp
@@ -36,8 +36,8 @@ bool CameraModule::Init()
 
     camera.horizontalFov             = (float)HFOV / RAD_DEGREE_CONV;
 
-    int width                        = App->GetWindowModule()->GetWidth();
-    int height                       = App->GetWindowModule()->GetHeight();
+    const int width                  = App->GetWindowModule()->GetWidth();
+    const int height                 = App->GetWindowModule()->GetHeight();
 
     camera.verticalFov               = 2.0f * atanf(tanf(camera.horizontalFov * 0.5f) * ((float)height / (float)width));
 
@@ -126,16 +126,16 @@ void CameraModule::Controls(float deltaTime)
     const KeyState* keyboard     = inputModule->GetKeyboard();
     const KeyState* mouseButtons = inputModule->GetMouseButtons();
     const float2& mouseMotion    = inputModule->GetMouseMotion();
-    int mouseWheel               = inputModule->GetMouseWheel();
+    const int mouseWheel         = inputModule->GetMouseWheel();
 
     float scaleFactor            = movementScaleFactor;
     if (keyboard[SDL_SCANCODE_LSHIFT]) scaleFactor *= 2;
 
-    float finalCameraSpeed       = cameraMoveSpeed * scaleFactor * deltaTime;
-    float finalRotateSensitivity = rotateSensitivity * scaleFactor;
-    float finalDragSensitivity   = dragSensitivity * scaleFactor;
-    float finalWheelSensitivity  = wheelSensitivity * scaleFactor;
-    float finalZoomSensitivity   = zoomSensitivity * scaleFactor;
+    const float finalCameraSpeed       = cameraMoveSpeed * scaleFactor * deltaTime;
+    const float finalRotateSensitivity = rotateSensitivity * scaleFactor;
+    const float finalDragSensitivity   = dragSensitivity * scaleFactor;
+    const float finalWheelSensitivity  = wheelSensitivity * scaleFactor;
+    const float finalZoomSensitivity   = zoomSensitivity * scaleFactor;
 
     if (mouseButtons[SDL_BUTTON_RIGHT - 1])
     {
@@ -190,9 +190,9 @@ void CameraModule::Controls(float deltaTime)
         else
         {
             // ROTATION WITH MOUSE
-            float mouseX             = mouseMotion.x;
-            float mouseY             = mouseMotion.y;
-            float deltaRotationAngle = cameraRotationAngle * finalRotateSensitivity;
+            const float mouseX             = mouseMotion.x;
+            const float mouseY             = mouseMotion.y;
+            const float deltaRotationAngle = cameraRotationAngle * finalRotateSensitivity;
             RotateCamera(-mouseX * deltaRotationAngle, -mouseY * deltaRotationAngle);
         }
     }
@@ -229,9 +229,9 @@ void CameraModule::Controls(float deltaTime)
     // ORBIT
     if (mouseButtons[SDL_BUTTON_LEFT - 1] && keyboard[SDL_SCANCODE_LALT])
     {
-        float mouseX             = mouseMotion.x;
-        float mouseY             = mouseMotion.y;
-        float deltaRotationAngle = cameraRotationAngle * finalRotateSensitivity;
+        const float mouseX             = mouseMotion.x;
+        const float mouseY             = mouseMotion.y;
+        const float deltaRotationAngle = cameraRotationAngle * finalRotateSensitivity;
 
         RotateCamera(-mouseX * deltaRotationAngle, -mouseY * deltaRotationAngle);
 
@@ -329,8 +329,8 @@ void CameraModule::FocusCamera()
 
     if (distance == 0 || distance == FLOAT_INF || distance == -FLOAT_INF) distance = 1;
 
-    float3 direction   = camera.front.Normalized();
-    float3 newPosition = center - direction * (float)distance;
+    const float3 direction   = camera.front.Normalized();
+    const float3 newPosition = center - direction * (float)distance;
 
     camera.pos         = newPosition;
     camera.front       = (center - newPosition).Normalized();

--- a/SobrassadaEngine/Modules/EditorUIModule.cpp
+++ b/SobrassadaEngine/Modules/EditorUIModule.cpp
@@ -80,7 +80,7 @@ EditorUIModule::~EditorUIModule()
 
 bool EditorUIModule::Init()
 {
-    context = ImGui::CreateContext();
+    ImGuiContext* context = ImGui::CreateContext();
     ImGuizmo::SetImGuiContext(context);
     ImGuiIO& io     = ImGui::GetIO();
     io.ConfigFlags &= ~ImGuiConfigFlags_NavEnableKeyboard; // Enable Keyboard Controls

--- a/SobrassadaEngine/Modules/EditorUIModule.cpp
+++ b/SobrassadaEngine/Modules/EditorUIModule.cpp
@@ -19,6 +19,7 @@
 #include "SceneImporter.h"
 
 #include "SceneModule.h"
+#include "Script.h"
 #include "ScriptModule.h"
 #include "StateMachineEditor.h"
 #include "TextureEditor.h"
@@ -98,16 +99,6 @@ bool EditorUIModule::Init()
     return true;
 }
 
-void EditorUIModule::DrawScriptInspector(std::function<void()> callback)
-{
-
-    if (ImGui::CollapsingHeader("Script Inspector", ImGuiTreeNodeFlags_None))
-    {
-        callback();
-    }
-    callback = nullptr;
-}
-
 update_status EditorUIModule::PreUpdate(float deltaTime)
 {
 #ifndef GAME
@@ -185,7 +176,6 @@ update_status EditorUIModule::PostUpdate(float deltaTime)
 bool EditorUIModule::ShutDown()
 {
     App->GetScriptModule()->close();
-
 
     framerate.clear();
     frametime.clear();
@@ -799,6 +789,29 @@ std::string EditorUIModule::RenderFileDialog(bool& window, const char* windowTit
     }
 
     return importPath;
+}
+
+void EditorUIModule::DrawScriptInspector(const std::vector<InspectorField>& fields)
+{
+
+    for (auto& field : fields)
+    {
+        switch (field.type)
+        {
+        case InspectorField::FieldType::Text:
+            ImGui::Text(static_cast<const char*>(field.data));
+            break;
+        case InspectorField::FieldType::Float:
+            ImGui::SliderFloat(field.name, (float*)field.data, field.minValue, field.maxValue);
+            break;
+        case InspectorField::FieldType::Bool:
+            ImGui::Checkbox(field.name, (bool*)field.data);
+            break;
+        case InspectorField::FieldType::Int:
+            ImGui::InputInt(field.name, (int*)field.data);
+            break;
+        }
+    }
 }
 
 void EditorUIModule::ImportDialog(bool& import)

--- a/SobrassadaEngine/Modules/EditorUIModule.cpp
+++ b/SobrassadaEngine/Modules/EditorUIModule.cpp
@@ -810,6 +810,30 @@ void EditorUIModule::DrawScriptInspector(const std::vector<InspectorField>& fiel
         case InspectorField::FieldType::Int:
             ImGui::InputInt(field.name, (int*)field.data);
             break;
+        case InspectorField::FieldType::Vec2:
+        {
+            float* vec2Data = reinterpret_cast<float*>(field.data);
+            ImGui::SliderFloat2(field.name, vec2Data, field.minValue, field.maxValue);
+            break;
+        }
+        case InspectorField::FieldType::Vec3:
+        {
+            float* vec3Data = reinterpret_cast<float*>(field.data);
+            ImGui::SliderFloat3(field.name, vec3Data, field.minValue, field.maxValue);
+            break;
+        }
+        case InspectorField::FieldType::Vec4:
+        {
+            float* vec4Data = reinterpret_cast<float*>(field.data);
+            ImGui::SliderFloat4(field.name, vec4Data, field.minValue, field.maxValue);
+            break;
+        }
+        case InspectorField::FieldType::Color:
+        {
+            ImColor* color = (ImColor*)field.data;
+            ImGui::ColorEdit3(field.name, (float*)&color->Value);
+            break;
+        }
         }
     }
 }

--- a/SobrassadaEngine/Modules/EditorUIModule.cpp
+++ b/SobrassadaEngine/Modules/EditorUIModule.cpp
@@ -24,7 +24,6 @@
 #include "TextureEditor.h"
 #include "TextureImporter.h"
 #include "WindowModule.h"
-#include "ScriptModule.h"
 
 #include "Math/Quat.h"
 #include "SDL.h"
@@ -101,11 +100,12 @@ bool EditorUIModule::Init()
 
 void EditorUIModule::DrawScriptInspector(std::function<void()> callback)
 {
-    ImGui::SetNextItemOpen(true, ImGuiCond_Always);
+
     if (ImGui::CollapsingHeader("Script Inspector", ImGuiTreeNodeFlags_None))
     {
         callback();
     }
+    callback = nullptr;
 }
 
 update_status EditorUIModule::PreUpdate(float deltaTime)
@@ -184,9 +184,8 @@ update_status EditorUIModule::PostUpdate(float deltaTime)
 
 bool EditorUIModule::ShutDown()
 {
-    ImGui_ImplOpenGL3_Shutdown();
-    ImGui_ImplSDL2_Shutdown();
-    ImGui::DestroyContext();
+    App->GetScriptModule()->close();
+
 
     framerate.clear();
     frametime.clear();

--- a/SobrassadaEngine/Modules/EditorUIModule.cpp
+++ b/SobrassadaEngine/Modules/EditorUIModule.cpp
@@ -24,6 +24,7 @@
 #include "TextureEditor.h"
 #include "TextureImporter.h"
 #include "WindowModule.h"
+#include "ScriptModule.h"
 
 #include "Math/Quat.h"
 #include "SDL.h"
@@ -79,7 +80,7 @@ EditorUIModule::~EditorUIModule()
 
 bool EditorUIModule::Init()
 {
-    ImGuiContext* context = ImGui::CreateContext();
+    context = ImGui::CreateContext();
     ImGuizmo::SetImGuiContext(context);
     ImGuiIO& io     = ImGui::GetIO();
     io.ConfigFlags &= ~ImGuiConfigFlags_NavEnableKeyboard; // Enable Keyboard Controls
@@ -96,6 +97,15 @@ bool EditorUIModule::Init()
     fileDialogCurrentPath = App->GetProjectModule()->GetLoadedProjectPath();
 
     return true;
+}
+
+void EditorUIModule::DrawScriptInspector(std::function<void()> callback)
+{
+    ImGui::SetNextItemOpen(true, ImGuiCond_Always);
+    if (ImGui::CollapsingHeader("Script Inspector", ImGuiTreeNodeFlags_None))
+    {
+        callback();
+    }
 }
 
 update_status EditorUIModule::PreUpdate(float deltaTime)

--- a/SobrassadaEngine/Modules/EditorUIModule.h
+++ b/SobrassadaEngine/Modules/EditorUIModule.h
@@ -15,6 +15,7 @@
 #include <vector>
 
 class EngineEditorBase;
+struct InspectorField;
 
 namespace ImGuizmo
 {
@@ -83,7 +84,7 @@ class EditorUIModule : public Module
     GizmoTransform& GetTransformType() { return transformType; }
     float3& GetSnapValues() { return snapValues; }
     GizmoDragState GetImGuizmoDragState() const { return guizmoDragState; };
-    void SOBRASADA_API_ENGINE DrawScriptInspector(std::function<void()> callback);
+    void SOBRASADA_API_ENGINE DrawScriptInspector(const std::vector<InspectorField>& fields);
     ImGuiContext* GetImGuiContext() { return context; }
 
     const std::unordered_map<std::string, ComponentType>& GetStandaloneComponents() const

--- a/SobrassadaEngine/Modules/EditorUIModule.h
+++ b/SobrassadaEngine/Modules/EditorUIModule.h
@@ -86,7 +86,6 @@ class EditorUIModule : public Module
     float3& GetSnapValues() { return snapValues; }
     GizmoDragState GetImGuizmoDragState() const { return guizmoDragState; };
     void SOBRASADA_API_ENGINE DrawScriptInspector(const std::vector<InspectorField>& fields);
-    ImGuiContext* GetImGuiContext() { return context; }
     StateMachineEditor* GetStateMachine() { return stateMachineEditor; }
 
     const std::unordered_map<std::string, ComponentType>& GetStandaloneComponents() const
@@ -230,6 +229,5 @@ class EditorUIModule : public Module
     std::string tpsStr;
     std::unordered_map<std::string, ComponentType> standaloneComponents;
 
-    ImGuiContext* context;
     StateMachineEditor* stateMachineEditor = nullptr;
 };

--- a/SobrassadaEngine/Modules/EditorUIModule.h
+++ b/SobrassadaEngine/Modules/EditorUIModule.h
@@ -83,6 +83,8 @@ class EditorUIModule : public Module
     GizmoTransform& GetTransformType() { return transformType; }
     float3& GetSnapValues() { return snapValues; }
     GizmoDragState GetImGuizmoDragState() const { return guizmoDragState; };
+    void SOBRASADA_API_ENGINE DrawScriptInspector(std::function<void()> callback);
+    ImGuiContext* GetImGuiContext() { return context; }
 
     const std::unordered_map<std::string, ComponentType>& GetStandaloneComponents() const
     {
@@ -224,4 +226,6 @@ class EditorUIModule : public Module
     float lastTimeOpenGL         = 0.f;
     std::string tpsStr;
     std::unordered_map<std::string, ComponentType> standaloneComponents;
+
+    ImGuiContext* context;
 };

--- a/SobrassadaEngine/Modules/ScriptModule.cpp
+++ b/SobrassadaEngine/Modules/ScriptModule.cpp
@@ -4,6 +4,10 @@
 #include "SceneModule.h"
 #include "Script.h"
 #include "ScriptComponent.h"
+#include "imgui.h"
+#include "imgui_impl_opengl3.h"
+#include "imgui_impl_sdl2.h"
+#include "imgui_internal.h"
 
 bool ScriptModule::Init()
 {
@@ -13,11 +17,21 @@ bool ScriptModule::Init()
     return true;
 }
 
-bool ScriptModule::ShutDown()
+bool ScriptModule::close()
 {
+    DeleteAllScripts();
+    ImGui_ImplOpenGL3_Shutdown();
+    ImGui_ImplSDL2_Shutdown();
+    ImGui::DestroyContext();
     UnloadDLL();
     running = false;
     if (dllMonitorThread.joinable()) dllMonitorThread.join();
+
+    return true;
+}
+
+bool ScriptModule::ShutDown()
+{
     return true;
 }
 
@@ -36,9 +50,9 @@ void ScriptModule::LoadDLL()
     destroyScriptFunc = (DestroyScriptFunc)GetProcAddress(dllHandle, "DestroyScript");
     freeScriptFunc    = (FreeSobrassadaScripts)GetProcAddress(dllHandle, "FreeSobrassadaScripts");
 
-    if (!createScriptFunc || !destroyScriptFunc)
+    if (!startScriptFunc || !createScriptFunc || !destroyScriptFunc)
     {
-        GLOG("Failed to load CreateScript or DestroyScript functions\n");
+        GLOG("Failed to load required functions from DLL\n Trying Again.");
         return;
     }
 

--- a/SobrassadaEngine/Modules/ScriptModule.cpp
+++ b/SobrassadaEngine/Modules/ScriptModule.cpp
@@ -1,7 +1,7 @@
 #include "ScriptModule.h"
 #include "Application.h"
-#include "SceneModule.h"
 #include "Component.h"
+#include "SceneModule.h"
 #include "Script.h"
 #include "ScriptComponent.h"
 
@@ -29,16 +29,19 @@ void ScriptModule::LoadDLL()
         GLOG("Failed to load DLL\n");
         return;
     }
-    lastWriteTime         = fs::last_write_time("SobrassadaScripts.dll");
+    lastWriteTime     = fs::last_write_time("SobrassadaScripts.dll");
 
-    createScriptFunc      = (CreateScriptFunc)GetProcAddress(dllHandle, "CreateScript");
-    destroyScriptFunc     = (DestroyScriptFunc)GetProcAddress(dllHandle, "DestroyScript");
+    startScriptFunc   = (StartSobrassadaScripts)GetProcAddress(dllHandle, "InitSobrassadaScripts");
+    createScriptFunc  = (CreateScriptFunc)GetProcAddress(dllHandle, "CreateScript");
+    destroyScriptFunc = (DestroyScriptFunc)GetProcAddress(dllHandle, "DestroyScript");
 
     if (!createScriptFunc || !destroyScriptFunc)
     {
         GLOG("Failed to load CreateScript or DestroyScript functions\n");
         return;
     }
+
+    startScriptFunc(App);
 }
 
 update_status ScriptModule::Update(float deltaTime)
@@ -50,8 +53,8 @@ void ScriptModule::UnloadDLL()
 {
     if (dllHandle)
     {
-        createScriptFunc      = nullptr;
-        destroyScriptFunc     = nullptr;
+        createScriptFunc  = nullptr;
+        destroyScriptFunc = nullptr;
 
         FreeLibrary(dllHandle);
         dllHandle = nullptr;

--- a/SobrassadaEngine/Modules/ScriptModule.cpp
+++ b/SobrassadaEngine/Modules/ScriptModule.cpp
@@ -20,10 +20,10 @@ bool ScriptModule::Init()
 bool ScriptModule::close()
 {
     DeleteAllScripts();
+    UnloadDLL();
     ImGui_ImplOpenGL3_Shutdown();
     ImGui_ImplSDL2_Shutdown();
     ImGui::DestroyContext();
-    UnloadDLL();
     running = false;
     if (dllMonitorThread.joinable()) dllMonitorThread.join();
 

--- a/SobrassadaEngine/Modules/ScriptModule.cpp
+++ b/SobrassadaEngine/Modules/ScriptModule.cpp
@@ -88,8 +88,8 @@ void ScriptModule::DeleteAllScripts()
                 scriptComponent->DeleteScript();
             }
         }
+        freeScriptFunc();
     }
-    freeScriptFunc();
 }
 
 void ScriptModule::RecreateAllScripts()

--- a/SobrassadaEngine/Modules/ScriptModule.cpp
+++ b/SobrassadaEngine/Modules/ScriptModule.cpp
@@ -34,6 +34,7 @@ void ScriptModule::LoadDLL()
     startScriptFunc   = (StartSobrassadaScripts)GetProcAddress(dllHandle, "InitSobrassadaScripts");
     createScriptFunc  = (CreateScriptFunc)GetProcAddress(dllHandle, "CreateScript");
     destroyScriptFunc = (DestroyScriptFunc)GetProcAddress(dllHandle, "DestroyScript");
+    freeScriptFunc    = (FreeSobrassadaScripts)GetProcAddress(dllHandle, "FreeSobrassadaScripts");
 
     if (!createScriptFunc || !destroyScriptFunc)
     {
@@ -55,6 +56,8 @@ void ScriptModule::UnloadDLL()
     {
         createScriptFunc  = nullptr;
         destroyScriptFunc = nullptr;
+        startScriptFunc   = nullptr;
+        freeScriptFunc    = nullptr;
 
         FreeLibrary(dllHandle);
         dllHandle = nullptr;
@@ -86,6 +89,7 @@ void ScriptModule::DeleteAllScripts()
             }
         }
     }
+    freeScriptFunc();
 }
 
 void ScriptModule::RecreateAllScripts()

--- a/SobrassadaEngine/Modules/ScriptModule.h
+++ b/SobrassadaEngine/Modules/ScriptModule.h
@@ -20,6 +20,7 @@ class ScriptModule : public Module
 
     bool Init() override;
     update_status Update(float deltaTime) override;
+    bool close();
     bool ShutDown() override;
 
     Script* CreateScript(const std::string& name, GameObject* parent) const { return createScriptFunc(name, parent); }

--- a/SobrassadaEngine/Modules/ScriptModule.h
+++ b/SobrassadaEngine/Modules/ScriptModule.h
@@ -39,10 +39,12 @@ class ScriptModule : public Module
     typedef Script* (*CreateScriptFunc)(const std::string&, GameObject*);
     typedef void (*DestroyScriptFunc)(Script*);
     typedef void (*StartSobrassadaScripts)(Application* App);
+    typedef void (*FreeSobrassadaScripts)();
 
     StartSobrassadaScripts startScriptFunc    = nullptr;
     CreateScriptFunc createScriptFunc    = nullptr;
     DestroyScriptFunc destroyScriptFunc  = nullptr;
+    FreeSobrassadaScripts freeScriptFunc  = nullptr;
 
     fs::file_time_type lastWriteTime;
     std::atomic<bool> running = true;

--- a/SobrassadaEngine/Modules/ScriptModule.h
+++ b/SobrassadaEngine/Modules/ScriptModule.h
@@ -38,7 +38,9 @@ class ScriptModule : public Module
 
     typedef Script* (*CreateScriptFunc)(const std::string&, GameObject*);
     typedef void (*DestroyScriptFunc)(Script*);
+    typedef void (*StartSobrassadaScripts)(Application* App);
 
+    StartSobrassadaScripts startScriptFunc    = nullptr;
     CreateScriptFunc createScriptFunc    = nullptr;
     DestroyScriptFunc destroyScriptFunc  = nullptr;
 

--- a/SobrassadaEngine/Scene/Components/CameraComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/CameraComponent.cpp
@@ -15,7 +15,7 @@
 
 CameraComponent::CameraComponent(UID uid, GameObject* parent) : Component(uid, parent, "Camera", COMPONENT_CAMERA)
 {
-    float4x4 globalTransform  = GetGlobalTransform();
+    const float4x4 globalTransform  = GetGlobalTransform();
     camera.type               = FrustumType::PerspectiveFrustum;
     camera.pos                = float3(globalTransform[0][3], globalTransform[1][3], globalTransform[2][3]);
     camera.front              = -float3(globalTransform[0][2], globalTransform[1][2], globalTransform[2][2]);
@@ -27,8 +27,8 @@ CameraComponent::CameraComponent(UID uid, GameObject* parent) : Component(uid, p
     camera.horizontalFov      = (float)HFOV * DEGREE_RAD_CONV;
 
     auto framebuffer          = App->GetOpenGLModule()->GetFramebuffer();
-    int width                 = framebuffer->GetTextureWidth();
-    int height                = framebuffer->GetTextureHeight();
+    const int width                 = framebuffer->GetTextureWidth();
+    const int height                = framebuffer->GetTextureHeight();
 
     camera.verticalFov        = 2.0f * atanf(tanf(camera.horizontalFov * 0.5f) * ((float)height / (float)width));
 
@@ -299,15 +299,15 @@ void CameraComponent::Update(float deltaTime)
 
     if (!freeCamera)
     {
-        float4x4 globalTransform = GetGlobalTransform();
+        const float4x4 globalTransform = GetGlobalTransform();
         camera.pos               = float3(globalTransform[0][3], globalTransform[1][3], globalTransform[2][3]);
         camera.front = -float3(globalTransform[0][2], globalTransform[1][2], globalTransform[2][2]).Normalized();
         camera.up    = float3(globalTransform[0][1], globalTransform[1][1], globalTransform[2][1]).Normalized();
     }
 
     auto framebuffer = App->GetOpenGLModule()->GetFramebuffer();
-    int width        = framebuffer->GetTextureWidth();
-    int height       = framebuffer->GetTextureHeight();
+    const int width        = framebuffer->GetTextureWidth();
+    const int height       = framebuffer->GetTextureHeight();
     SetAspectRatio((float)height / (float)width);
 
     matrices.projectionMatrix = camera.ProjectionMatrix();
@@ -329,8 +329,8 @@ void CameraComponent::Update(float deltaTime)
 
 void CameraComponent::RenderCameraPreview(float deltaTime)
 {
-    int mainFramebufferWidth  = App->GetOpenGLModule()->GetFramebuffer()->GetTextureWidth();
-    int mainFramebufferHeight = App->GetOpenGLModule()->GetFramebuffer()->GetTextureHeight();
+    const int mainFramebufferWidth  = App->GetOpenGLModule()->GetFramebuffer()->GetTextureWidth();
+    const int mainFramebufferHeight = App->GetOpenGLModule()->GetFramebuffer()->GetTextureHeight();
 
     float scaleFactor         = 0.2f;
     previewWidth              = static_cast<int>(mainFramebufferWidth * scaleFactor);
@@ -394,14 +394,14 @@ void CameraComponent::Translate(const float3& direction)
 
 void SOBRASADA_API_ENGINE CameraComponent::Rotate(float yaw, float pitch)
 {
-    Quat yawRotation = Quat::RotateY(yaw);
+    const Quat yawRotation = Quat::RotateY(yaw);
     camera.front     = yawRotation.Mul(camera.front).Normalized();
     camera.up        = yawRotation.Mul(camera.up).Normalized();
 
     if ((currentPitchAngle + pitch) > maximumNegativePitch && (currentPitchAngle + pitch) < maximumPositivePitch)
     {
         currentPitchAngle  += pitch;
-        Quat pitchRotation  = Quat::RotateAxisAngle(camera.WorldRight(), pitch);
+        const Quat pitchRotation  = Quat::RotateAxisAngle(camera.WorldRight(), pitch);
         camera.front        = pitchRotation.Mul(camera.front).Normalized();
         camera.up           = pitchRotation.Mul(camera.up).Normalized();
     }

--- a/SobrassadaEngine/Scene/Components/CameraComponent.h
+++ b/SobrassadaEngine/Scene/Components/CameraComponent.h
@@ -35,7 +35,7 @@ class CameraComponent : public Component
     const FrustumPlanes& GetFrustrumPlanes() const { return frustumPlanes; }
     const float3& GetCameraPosition() const { return camera.pos; }
     const float3& GetCameraFront() const { return camera.front; }
-    const float3& GetCameraRight() const { return camera.WorldRight(); }
+    float3 GetCameraRight() const { return camera.WorldRight(); }
     const float3& GetCameraUp() const { return camera.up; }
     unsigned int GetUbo() const { return ubo; }
     const float4x4 GetProjectionMatrix() { return camera.ProjectionMatrix(); }

--- a/SobrassadaEngine/Scene/Components/CameraComponent.h
+++ b/SobrassadaEngine/Scene/Components/CameraComponent.h
@@ -29,14 +29,24 @@ class CameraComponent : public Component
 
     void RenderCameraPreview(float deltaTime);
 
+    void SOBRASADA_API_ENGINE Translate(const float3& direction);
+    void SOBRASADA_API_ENGINE Rotate(float yaw, float pitch);
+
     const FrustumPlanes& GetFrustrumPlanes() const { return frustumPlanes; }
     const float3& GetCameraPosition() const { return camera.pos; }
+    const float3& GetCameraFront() const { return camera.front; }
+    const float3& GetCameraRight() const { return camera.WorldRight(); }
+    const float3& GetCameraUp() const { return camera.up; }
     unsigned int GetUbo() const { return ubo; }
     const float4x4 GetProjectionMatrix() { return camera.ProjectionMatrix(); }
     const float4x4 GetViewMatrix() { return camera.ViewMatrix(); }
     const int GetType() { return (camera.type == OrthographicFrustum) ? 1 : 0; }
 
     void SetAspectRatio(float newAspectRatio);
+    void SetCameraPosition(const float3& position) { camera.pos = position; }
+    void SetCameraFront(const float3& front) { camera.front = front; }
+    void SetCameraUp(const float3& up) { camera.up = up; }
+    void SetFreeCamera(const bool freecamera) { freeCamera = freecamera; }
 
   private:
     Frustum camera;
@@ -68,4 +78,6 @@ class CameraComponent : public Component
 
     bool autorendering              = false;
     bool firstFrame                 = false;
+    bool freeCamera                 = false;
+    float currentPitchAngle   = 0.f;
 };

--- a/SobrassadaEngine/Scene/Components/ScriptComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/ScriptComponent.cpp
@@ -101,7 +101,6 @@ void ScriptComponent::RenderEditorInspector()
         {
             ImGui::Separator();
             scriptInstance->Inspector();
-            ImGui::SetCurrentContext(App->GetEditorUIModule()->GetImGuiContext());
         }
     }
 }

--- a/SobrassadaEngine/Scene/Components/ScriptComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/ScriptComponent.cpp
@@ -4,6 +4,7 @@
 #include "SceneModule.h"
 #include "Script.h"
 #include "ScriptModule.h"
+#include "EditorUIModule.h"
 
 // Do script of object rotating
 
@@ -100,6 +101,7 @@ void ScriptComponent::RenderEditorInspector()
         {
             ImGui::Separator();
             scriptInstance->Inspector();
+            ImGui::SetCurrentContext(App->GetEditorUIModule()->GetImGuiContext());
         }
     }
 }

--- a/SobrassadaEngine/Scene/Components/ScriptComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/ScriptComponent.cpp
@@ -96,6 +96,11 @@ void ScriptComponent::RenderEditorInspector()
             }
             ImGui::EndPopup();
         }
+        if (scriptInstance != nullptr)
+        {
+            ImGui::Separator();
+            scriptInstance->Inspector();
+        }
     }
 }
 

--- a/SobrassadaEngine/Scene/Components/ScriptComponent.h
+++ b/SobrassadaEngine/Scene/Components/ScriptComponent.h
@@ -27,6 +27,6 @@ class ScriptComponent : public Component
   private:
     std::string scriptName           = "Not selected";
     Script* scriptInstance           = nullptr;
-    std::vector<std::string> scripts = {"RotateGameObject", "ButtonScript"};
+    std::vector<std::string> scripts = {"RotateGameObject", "ButtonScript", "GodMode"};
     bool startScript                 = false;
 };

--- a/SobrassadaEngine/Scene/Components/Standalone/CharacterControllerComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/CharacterControllerComponent.cpp
@@ -157,8 +157,7 @@ void CharacterControllerComponent::Update(float deltaTime)
     parent->SetLocalTransform(finalLocal);
     parent->UpdateTransformForGOBranch();
 
-    HandleInput(deltaTime);
-
+    if(inputDown) HandleInput(deltaTime);
 }
 
 void CharacterControllerComponent::Render(float deltaTime)

--- a/SobrassadaEngine/Scene/Components/Standalone/CharacterControllerComponent.h
+++ b/SobrassadaEngine/Scene/Components/Standalone/CharacterControllerComponent.h
@@ -6,7 +6,7 @@ class dtNavMeshQuery;
 
 using dtPolyRef = unsigned int;
 
-class CharacterControllerComponent : public Component
+class SOBRASADA_API_ENGINE CharacterControllerComponent : public Component
 {
 
   public:
@@ -32,6 +32,7 @@ class CharacterControllerComponent : public Component
 
     void SetTargetDirection(float3 newTargetDirection) { targetDirection = newTargetDirection; }
     void SetSpeed(float newSpeed) { speed = newSpeed; }
+    void SetInputDown(bool input) { inputDown = input; }
 
   private:
     float3 targetDirection;
@@ -48,4 +49,6 @@ class CharacterControllerComponent : public Component
     float gravity                = -9.81f;
     float verticalSpeed          = 0.0f;
     float maxFallSpeed           = -20.0f;
+
+    bool inputDown               = true;
 };

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
@@ -405,6 +405,17 @@ Component* GameObject::GetComponentByType(ComponentType type) const
     return nullptr;
 }
 
+Component* GameObject::GetComponentChildByType(ComponentType componentType) const
+{
+    const std::vector<UID>& children = GetChildren();
+    if (!children.empty())
+    {
+        GameObject* gameObject = App->GetSceneModule()->GetScene()->GetGameObjectByUID(children[0]);
+        return gameObject->GetComponentByType(componentType);
+    }
+    return nullptr;
+}
+
 MeshComponent* GameObject::GetMeshComponent() const
 {
     if (components.find(COMPONENT_MESH) != components.end())

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.h
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.h
@@ -89,6 +89,7 @@ class SOBRASADA_API_ENGINE GameObject
 
     const std::unordered_map<ComponentType, Component*>& GetComponents() const { return components; }
     Component* GetComponentByType(ComponentType type) const;
+    Component* GetComponentChildByType(ComponentType componentType) const;
 
     MeshComponent* GetMeshComponent() const;
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/ButtonScript.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/ButtonScript.h
@@ -7,5 +7,6 @@ class ButtonScript : public Script
     ButtonScript(GameObject* parent) : Script(parent) {}
     bool Init() override;
     void Update(float deltaTime) override;
+    void Inspector() override {};
     void TestDispatcher();
 };

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/GodMode.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/GodMode.cpp
@@ -28,8 +28,8 @@ void GodMode::Update(float deltaTime)
         float scaleFactor            = 1.0f;
         if (keyboard[SDL_SCANCODE_LSHIFT]) scaleFactor *= 2;
 
-        float finalCameraSpeed       = 7.5f * scaleFactor * deltaTime;
-        float finalRotateSensitivity = 0.006f * scaleFactor;
+        const float finalCameraSpeed       = 7.5f * scaleFactor * deltaTime;
+        const float finalRotateSensitivity = 0.006f * scaleFactor;
 
         if (keyboard[SDL_SCANCODE_W]) godCamera->Translate(godCamera->GetCameraFront() * finalCameraSpeed);
         if (keyboard[SDL_SCANCODE_S]) godCamera->Translate(-godCamera->GetCameraFront() * finalCameraSpeed);
@@ -40,9 +40,9 @@ void GodMode::Update(float deltaTime)
 
         if (mouseButtons[SDL_BUTTON_RIGHT - 1])
         {
-            float mouseX             = mouseMotion.x;
-            float mouseY             = mouseMotion.y;
-            float deltaRotationAngle = cameraRotationAngle * finalRotateSensitivity;
+            const float mouseX             = mouseMotion.x;
+            const float mouseY             = mouseMotion.y;
+            const float deltaRotationAngle = cameraRotationAngle * finalRotateSensitivity;
             godCamera->Rotate(-mouseX * deltaRotationAngle, -mouseY * deltaRotationAngle);
         }
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/GodMode.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/GodMode.cpp
@@ -1,0 +1,66 @@
+#include "pch.h"
+#include "GodMode.h"
+#include "Application.h"
+#include "CameraComponent.h"
+#include "Components/Standalone/CharacterControllerComponent.h"
+#include "GameObject.h"
+#include "InputModule.h"
+#include <SDL_mouse.h>
+
+bool GodMode::Init()
+{
+    characterController =
+        dynamic_cast<CharacterControllerComponent*>(parent->GetComponentByType(COMPONENT_CHARACTER_CONTROLLER));
+    godCamera = dynamic_cast<CameraComponent*>(parent->GetComponentChildByType(COMPONENT_CAMERA));
+
+    return true;
+}
+
+void GodMode::Update(float deltaTime)
+{
+    const KeyState* keyboard = AppEngine->GetInputModule()->GetKeyboard();
+
+    if (freeCamera)
+    {
+        const KeyState* mouseButtons = AppEngine->GetInputModule()->GetMouseButtons();
+        const float2& mouseMotion    = AppEngine->GetInputModule()->GetMouseMotion();
+
+        float scaleFactor            = 1.0f;
+        if (keyboard[SDL_SCANCODE_LSHIFT]) scaleFactor *= 2;
+
+        float finalCameraSpeed       = 7.5f * scaleFactor * deltaTime;
+        float finalRotateSensitivity = 0.006f * scaleFactor;
+
+        if (keyboard[SDL_SCANCODE_W]) godCamera->Translate(godCamera->GetCameraFront() * finalCameraSpeed);
+        if (keyboard[SDL_SCANCODE_S]) godCamera->Translate(-godCamera->GetCameraFront() * finalCameraSpeed);
+        if (keyboard[SDL_SCANCODE_A]) godCamera->Translate(-godCamera->GetCameraRight() * finalCameraSpeed);
+        if (keyboard[SDL_SCANCODE_D]) godCamera->Translate(godCamera->GetCameraRight() * finalCameraSpeed);
+        if (keyboard[SDL_SCANCODE_E]) godCamera->Translate(godCamera->GetCameraUp() * finalCameraSpeed);
+        if (keyboard[SDL_SCANCODE_Q]) godCamera->Translate(-godCamera->GetCameraUp() * finalCameraSpeed);
+
+        if (mouseButtons[SDL_BUTTON_RIGHT - 1])
+        {
+            float mouseX             = mouseMotion.x;
+            float mouseY             = mouseMotion.y;
+            float deltaRotationAngle = cameraRotationAngle * finalRotateSensitivity;
+            godCamera->Rotate(-mouseX * deltaRotationAngle, -mouseY * deltaRotationAngle);
+        }
+
+        if (keyboard[SDL_SCANCODE_K] == KEY_DOWN)
+        {
+            freeCamera = false;
+            godCamera->SetFreeCamera(false);
+            characterController->SetInputDown(true);
+        }
+    }
+    if (keyboard[SDL_SCANCODE_L] == KEY_DOWN)
+    {
+        characterController->SetInputDown(false);
+        godCamera->SetFreeCamera(true);
+        freeCamera = true;
+    }
+}
+
+void GodMode::Inspector()
+{
+}

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/GodMode.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/GodMode.cpp
@@ -46,14 +46,14 @@ void GodMode::Update(float deltaTime)
             godCamera->Rotate(-mouseX * deltaRotationAngle, -mouseY * deltaRotationAngle);
         }
 
-        if (keyboard[SDL_SCANCODE_K] == KEY_DOWN)
+        if (keyboard[SDL_SCANCODE_O] == KEY_DOWN)
         {
             freeCamera = false;
             godCamera->SetFreeCamera(false);
             characterController->SetInputDown(true);
         }
     }
-    if (keyboard[SDL_SCANCODE_L] == KEY_DOWN)
+    if (keyboard[SDL_SCANCODE_P] == KEY_DOWN)
     {
         characterController->SetInputDown(false);
         godCamera->SetFreeCamera(true);

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/GodMode.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/GodMode.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "Script.h"
+#include "Math/float4x4.h"
+
+class CharacterControllerComponent;
+class CameraComponent;
+
+class GodMode : public Script
+{
+  public:
+    GodMode(GameObject* parent) : Script(parent) {}
+    bool Init() override;
+    void Update(float deltaTime) override;
+    void Inspector() override;
+
+  private:
+    CharacterControllerComponent* characterController;
+    CameraComponent* godCamera;
+    float4x4 originalTransform;
+    bool freeCamera = false;
+};

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/RotateGameObject.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/RotateGameObject.cpp
@@ -24,12 +24,12 @@ void RotateGameObject::Update(float deltaTime)
 
 void RotateGameObject::Inspector()
 {   
-    // Probably I will change this
-    /*
-    AppEngine->GetEditorUIModule()->DrawScriptInspector([this]() {
-        ImGui::SetCurrentContext(AppEngine->GetEditorUIModule()->GetImGuiContext());
-        ImGui::Text("Hello");
-        ImGui::SliderFloat("Speed", &speed, 0.0f, 1.0f);
-    });
-    */
+    //Using ImGui in the dll cause problems, so we need to call ImGui outside the dll
+    if (fields.empty())
+    {
+        fields.push_back({InspectorField::FieldType::Text, (void*)"Test"});
+        fields.push_back({"Speed", InspectorField::FieldType::Float, &speed});
+    }
+
+    AppEngine->GetEditorUIModule()->DrawScriptInspector(fields);
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/RotateGameObject.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/RotateGameObject.cpp
@@ -28,7 +28,9 @@ void RotateGameObject::Inspector()
     if (fields.empty())
     {
         fields.push_back({InspectorField::FieldType::Text, (void*)"Test"});
-        fields.push_back({"Speed", InspectorField::FieldType::Float, &speed});
+        fields.push_back({"Speed", InspectorField::FieldType::Float, &speed, 0.0f, 2.0f});
+        fields.push_back({"Prueba vec2", InspectorField::FieldType::Vec2, &prueba});
+        fields.push_back({"Color", InspectorField::FieldType::Color, &color});
     }
 
     AppEngine->GetEditorUIModule()->DrawScriptInspector(fields);

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/RotateGameObject.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/RotateGameObject.cpp
@@ -4,6 +4,8 @@
 #include "Math/float4x4.h"
 #include "CameraModule.h"
 #include "Application.h"
+#include "ImGui.h"
+#include "EditorUIModule.h"
 
 bool RotateGameObject::Init()
 {
@@ -14,8 +16,17 @@ bool RotateGameObject::Init()
 void RotateGameObject::Update(float deltaTime)
 {
     float4x4 newTransform = parent->GetLocalTransform();
-    newTransform = newTransform * float4x4::RotateX(0.5f * deltaTime);
+    newTransform = newTransform * float4x4::RotateX(speed * deltaTime);
     parent->SetLocalTransform(newTransform);
     parent->UpdateTransformForGOBranch();
     GLOG("%f", AppEngine->GetCameraModule()->GetCameraPosition().y);
+}
+
+void RotateGameObject::Inspector()
+{
+    ImGui::SetCurrentContext(AppEngine->GetEditorUIModule()->GetImGuiContext());
+    AppEngine->GetEditorUIModule()->DrawScriptInspector([this]() {
+        ImGui::Text("Hello");
+        ImGui::SliderFloat("Speed", &speed, 0.0f, 1.0f);
+    });
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/RotateGameObject.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/RotateGameObject.cpp
@@ -2,6 +2,8 @@
 #include "RotateGameObject.h"
 #include "GameObject.h"
 #include "Math/float4x4.h"
+#include "CameraModule.h"
+#include "Application.h"
 
 bool RotateGameObject::Init()
 {
@@ -15,4 +17,5 @@ void RotateGameObject::Update(float deltaTime)
     newTransform = newTransform * float4x4::RotateX(0.5f * deltaTime);
     parent->SetLocalTransform(newTransform);
     parent->UpdateTransformForGOBranch();
+    GLOG("%f", AppEngine->GetCameraModule()->GetCameraPosition().y);
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/RotateGameObject.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/RotateGameObject.cpp
@@ -23,10 +23,13 @@ void RotateGameObject::Update(float deltaTime)
 }
 
 void RotateGameObject::Inspector()
-{
-    ImGui::SetCurrentContext(AppEngine->GetEditorUIModule()->GetImGuiContext());
+{   
+    // Probably I will change this
+    /*
     AppEngine->GetEditorUIModule()->DrawScriptInspector([this]() {
+        ImGui::SetCurrentContext(AppEngine->GetEditorUIModule()->GetImGuiContext());
         ImGui::Text("Hello");
         ImGui::SliderFloat("Speed", &speed, 0.0f, 1.0f);
     });
+    */
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/RotateGameObject.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/RotateGameObject.h
@@ -1,5 +1,7 @@
 #pragma once
 #include "Script.h"
+#include "Math/float2.h"
+#include "Math/float3.h"
 
 class RotateGameObject : public Script
 {
@@ -11,4 +13,6 @@ class RotateGameObject : public Script
 
   private:
     float speed = 0.5f;
+    float2 prueba = {0.0f, 0.0f};
+    float3 color = {1.0f, 0.0f, 0.0f};
 };

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/RotateGameObject.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/RotateGameObject.h
@@ -7,4 +7,8 @@ class RotateGameObject : public Script
     RotateGameObject(GameObject* parent) : Script(parent) {}
     bool Init() override;
     void Update(float deltaTime) override;
+    void Inspector() override;
+
+  private:
+    float speed = 0.5f;
 };

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Script.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Script.h
@@ -1,6 +1,7 @@
 #pragma once
 
 class GameObject;
+class Application;
 
 class Script
 {
@@ -14,3 +15,5 @@ class Script
   protected:
     GameObject* parent;
 };
+
+extern Application* AppEngine;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Script.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Script.h
@@ -2,6 +2,36 @@
 
 class GameObject;
 class Application;
+#include <vector>
+
+struct InspectorField
+{
+    enum class FieldType
+    {
+        Text,
+        Float,
+        Int,
+        Bool
+    };
+
+    const char* name;
+    FieldType type;
+    void* data;
+    float minValue;
+    float maxValue;
+
+    InspectorField(const char* name, FieldType type, void* data, float minValue, float maxValue)
+        : name(name), type(type), data(data), minValue(minValue), maxValue(maxValue)
+    {
+    }
+    InspectorField(const char* name, FieldType type, void* data)
+        : name(name), type(type), data(data), minValue(0.0f), maxValue(1.0f)
+    {
+    }
+    InspectorField(FieldType type, void* data) : name("No name"), type(type), data(data), minValue(0.0f), maxValue(1.0f)
+    {
+    }
+};
 
 class Script
 {
@@ -15,6 +45,7 @@ class Script
 
   protected:
     GameObject* parent;
+    std::vector<InspectorField> fields;
 };
 
 extern Application* AppEngine;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Script.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Script.h
@@ -11,6 +11,7 @@ class Script
 
     virtual bool Init()                  = 0;
     virtual void Update(float deltaTime) = 0;
+    virtual void Inspector()             = 0;
 
   protected:
     GameObject* parent;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Script.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Script.h
@@ -11,7 +11,11 @@ struct InspectorField
         Text,
         Float,
         Int,
-        Bool
+        Bool,
+        Vec2,
+        Vec3,
+        Vec4,
+        Color
     };
 
     const char* name;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/ScriptExport.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/ScriptExport.cpp
@@ -28,3 +28,9 @@ extern "C" SOBRASSADA_API void DestroyScript(Script* script)
 {
     delete script;
 }
+
+extern "C" SOBRASSADA_API void FreeSobrassadaScripts()
+{
+    GLOG("Sobrassada Scripts deleted");
+    AppEngine = nullptr;
+}

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/ScriptExport.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/ScriptExport.cpp
@@ -10,6 +10,13 @@
 #define SOBRASSADA_API __declspec(dllimport)
 #endif
 
+Application* AppEngine = nullptr;
+extern "C" SOBRASSADA_API void InitSobrassadaScripts(Application* App)
+{
+    GLOG("Sobrassada Scripts Initialized");
+    AppEngine = App;
+}
+
 extern "C" SOBRASSADA_API Script* CreateScript(const std::string& scriptType, GameObject* parent)
 {
     if (scriptType == "RotateGameObject") return new RotateGameObject(parent);

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/ScriptExport.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/ScriptExport.cpp
@@ -2,6 +2,7 @@
 #include "RotateGameObject.h"
 #include "Globals.h"
 #include "ButtonScript.h"
+#include "GodMode.h"
 #include <string>
 
 #ifndef SOBRASSADASCRIPTS_EXPORTS
@@ -21,6 +22,7 @@ extern "C" SOBRASSADA_API Script* CreateScript(const std::string& scriptType, Ga
 {
     if (scriptType == "RotateGameObject") return new RotateGameObject(parent);
     if (scriptType == "ButtonScript") return new ButtonScript(parent);
+    if (scriptType == "GodMode") return new GodMode(parent);
     return nullptr;
 }
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj
@@ -387,6 +387,7 @@
   <ItemGroup>
     <ClInclude Include="ButtonScript.h" />
     <ClInclude Include="framework.h" />
+    <ClInclude Include="GodMode.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="RotateGameObject.h" />
     <ClInclude Include="Script.h" />
@@ -636,6 +637,7 @@
     </ClCompile>
     <ClCompile Include="ButtonScript.cpp" />
     <ClCompile Include="dllmain.cpp" />
+    <ClCompile Include="GodMode.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Game Debug|x64'">Create</PrecompiledHeader>

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj
@@ -277,7 +277,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)DirectXTex;$(SolutionDir)Libs;$(SolutionDir)Libs\SDL\include;$(SolutionDir)Libs\glew-2.1.0\include;$(SolutionDir)Libs\MathGeoLib\include;$(SolutionDir)Libs\ImGui;$(SolutionDir)Libs\ImGuizmo;$(SolutionDir)Libs\Tinygltf;$(SolutionDir)Libs\freetype\include;$(SolutionDir)Libs\Optick_1.4.0\include;$(SolutionDir)Libs\RecastDetour\Detour\Include;$(SolutionDir)Libs\RecastDetour\Recast\Include;$(SolutionDir)Modules;$(SolutionDir)ResourceManagement\Resources;$(SolutionDir)UI;$(SolutionDir)UI\EngineEditors\;$(SolutionDir)UI\EngineEditors\Editor;$(SolutionDir)UI\EngineEditors\Nodes;$(SolutionDir)Utils;$(SolutionDir)Utils\Trees;$(SolutionDir)FileSystem;$(SolutionDir)FileSystem\Config;$(SolutionDir)FileSystem\Importers;$(SolutionDir)FileSystem\Meta;$(SolutionDir)DebugDraw;$(SolutionDir)Scene;$(SolutionDir)Scene\GameObjects;$(SolutionDir)Scene\Components;$(SolutionDir)Libs\bullet\include;$(SolutionDir)Libs\ImNodeFlow-1.2.2\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)DirectXTex;$(SolutionDir)Libs;$(SolutionDir)Libs\SDL\include;$(SolutionDir)Libs\glew-2.1.0\include;$(SolutionDir)Libs\MathGeoLib\include;$(SolutionDir)Libs\ImGui;$(SolutionDir)Libs\ImGuizmo;$(SolutionDir)Libs\Tinygltf;$(SolutionDir)Libs\freetype\include;$(SolutionDir)Libs\Optick_1.4.0\include;$(SolutionDir)Libs\RecastDetour\Detour\Include;$(SolutionDir)Libs\RecastDetour\Recast\Include;$(SolutionDir)Modules;$(SolutionDir)ResourceManagement\Resources;$(SolutionDir)UI;$(SolutionDir)UI\EngineEditors\;$(SolutionDir)UI\EngineEditors\Editor;$(SolutionDir)UI\EngineEditors\Nodes;$(SolutionDir)Utils;$(SolutionDir)Utils\Trees;$(SolutionDir)FileSystem;$(SolutionDir)FileSystem\Config;$(SolutionDir)FileSystem\Importers;$(SolutionDir)FileSystem\Meta;$(SolutionDir)DebugDraw;$(SolutionDir)Scene;$(SolutionDir)Scene\GameObjects;$(SolutionDir)Scene\Components;$(SolutionDir)Libs\bullet\include;$(SolutionDir)Libs\ImNodeFlow-1.2.2\include;$(SolutionDir)Libs\ImNodeFlow-1.2.2\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
@@ -297,7 +297,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)DirectXTex;$(SolutionDir)Libs;$(SolutionDir)Libs\SDL\include;$(SolutionDir)Libs\glew-2.1.0\include;$(SolutionDir)Libs\MathGeoLib\include;$(SolutionDir)Libs\ImGui;$(SolutionDir)Libs\ImGuizmo;$(SolutionDir)Libs\Tinygltf;$(SolutionDir)Libs\freetype\include;$(SolutionDir)Libs\Optick_1.4.0\include;$(SolutionDir)Libs\RecastDetour\Detour\Include;$(SolutionDir)Libs\RecastDetour\Recast\Include;$(SolutionDir)Modules;$(SolutionDir)ResourceManagement\Resources;$(SolutionDir)UI;$(SolutionDir)UI\EngineEditors\;$(SolutionDir)UI\EngineEditors\Editor;$(SolutionDir)UI\EngineEditors\Nodes;$(SolutionDir)Utils;$(SolutionDir)Utils\Trees;$(SolutionDir)FileSystem;$(SolutionDir)FileSystem\Config;$(SolutionDir)FileSystem\Importers;$(SolutionDir)FileSystem\Meta;$(SolutionDir)DebugDraw;$(SolutionDir)Scene;$(SolutionDir)Scene\GameObjects;$(SolutionDir)Scene\Components;$(SolutionDir)Libs\bullet\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)DirectXTex;$(SolutionDir)Libs;$(SolutionDir)Libs\SDL\include;$(SolutionDir)Libs\glew-2.1.0\include;$(SolutionDir)Libs\MathGeoLib\include;$(SolutionDir)Libs\ImGui;$(SolutionDir)Libs\ImGuizmo;$(SolutionDir)Libs\Tinygltf;$(SolutionDir)Libs\freetype\include;$(SolutionDir)Libs\Optick_1.4.0\include;$(SolutionDir)Libs\RecastDetour\Detour\Include;$(SolutionDir)Libs\RecastDetour\Recast\Include;$(SolutionDir)Modules;$(SolutionDir)ResourceManagement\Resources;$(SolutionDir)UI;$(SolutionDir)UI\EngineEditors\;$(SolutionDir)UI\EngineEditors\Editor;$(SolutionDir)UI\EngineEditors\Nodes;$(SolutionDir)Utils;$(SolutionDir)Utils\Trees;$(SolutionDir)FileSystem;$(SolutionDir)FileSystem\Config;$(SolutionDir)FileSystem\Importers;$(SolutionDir)FileSystem\Meta;$(SolutionDir)DebugDraw;$(SolutionDir)Scene;$(SolutionDir)Scene\GameObjects;$(SolutionDir)Scene\Components;$(SolutionDir)Libs\bullet\include;$(SolutionDir)Libs\ImNodeFlow-1.2.2\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
@@ -319,7 +319,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)DirectXTex;$(SolutionDir)Libs;$(SolutionDir)Libs\SDL\include;$(SolutionDir)Libs\glew-2.1.0\include;$(SolutionDir)Libs\MathGeoLib\include;$(SolutionDir)Libs\ImGui;$(SolutionDir)Libs\ImGuizmo;$(SolutionDir)Libs\Tinygltf;$(SolutionDir)Libs\freetype\include;$(SolutionDir)Libs\Optick_1.4.0\include;$(SolutionDir)Libs\RecastDetour\Detour\Include;$(SolutionDir)Libs\RecastDetour\Recast\Include;$(SolutionDir)Modules;$(SolutionDir)ResourceManagement\Resources;$(SolutionDir)UI;$(SolutionDir)UI\EngineEditors\;$(SolutionDir)UI\EngineEditors\Editor;$(SolutionDir)UI\EngineEditors\Nodes;$(SolutionDir)Utils;$(SolutionDir)Utils\Trees;$(SolutionDir)FileSystem;$(SolutionDir)FileSystem\Config;$(SolutionDir)FileSystem\Importers;$(SolutionDir)FileSystem\Meta;$(SolutionDir)DebugDraw;$(SolutionDir)Scene;$(SolutionDir)Scene\GameObjects;$(SolutionDir)Scene\Components;$(SolutionDir)Libs\bullet\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)DirectXTex;$(SolutionDir)Libs;$(SolutionDir)Libs\SDL\include;$(SolutionDir)Libs\glew-2.1.0\include;$(SolutionDir)Libs\MathGeoLib\include;$(SolutionDir)Libs\ImGui;$(SolutionDir)Libs\ImGuizmo;$(SolutionDir)Libs\Tinygltf;$(SolutionDir)Libs\freetype\include;$(SolutionDir)Libs\Optick_1.4.0\include;$(SolutionDir)Libs\RecastDetour\Detour\Include;$(SolutionDir)Libs\RecastDetour\Recast\Include;$(SolutionDir)Modules;$(SolutionDir)ResourceManagement\Resources;$(SolutionDir)UI;$(SolutionDir)UI\EngineEditors\;$(SolutionDir)UI\EngineEditors\Editor;$(SolutionDir)UI\EngineEditors\Nodes;$(SolutionDir)Utils;$(SolutionDir)Utils\Trees;$(SolutionDir)FileSystem;$(SolutionDir)FileSystem\Config;$(SolutionDir)FileSystem\Importers;$(SolutionDir)FileSystem\Meta;$(SolutionDir)DebugDraw;$(SolutionDir)Scene;$(SolutionDir)Scene\GameObjects;$(SolutionDir)Scene\Components;$(SolutionDir)Libs\bullet\include;$(SolutionDir)Libs\ImNodeFlow-1.2.2\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
@@ -343,7 +343,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)DirectXTex;$(SolutionDir)Libs;$(SolutionDir)Libs\SDL\include;$(SolutionDir)Libs\glew-2.1.0\include;$(SolutionDir)Libs\MathGeoLib\include;$(SolutionDir)Libs\ImGui;$(SolutionDir)Libs\ImGuizmo;$(SolutionDir)Libs\Tinygltf;$(SolutionDir)Libs\freetype\include;$(SolutionDir)Libs\Optick_1.4.0\include;$(SolutionDir)Libs\RecastDetour\Detour\Include;$(SolutionDir)Libs\RecastDetour\Recast\Include;$(SolutionDir)Modules;$(SolutionDir)ResourceManagement\Resources;$(SolutionDir)UI;$(SolutionDir)UI\EngineEditors\;$(SolutionDir)UI\EngineEditors\Editor;$(SolutionDir)UI\EngineEditors\Nodes;$(SolutionDir)Utils;$(SolutionDir)Utils\Trees;$(SolutionDir)FileSystem;$(SolutionDir)FileSystem\Config;$(SolutionDir)FileSystem\Importers;$(SolutionDir)FileSystem\Meta;$(SolutionDir)DebugDraw;$(SolutionDir)Scene;$(SolutionDir)Scene\GameObjects;$(SolutionDir)Scene\Components;$(SolutionDir)Libs\bullet\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)DirectXTex;$(SolutionDir)Libs;$(SolutionDir)Libs\SDL\include;$(SolutionDir)Libs\glew-2.1.0\include;$(SolutionDir)Libs\MathGeoLib\include;$(SolutionDir)Libs\ImGui;$(SolutionDir)Libs\ImGuizmo;$(SolutionDir)Libs\Tinygltf;$(SolutionDir)Libs\freetype\include;$(SolutionDir)Libs\Optick_1.4.0\include;$(SolutionDir)Libs\RecastDetour\Detour\Include;$(SolutionDir)Libs\RecastDetour\Recast\Include;$(SolutionDir)Modules;$(SolutionDir)ResourceManagement\Resources;$(SolutionDir)UI;$(SolutionDir)UI\EngineEditors\;$(SolutionDir)UI\EngineEditors\Editor;$(SolutionDir)UI\EngineEditors\Nodes;$(SolutionDir)Utils;$(SolutionDir)Utils\Trees;$(SolutionDir)FileSystem;$(SolutionDir)FileSystem\Config;$(SolutionDir)FileSystem\Importers;$(SolutionDir)FileSystem\Meta;$(SolutionDir)DebugDraw;$(SolutionDir)Scene;$(SolutionDir)Scene\GameObjects;$(SolutionDir)Scene\Components;$(SolutionDir)Libs\bullet\include;$(SolutionDir)Libs\ImNodeFlow-1.2.2\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
@@ -367,7 +367,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)DirectXTex;$(SolutionDir)Libs;$(SolutionDir)Libs\SDL\include;$(SolutionDir)Libs\glew-2.1.0\include;$(SolutionDir)Libs\MathGeoLib\include;$(SolutionDir)Libs\ImGui;$(SolutionDir)Libs\ImGuizmo;$(SolutionDir)Libs\Tinygltf;$(SolutionDir)Libs\freetype\include;$(SolutionDir)Libs\Optick_1.4.0\include;$(SolutionDir)Libs\RecastDetour\Detour\Include;$(SolutionDir)Libs\RecastDetour\Recast\Include;$(SolutionDir)Modules;$(SolutionDir)ResourceManagement\Resources;$(SolutionDir)UI;$(SolutionDir)UI\EngineEditors\;$(SolutionDir)UI\EngineEditors\Editor;$(SolutionDir)UI\EngineEditors\Nodes;$(SolutionDir)Utils;$(SolutionDir)Utils\Trees;$(SolutionDir)FileSystem;$(SolutionDir)FileSystem\Config;$(SolutionDir)FileSystem\Importers;$(SolutionDir)FileSystem\Meta;$(SolutionDir)DebugDraw;$(SolutionDir)Scene;$(SolutionDir)Scene\GameObjects;$(SolutionDir)Scene\Components;$(SolutionDir)Libs\bullet\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)DirectXTex;$(SolutionDir)Libs;$(SolutionDir)Libs\SDL\include;$(SolutionDir)Libs\glew-2.1.0\include;$(SolutionDir)Libs\MathGeoLib\include;$(SolutionDir)Libs\ImGui;$(SolutionDir)Libs\ImGuizmo;$(SolutionDir)Libs\Tinygltf;$(SolutionDir)Libs\freetype\include;$(SolutionDir)Libs\Optick_1.4.0\include;$(SolutionDir)Libs\RecastDetour\Detour\Include;$(SolutionDir)Libs\RecastDetour\Recast\Include;$(SolutionDir)Modules;$(SolutionDir)ResourceManagement\Resources;$(SolutionDir)UI;$(SolutionDir)UI\EngineEditors\;$(SolutionDir)UI\EngineEditors\Editor;$(SolutionDir)UI\EngineEditors\Nodes;$(SolutionDir)Utils;$(SolutionDir)Utils\Trees;$(SolutionDir)FileSystem;$(SolutionDir)FileSystem\Config;$(SolutionDir)FileSystem\Importers;$(SolutionDir)FileSystem\Meta;$(SolutionDir)DebugDraw;$(SolutionDir)Scene;$(SolutionDir)Scene\GameObjects;$(SolutionDir)Scene\Components;$(SolutionDir)Libs\bullet\include;$(SolutionDir)Libs\ImNodeFlow-1.2.2\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
@@ -395,21 +395,45 @@
   <ItemGroup>
     <ClCompile Include="..\..\..\Libs\ImGui\imgui.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Game|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Game Debug|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Profile|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="..\..\..\Libs\ImGui\imgui_demo.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Game|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Game Debug|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Profile|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="..\..\..\Libs\ImGui\imgui_draw.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Game|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Game Debug|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Profile|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="..\..\..\Libs\ImGui\imgui_impl_opengl3.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Game|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Game Debug|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Profile|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="..\..\..\Libs\ImGui\imgui_tables.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Game|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Game Debug|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Profile|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="..\..\..\Libs\ImGui\imgui_widgets.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Game|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Game Debug|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Profile|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="..\..\..\Libs\MathGeoLib\include\Algorithm\Random\LCG.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj
@@ -277,7 +277,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)DirectXTex;$(SolutionDir)Libs;$(SolutionDir)Libs\SDL\include;$(SolutionDir)Libs\glew-2.1.0\include;$(SolutionDir)Libs\MathGeoLib\include;$(SolutionDir)Libs\ImGui;$(SolutionDir)Libs\ImGuizmo;$(SolutionDir)Libs\Tinygltf;$(SolutionDir)Libs\freetype\include;$(SolutionDir)Libs\Optick_1.4.0\include;$(SolutionDir)Libs\RecastDetour\Detour\Include;$(SolutionDir)Libs\RecastDetour\Recast\Include;$(SolutionDir)Modules;$(SolutionDir)ResourceManagement\Resources;$(SolutionDir)UI;$(SolutionDir)UI\EngineEditors\;$(SolutionDir)UI\EngineEditors\Editor;$(SolutionDir)UI\EngineEditors\Nodes;$(SolutionDir)Utils;$(SolutionDir)Utils\Trees;$(SolutionDir)FileSystem;$(SolutionDir)FileSystem\Config;$(SolutionDir)FileSystem\Importers;$(SolutionDir)FileSystem\Meta;$(SolutionDir)DebugDraw;$(SolutionDir)Scene;$(SolutionDir)Scene\GameObjects;$(SolutionDir)Scene\Components;$(SolutionDir)Libs\bullet\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)DirectXTex;$(SolutionDir)Libs;$(SolutionDir)Libs\SDL\include;$(SolutionDir)Libs\glew-2.1.0\include;$(SolutionDir)Libs\MathGeoLib\include;$(SolutionDir)Libs\ImGui;$(SolutionDir)Libs\ImGuizmo;$(SolutionDir)Libs\Tinygltf;$(SolutionDir)Libs\freetype\include;$(SolutionDir)Libs\Optick_1.4.0\include;$(SolutionDir)Libs\RecastDetour\Detour\Include;$(SolutionDir)Libs\RecastDetour\Recast\Include;$(SolutionDir)Modules;$(SolutionDir)ResourceManagement\Resources;$(SolutionDir)UI;$(SolutionDir)UI\EngineEditors\;$(SolutionDir)UI\EngineEditors\Editor;$(SolutionDir)UI\EngineEditors\Nodes;$(SolutionDir)Utils;$(SolutionDir)Utils\Trees;$(SolutionDir)FileSystem;$(SolutionDir)FileSystem\Config;$(SolutionDir)FileSystem\Importers;$(SolutionDir)FileSystem\Meta;$(SolutionDir)DebugDraw;$(SolutionDir)Scene;$(SolutionDir)Scene\GameObjects;$(SolutionDir)Scene\Components;$(SolutionDir)Libs\bullet\include;$(SolutionDir)Libs\ImNodeFlow-1.2.2\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
@@ -392,6 +392,24 @@
     <ClInclude Include="Script.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\..\Libs\ImGui\imgui.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Libs\ImGui\imgui_demo.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Libs\ImGui\imgui_draw.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Libs\ImGui\imgui_impl_opengl3.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Libs\ImGui\imgui_tables.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Libs\ImGui\imgui_widgets.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="..\..\..\Libs\MathGeoLib\include\Algorithm\Random\LCG.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Game Debug|x64'">NotUsing</PrecompiledHeader>

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj.filters
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj.filters
@@ -36,6 +36,9 @@
     <ClInclude Include="ButtonScript.h">
       <Filter>Archivos de encabezado</Filter>
     </ClInclude>
+    <ClInclude Include="GodMode.h">
+      <Filter>Archivos de encabezado</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">
@@ -166,6 +169,9 @@
     </ClCompile>
     <ClCompile Include="..\..\..\Libs\ImGui\imgui_widgets.cpp">
       <Filter>External</Filter>
+    </ClCompile>
+    <ClCompile Include="GodMode.cpp">
+      <Filter>Archivos de origen</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj.filters
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj.filters
@@ -149,5 +149,23 @@
     <ClCompile Include="ButtonScript.cpp">
       <Filter>Archivos de origen</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\Libs\ImGui\imgui.cpp">
+      <Filter>External</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Libs\ImGui\imgui_demo.cpp">
+      <Filter>External</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Libs\ImGui\imgui_draw.cpp">
+      <Filter>External</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Libs\ImGui\imgui_impl_opengl3.cpp">
+      <Filter>External</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Libs\ImGui\imgui_tables.cpp">
+      <Filter>External</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Libs\ImGui\imgui_widgets.cpp">
+      <Filter>External</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/SobrassadaEngine/Utils/Script.h
+++ b/SobrassadaEngine/Utils/Script.h
@@ -8,4 +8,5 @@ class Script
 
     virtual bool Init()                  = 0;
     virtual void Update(float deltaTime) = 0;
+    virtual void Inspector()             = 0;
 };

--- a/SobrassadaEngine/Utils/Script.h
+++ b/SobrassadaEngine/Utils/Script.h
@@ -1,4 +1,20 @@
 #pragma once
+struct InspectorField
+{
+    enum class FieldType
+    {
+        Text,
+        Float,
+        Int,
+        Bool
+    };
+
+    const char* name;
+    FieldType type;
+    void* data;
+    float minValue;
+    float maxValue;
+};
 
 // Here we only need to add the functions that are going to be used in the ScriptModule
 class Script

--- a/SobrassadaEngine/Utils/Script.h
+++ b/SobrassadaEngine/Utils/Script.h
@@ -6,7 +6,11 @@ struct InspectorField
         Text,
         Float,
         Int,
-        Bool
+        Bool,
+        Vec2,
+        Vec3,
+        Vec4,
+        Color
     };
 
     const char* name;


### PR DESCRIPTION
Added godCamera and ImGui integration in scripting.
Test:
For god camera you can add a mesh, a character controller a godcamera script in a gameobject and a camera in a child gameobject. When you click play you can press P to detach the camera and inutilice the input of the player. You can attach the camera clicking O.
For ImGui Integration you can see rotateGameObject (only works the speed, the other ones are a test)
Remember to create a navmesh.