### PR TITLE
THO-398 NavmeshCheckbox and New components storage

### DIFF
--- a/SobrassadaEngine/Modules/OpenGLModule.cpp
+++ b/SobrassadaEngine/Modules/OpenGLModule.cpp
@@ -181,6 +181,7 @@ bool OpenGLModule::ShutDown()
 
     SDL_GL_DeleteContext(App->GetWindowModule()->window);
     delete framebuffer;
+    delete gBuffer;
     return true;
 }
 

--- a/SobrassadaEngine/Modules/PathfinderModule.cpp
+++ b/SobrassadaEngine/Modules/PathfinderModule.cpp
@@ -255,7 +255,7 @@ void PathfinderModule::CreateNavMesh()
             GameObject* gameObject = pair.second;
             if (!gameObject || !gameObject->IsGloballyEnabled() || !gameObject->IsNavMeshValid()) continue;
             {
-                const MeshComponent* meshComponent = gameObject->GetMeshComponent();
+                const MeshComponent* meshComponent = gameObject->GetComponent<MeshComponent*>();
                 const float4x4& globalMatrix       = gameObject->GetGlobalTransform();
 
                 if (meshComponent && meshComponent->GetEnabled())

--- a/SobrassadaEngine/Modules/PathfinderModule.cpp
+++ b/SobrassadaEngine/Modules/PathfinderModule.cpp
@@ -253,7 +253,7 @@ void PathfinderModule::CreateNavMesh()
         for (const auto& pair : gameObjects)
         {
             GameObject* gameObject = pair.second;
-            if (!gameObject || !gameObject->IsGloballyEnabled()) continue;
+            if (!gameObject || !gameObject->IsGloballyEnabled() || !gameObject->IsNavMeshValid()) continue;
             {
                 const MeshComponent* meshComponent = gameObject->GetMeshComponent();
                 const float4x4& globalMatrix       = gameObject->GetGlobalTransform();

--- a/SobrassadaEngine/Modules/PhysicsModule.cpp
+++ b/SobrassadaEngine/Modules/PhysicsModule.cpp
@@ -401,6 +401,6 @@ void PhysicsModule::RebuildWorld()
 
     for (const auto& gameObject : allGameObjects)
     {
-        gameObject.second->UpdateComponents();
+        gameObject.second->ParentUpdatedComponents();
     }
 }

--- a/SobrassadaEngine/Modules/PhysicsModule.cpp
+++ b/SobrassadaEngine/Modules/PhysicsModule.cpp
@@ -109,6 +109,7 @@ bool PhysicsModule::ShutDown()
     delete broadPhase;
     delete dispatcher;
     delete collisionConfiguration;
+    delete debugDraw;
 
     return true;
 }

--- a/SobrassadaEngine/Modules/SceneModule.cpp
+++ b/SobrassadaEngine/Modules/SceneModule.cpp
@@ -302,7 +302,7 @@ void SceneModule::HandleObjectDuplication()
         // ITERATE OVER ALL GAME OBJECTS TO CHECK IF ANY REMAPING IS NEEDED
         for (int i = 0; i < createdGameObjects.size(); ++i)
         {
-            MeshComponent* originalMeshComp = originalGameObjects[i]->GetMeshComponent();
+            MeshComponent* originalMeshComp = originalGameObjects[i]->GetComponent<MeshComponent*>();
             if (originalMeshComp && originalMeshComp->GetHasBones())
             {
                 // Remap the bones references
@@ -317,11 +317,11 @@ void SceneModule::HandleObjectDuplication()
                     newBonesObjects.push_back(loadedScene->GetGameObjectByUID(uid));
                 }
 
-                MeshComponent* newMesh = createdGameObjects[i]->GetMeshComponent();
+                MeshComponent* newMesh = createdGameObjects[i]->GetComponent<MeshComponent*>();
                 newMesh->SetBones(newBonesObjects, newBonesUIDs);
             }
 
-            AnimationComponent* animComp = createdGameObjects[i]->GetAnimationComponent();
+            AnimationComponent* animComp = createdGameObjects[i]->GetComponent<AnimationComponent*>();
             if (animComp) animComp->SetBoneMapping();
         }
     }

--- a/SobrassadaEngine/Modules/ScriptModule.cpp
+++ b/SobrassadaEngine/Modules/ScriptModule.cpp
@@ -4,6 +4,7 @@
 #include "SceneModule.h"
 #include "Script.h"
 #include "ScriptComponent.h"
+
 #include "imgui.h"
 #include "imgui_impl_opengl3.h"
 #include "imgui_impl_sdl2.h"

--- a/SobrassadaEngine/Modules/ScriptModule.cpp
+++ b/SobrassadaEngine/Modules/ScriptModule.cpp
@@ -1,6 +1,7 @@
 #include "ScriptModule.h"
 #include "Application.h"
 #include "Component.h"
+#include "GameObject.h"
 #include "SceneModule.h"
 #include "Script.h"
 #include "ScriptComponent.h"
@@ -95,14 +96,21 @@ void ScriptModule::DeleteAllScripts()
 {
     if (App->GetSceneModule()->GetScene())
     {
-        for (auto* component : App->GetSceneModule()->GetScene()->GetAllComponents())
+        /*for (auto* component : App->GetSceneModule()->GetScene()->GetAllComponents())
         {
             if (component->GetType() == ComponentType::COMPONENT_SCRIPT)
             {
                 ScriptComponent* scriptComponent = static_cast<ScriptComponent*>(component);
                 scriptComponent->DeleteScript();
             }
+        }*/
+
+        for (auto& gameObject : App->GetSceneModule()->GetScene()->GetAllGameObjects())
+        {
+            ScriptComponent* scriptComponent = gameObject.second->GetComponent<ScriptComponent*>();
+            if (scriptComponent) scriptComponent->DeleteScript();
         }
+
         freeScriptFunc();
     }
 }
@@ -111,13 +119,19 @@ void ScriptModule::RecreateAllScripts()
 {
     if (App->GetSceneModule()->GetScene())
     {
-        for (auto* component : App->GetSceneModule()->GetScene()->GetAllComponents())
+        // for (auto* component : App->GetSceneModule()->GetScene()->GetAllComponents())
+        //{
+        //     if (component->GetType() == ComponentType::COMPONENT_SCRIPT)
+        //     {
+        //         ScriptComponent* scriptComponent = static_cast<ScriptComponent*>(component);
+        //         scriptComponent->CreateScript(scriptComponent->GetScriptName());
+        //     }
+        // }
+
+        for (auto& gameObject : App->GetSceneModule()->GetScene()->GetAllGameObjects())
         {
-            if (component->GetType() == ComponentType::COMPONENT_SCRIPT)
-            {
-                ScriptComponent* scriptComponent = static_cast<ScriptComponent*>(component);
-                scriptComponent->CreateScript(scriptComponent->GetScriptName());
-            }
+            ScriptComponent* scriptComponent = gameObject.second->GetComponent<ScriptComponent*>();
+            if (scriptComponent) scriptComponent->CreateScript(scriptComponent->GetScriptName());
         }
     }
 }

--- a/SobrassadaEngine/Scene/Components/ComponentUtils.cpp
+++ b/SobrassadaEngine/Scene/Components/ComponentUtils.cpp
@@ -24,14 +24,14 @@
 
 #include <cstdint>
 
-Component* ComponentUtils::CreateEmptyComponent(const ComponentType type, const UID uid, GameObject* parent)
+void ComponentUtils::CreateEmptyComponent(const ComponentType type, const UID uid, GameObject* parent)
 {
     Component* generatedComponent;
     auto& componentTuple = parent->GetComponentsTupleRef();
     switch (type)
     {
     case COMPONENT_NONE:
-        return nullptr;
+        return;
     case COMPONENT_MESH:
     {
         MeshComponent* mesh                      = new MeshComponent(uid, parent);
@@ -166,14 +166,13 @@ Component* ComponentUtils::CreateEmptyComponent(const ComponentType type, const 
         break;
     }
     default:
-        return nullptr;
+        return;
     }
-
+    parent->SetComponentCreated(type - 1);
     generatedComponent->Init();
-    return generatedComponent;
 }
 
-Component* ComponentUtils::CreateExistingComponent(const rapidjson::Value& initialState, GameObject* parent)
+void ComponentUtils::CreateExistingComponent(const rapidjson::Value& initialState, GameObject* parent)
 {
     if (initialState.HasMember("Type"))
     {
@@ -181,124 +180,124 @@ Component* ComponentUtils::CreateExistingComponent(const rapidjson::Value& initi
         switch (initialState["Type"].GetInt())
         {
         case COMPONENT_NONE:
-            return nullptr;
+            return;
         case COMPONENT_MESH:
         {
             MeshComponent* mesh                      = new MeshComponent(initialState, parent);
             std::get<MeshComponent*>(componentTuple) = mesh;
-            return mesh;
+            break;
         }
         case COMPONENT_POINT_LIGHT:
         {
             PointLightComponent* pointLight                = new PointLightComponent(initialState, parent);
             std::get<PointLightComponent*>(componentTuple) = pointLight;
-            return pointLight;
+            break;
         }
         case COMPONENT_SPOT_LIGHT:
         {
             SpotLightComponent* spotLight                 = new SpotLightComponent(initialState, parent);
             std::get<SpotLightComponent*>(componentTuple) = spotLight;
-            return spotLight;
+            break;
         }
         case COMPONENT_DIRECTIONAL_LIGHT:
         {
             DirectionalLightComponent* directionalLight          = new DirectionalLightComponent(initialState, parent);
             std::get<DirectionalLightComponent*>(componentTuple) = directionalLight;
-            return directionalLight;
+            break;
         }
         case COMPONENT_CHARACTER_CONTROLLER:
         {
             CharacterControllerComponent* characterController = new CharacterControllerComponent(initialState, parent);
             std::get<CharacterControllerComponent*>(componentTuple) = characterController;
-            return characterController;
+            break;
         }
         case COMPONENT_TRANSFORM_2D:
         {
             Transform2DComponent* transform2d               = new Transform2DComponent(initialState, parent);
             std::get<Transform2DComponent*>(componentTuple) = transform2d;
-            return transform2d;
+            break;
         }
         case COMPONENT_CANVAS:
         {
             CanvasComponent* canvas                    = new CanvasComponent(initialState, parent);
             std::get<CanvasComponent*>(componentTuple) = canvas;
-            return canvas;
+            break;
         }
         case COMPONENT_LABEL:
         {
             UILabelComponent* uiLabel                   = new UILabelComponent(initialState, parent);
             std::get<UILabelComponent*>(componentTuple) = uiLabel;
-            return uiLabel;
+            break;
         }
         case COMPONENT_CAMERA:
         {
             CameraComponent* camera                    = new CameraComponent(initialState, parent);
             std::get<CameraComponent*>(componentTuple) = camera;
-            return camera;
+            break;
         }
         case COMPONENT_SCRIPT:
         {
             ScriptComponent* script                    = new ScriptComponent(initialState, parent);
             std::get<ScriptComponent*>(componentTuple) = script;
-            return script;
+            break;
         }
         case COMPONENT_CUBE_COLLIDER:
         {
             CubeColliderComponent* cube                      = new CubeColliderComponent(initialState, parent);
             std::get<CubeColliderComponent*>(componentTuple) = cube;
-            return cube;
+            break;
         }
         case COMPONENT_SPHERE_COLLIDER:
         {
             SphereColliderComponent* sphere                    = new SphereColliderComponent(initialState, parent);
             std::get<SphereColliderComponent*>(componentTuple) = sphere;
-            return sphere;
+            break;
         }
         case COMPONENT_CAPSULE_COLLIDER:
         {
             CapsuleColliderComponent* capsule                   = new CapsuleColliderComponent(initialState, parent);
             std::get<CapsuleColliderComponent*>(componentTuple) = capsule;
-            return capsule;
+            break;
         }
         case COMPONENT_ANIMATION:
         {
             AnimationComponent* animation                 = new AnimationComponent(initialState, parent);
             std::get<AnimationComponent*>(componentTuple) = animation;
-            return animation;
+            break;
         }
         case COMPONENT_AIAGENT:
         {
             AIAgentComponent* aiAgent                   = new AIAgentComponent(initialState, parent);
             std::get<AIAgentComponent*>(componentTuple) = aiAgent;
-            return aiAgent;
+            break;
         }
         case COMPONENT_IMAGE:
         {
             ImageComponent* image                     = new ImageComponent(initialState, parent);
             std::get<ImageComponent*>(componentTuple) = image;
-            return image;
+            break;
         }
         case COMPONENT_BUTTON:
         {
             ButtonComponent* button                    = new ButtonComponent(initialState, parent);
             std::get<ButtonComponent*>(componentTuple) = button;
-            return button;
+            break;
         }
         case COMPONENT_AUDIO_SOURCE:
         {
             AudioSourceComponent* audioSource               = new AudioSourceComponent(initialState, parent);
             std::get<AudioSourceComponent*>(componentTuple) = audioSource;
-            return audioSource;
+            break;
         }
         case COMPONENT_AUDIO_LISTENER:
         {
             AudioListenerComponent* audioListener             = new AudioListenerComponent(initialState, parent);
             std::get<AudioListenerComponent*>(componentTuple) = audioListener;
-            return audioListener;
+            break;
         }
         default:
-            return nullptr;
+            return;
         }
+        parent->SetComponentCreated(initialState["Type"].GetInt() - 1);
     }
-    return nullptr;
 }

--- a/SobrassadaEngine/Scene/Components/ComponentUtils.cpp
+++ b/SobrassadaEngine/Scene/Components/ComponentUtils.cpp
@@ -2,6 +2,7 @@
 
 #include "CameraComponent.h"
 #include "Component.h"
+#include "GameObject.h"
 #include "ScriptComponent.h"
 #include "Standalone/AIAgentComponent.h"
 #include "Standalone/AnimationComponent.h"
@@ -26,73 +27,149 @@
 Component* ComponentUtils::CreateEmptyComponent(const ComponentType type, const UID uid, GameObject* parent)
 {
     Component* generatedComponent;
+    auto& componentTuple = parent->GetComponentsTupleRef();
     switch (type)
     {
     case COMPONENT_NONE:
         return nullptr;
     case COMPONENT_MESH:
-        generatedComponent = new MeshComponent(uid, parent);
+    {
+        MeshComponent* mesh                      = new MeshComponent(uid, parent);
+        std::get<MeshComponent*>(componentTuple) = mesh;
+        generatedComponent                       = mesh;
         break;
+    }
     case COMPONENT_POINT_LIGHT:
-        generatedComponent = new PointLightComponent(uid, parent);
+    {
+        PointLightComponent* pointLight                = new PointLightComponent(uid, parent);
+        std::get<PointLightComponent*>(componentTuple) = pointLight;
+        generatedComponent                             = pointLight;
         break;
+    }
     case COMPONENT_SPOT_LIGHT:
-        generatedComponent = new SpotLightComponent(uid, parent);
+    {
+        SpotLightComponent* spotLight                 = new SpotLightComponent(uid, parent);
+        std::get<SpotLightComponent*>(componentTuple) = spotLight;
+        generatedComponent                            = spotLight;
         break;
+    }
     case COMPONENT_DIRECTIONAL_LIGHT:
-        generatedComponent = new DirectionalLightComponent(uid, parent);
+    {
+        DirectionalLightComponent* directionalLight          = new DirectionalLightComponent(uid, parent);
+        std::get<DirectionalLightComponent*>(componentTuple) = directionalLight;
+        generatedComponent                                   = directionalLight;
         break;
+    }
     case COMPONENT_CHARACTER_CONTROLLER:
-        generatedComponent = new CharacterControllerComponent(uid, parent);
+    {
+        CharacterControllerComponent* characterController       = new CharacterControllerComponent(uid, parent);
+        std::get<CharacterControllerComponent*>(componentTuple) = characterController;
+        generatedComponent                                      = characterController;
         break;
+    }
     case COMPONENT_TRANSFORM_2D:
-        generatedComponent = new Transform2DComponent(uid, parent);
+    {
+        Transform2DComponent* transform2d               = new Transform2DComponent(uid, parent);
+        std::get<Transform2DComponent*>(componentTuple) = transform2d;
+        generatedComponent                              = transform2d;
         break;
+    }
     case COMPONENT_CANVAS:
-        generatedComponent = new CanvasComponent(uid, parent);
+    {
+        CanvasComponent* canvas                    = new CanvasComponent(uid, parent);
+        std::get<CanvasComponent*>(componentTuple) = canvas;
+        generatedComponent                         = canvas;
         break;
+    }
     case COMPONENT_LABEL:
-        generatedComponent = new UILabelComponent(uid, parent);
+    {
+        UILabelComponent* uiLabel                   = new UILabelComponent(uid, parent);
+        std::get<UILabelComponent*>(componentTuple) = uiLabel;
+        generatedComponent                          = uiLabel;
         break;
+    }
     case COMPONENT_CAMERA:
-        generatedComponent = new CameraComponent(uid, parent);
+    {
+        CameraComponent* camera                    = new CameraComponent(uid, parent);
+        std::get<CameraComponent*>(componentTuple) = camera;
+        generatedComponent                         = camera;
         break;
+    }
     case COMPONENT_SCRIPT:
-        generatedComponent = new ScriptComponent(uid, parent);
+    {
+        ScriptComponent* script                    = new ScriptComponent(uid, parent);
+        std::get<ScriptComponent*>(componentTuple) = script;
+        generatedComponent                         = script;
         break;
+    }
     case COMPONENT_CUBE_COLLIDER:
-        generatedComponent = new CubeColliderComponent(uid, parent);
+    {
+        CubeColliderComponent* cube                      = new CubeColliderComponent(uid, parent);
+        std::get<CubeColliderComponent*>(componentTuple) = cube;
+        generatedComponent                               = cube;
         break;
+    }
     case COMPONENT_SPHERE_COLLIDER:
-        generatedComponent = new SphereColliderComponent(uid, parent);
+    {
+        SphereColliderComponent* sphere                    = new SphereColliderComponent(uid, parent);
+        std::get<SphereColliderComponent*>(componentTuple) = sphere;
+        generatedComponent                                 = sphere;
         break;
+    }
     case COMPONENT_CAPSULE_COLLIDER:
-        generatedComponent = new CapsuleColliderComponent(uid, parent);
+    {
+        CapsuleColliderComponent* capsule                   = new CapsuleColliderComponent(uid, parent);
+        std::get<CapsuleColliderComponent*>(componentTuple) = capsule;
+        generatedComponent                                  = capsule;
         break;
+    }
     case COMPONENT_ANIMATION:
-        generatedComponent = new AnimationComponent(uid, parent);
+    {
+        AnimationComponent* animation                 = new AnimationComponent(uid, parent);
+        std::get<AnimationComponent*>(componentTuple) = animation;
+        generatedComponent                            = animation;
         break;
+    }
     case COMPONENT_AIAGENT:
-        generatedComponent = new AIAgentComponent(uid, parent);
+    {
+        AIAgentComponent* aiAgent                   = new AIAgentComponent(uid, parent);
+        std::get<AIAgentComponent*>(componentTuple) = aiAgent;
+        generatedComponent                          = aiAgent;
         break;
+    }
     case COMPONENT_IMAGE:
-        generatedComponent = new ImageComponent(uid, parent);
+    {
+        ImageComponent* image                     = new ImageComponent(uid, parent);
+        std::get<ImageComponent*>(componentTuple) = image;
+        generatedComponent                        = image;
         break;
+    }
     case COMPONENT_BUTTON:
-        generatedComponent = new ButtonComponent(uid, parent);
+    {
+        ButtonComponent* button                    = new ButtonComponent(uid, parent);
+        std::get<ButtonComponent*>(componentTuple) = button;
+        generatedComponent                         = button;
         break;
+    }
     case COMPONENT_AUDIO_SOURCE:
-        generatedComponent = new AudioSourceComponent(uid, parent);
+    {
+        AudioSourceComponent* audioSource               = new AudioSourceComponent(uid, parent);
+        std::get<AudioSourceComponent*>(componentTuple) = audioSource;
+        generatedComponent                              = audioSource;
         break;
+    }
     case COMPONENT_AUDIO_LISTENER:
-        generatedComponent = new AudioListenerComponent(uid, parent);
+    {
+        AudioListenerComponent* audioListener             = new AudioListenerComponent(uid, parent);
+        std::get<AudioListenerComponent*>(componentTuple) = audioListener;
+        generatedComponent                                = audioListener;
         break;
+    }
     default:
         return nullptr;
     }
 
     generatedComponent->Init();
-
     return generatedComponent;
 }
 
@@ -100,48 +177,125 @@ Component* ComponentUtils::CreateExistingComponent(const rapidjson::Value& initi
 {
     if (initialState.HasMember("Type"))
     {
+        auto& componentTuple = parent->GetComponentsTupleRef();
         switch (initialState["Type"].GetInt())
         {
         case COMPONENT_NONE:
             return nullptr;
         case COMPONENT_MESH:
-            return new MeshComponent(initialState, parent);
+        {
+            MeshComponent* mesh                      = new MeshComponent(initialState, parent);
+            std::get<MeshComponent*>(componentTuple) = mesh;
+            return mesh;
+        }
         case COMPONENT_POINT_LIGHT:
-            return new PointLightComponent(initialState, parent);
+        {
+            PointLightComponent* pointLight                = new PointLightComponent(initialState, parent);
+            std::get<PointLightComponent*>(componentTuple) = pointLight;
+            return pointLight;
+        }
         case COMPONENT_SPOT_LIGHT:
-            return new SpotLightComponent(initialState, parent);
+        {
+            SpotLightComponent* spotLight                 = new SpotLightComponent(initialState, parent);
+            std::get<SpotLightComponent*>(componentTuple) = spotLight;
+            return spotLight;
+        }
         case COMPONENT_DIRECTIONAL_LIGHT:
-            return new DirectionalLightComponent(initialState, parent);
+        {
+            DirectionalLightComponent* directionalLight          = new DirectionalLightComponent(initialState, parent);
+            std::get<DirectionalLightComponent*>(componentTuple) = directionalLight;
+            return directionalLight;
+        }
         case COMPONENT_CHARACTER_CONTROLLER:
-            return new CharacterControllerComponent(initialState, parent);
+        {
+            CharacterControllerComponent* characterController = new CharacterControllerComponent(initialState, parent);
+            std::get<CharacterControllerComponent*>(componentTuple) = characterController;
+            return characterController;
+        }
         case COMPONENT_TRANSFORM_2D:
-            return new Transform2DComponent(initialState, parent);
+        {
+            Transform2DComponent* transform2d               = new Transform2DComponent(initialState, parent);
+            std::get<Transform2DComponent*>(componentTuple) = transform2d;
+            return transform2d;
+        }
         case COMPONENT_CANVAS:
-            return new CanvasComponent(initialState, parent);
+        {
+            CanvasComponent* canvas                    = new CanvasComponent(initialState, parent);
+            std::get<CanvasComponent*>(componentTuple) = canvas;
+            return canvas;
+        }
         case COMPONENT_LABEL:
-            return new UILabelComponent(initialState, parent);
+        {
+            UILabelComponent* uiLabel                   = new UILabelComponent(initialState, parent);
+            std::get<UILabelComponent*>(componentTuple) = uiLabel;
+            return uiLabel;
+        }
         case COMPONENT_CAMERA:
-            return new CameraComponent(initialState, parent);
+        {
+            CameraComponent* camera                    = new CameraComponent(initialState, parent);
+            std::get<CameraComponent*>(componentTuple) = camera;
+            return camera;
+        }
         case COMPONENT_SCRIPT:
-            return new ScriptComponent(initialState, parent);
+        {
+            ScriptComponent* script                    = new ScriptComponent(initialState, parent);
+            std::get<ScriptComponent*>(componentTuple) = script;
+            return script;
+        }
         case COMPONENT_CUBE_COLLIDER:
-            return new CubeColliderComponent(initialState, parent);
+        {
+            CubeColliderComponent* cube                      = new CubeColliderComponent(initialState, parent);
+            std::get<CubeColliderComponent*>(componentTuple) = cube;
+            return cube;
+        }
         case COMPONENT_SPHERE_COLLIDER:
-            return new SphereColliderComponent(initialState, parent);
+        {
+            SphereColliderComponent* sphere                    = new SphereColliderComponent(initialState, parent);
+            std::get<SphereColliderComponent*>(componentTuple) = sphere;
+            return sphere;
+        }
         case COMPONENT_CAPSULE_COLLIDER:
-            return new CapsuleColliderComponent(initialState, parent);
+        {
+            CapsuleColliderComponent* capsule                   = new CapsuleColliderComponent(initialState, parent);
+            std::get<CapsuleColliderComponent*>(componentTuple) = capsule;
+            return capsule;
+        }
         case COMPONENT_ANIMATION:
-            return new AnimationComponent(initialState, parent);
+        {
+            AnimationComponent* animation                 = new AnimationComponent(initialState, parent);
+            std::get<AnimationComponent*>(componentTuple) = animation;
+            return animation;
+        }
         case COMPONENT_AIAGENT:
-            return new AIAgentComponent(initialState, parent);
+        {
+            AIAgentComponent* aiAgent                   = new AIAgentComponent(initialState, parent);
+            std::get<AIAgentComponent*>(componentTuple) = aiAgent;
+            return aiAgent;
+        }
         case COMPONENT_IMAGE:
-            return new ImageComponent(initialState, parent);
+        {
+            ImageComponent* image                     = new ImageComponent(initialState, parent);
+            std::get<ImageComponent*>(componentTuple) = image;
+            return image;
+        }
         case COMPONENT_BUTTON:
-            return new ButtonComponent(initialState, parent);
+        {
+            ButtonComponent* button                    = new ButtonComponent(initialState, parent);
+            std::get<ButtonComponent*>(componentTuple) = button;
+            return button;
+        }
         case COMPONENT_AUDIO_SOURCE:
-            return new AudioSourceComponent(initialState, parent);
+        {
+            AudioSourceComponent* audioSource               = new AudioSourceComponent(initialState, parent);
+            std::get<AudioSourceComponent*>(componentTuple) = audioSource;
+            return audioSource;
+        }
         case COMPONENT_AUDIO_LISTENER:
-            return new AudioListenerComponent(initialState, parent);
+        {
+            AudioListenerComponent* audioListener             = new AudioListenerComponent(initialState, parent);
+            std::get<AudioListenerComponent*>(componentTuple) = audioListener;
+            return audioListener;
+        }
         default:
             return nullptr;
         }

--- a/SobrassadaEngine/Scene/Components/ComponentUtils.h
+++ b/SobrassadaEngine/Scene/Components/ComponentUtils.h
@@ -64,9 +64,9 @@ typedef Delegate<void, GameObject*, float3> CollisionDelegate;
 class ComponentUtils
 {
   public:
-    static Component* CreateEmptyComponent(ComponentType type, UID uid, GameObject* parent);
+    static void CreateEmptyComponent(ComponentType type, UID uid, GameObject* parent);
 
-    static Component* CreateExistingComponent(const rapidjson::Value& initialState, GameObject* parent);
+    static void CreateExistingComponent(const rapidjson::Value& initialState, GameObject* parent);
 };
 
 #define COMPONENTS                                                                                                     \

--- a/SobrassadaEngine/Scene/Components/ComponentUtils.h
+++ b/SobrassadaEngine/Scene/Components/ComponentUtils.h
@@ -10,7 +10,7 @@
 class Component;
 class GameObject;
 
-enum ComponentType
+enum ComponentType : int
 {
     // Empty type
     COMPONENT_NONE = 0,
@@ -34,8 +34,6 @@ enum ComponentType
     COMPONENT_BUTTON,
     COMPONENT_AUDIO_SOURCE,
     COMPONENT_AUDIO_LISTENER,
-    FIRST = COMPONENT_NONE,
-    LAST  = COMPONENT_AUDIO_LISTENER
 };
 
 enum class ColliderType : uint8_t
@@ -70,3 +68,14 @@ class ComponentUtils
 
     static Component* CreateExistingComponent(const rapidjson::Value& initialState, GameObject* parent);
 };
+
+#define COMPONENTS                                                                                                     \
+    MeshComponent*, PointLightComponent*, SpotLightComponent*, DirectionalLightComponent*,                             \
+        CharacterControllerComponent*, Transform2DComponent*, CanvasComponent*,         \
+        UILabelComponent*, CameraComponent*, ScriptComponent*, CubeColliderComponent*, SphereColliderComponent*,       \
+        CapsuleColliderComponent*, AnimationComponent*, AIAgentComponent*, ImageComponent*, ButtonComponent*,          \
+        AudioSourceComponent*, AudioListenerComponent*
+
+#define COMPONENTS_NULLPTR                                                                                             \
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,        \
+        nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr

--- a/SobrassadaEngine/Scene/Components/Standalone/AnimationComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/AnimationComponent.cpp
@@ -193,7 +193,7 @@ void AnimationComponent::OnInspector()
         {
             ImGui::Text("Selected Object: %s", selectedObj->GetName().c_str());
 
-            currentAnimComp = static_cast<AnimationComponent*>(selectedObj->GetAnimationComponent());
+            currentAnimComp = selectedObj->GetComponent<AnimationComponent*>();
 
             if (currentAnimComp)
             {

--- a/SobrassadaEngine/Scene/Components/Standalone/Physics/CapsuleColliderComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/Physics/CapsuleColliderComponent.cpp
@@ -233,8 +233,8 @@ void CapsuleColliderComponent::OnCollision(GameObject* otherObject, float3 colli
 {
     if (!enabled) return;
 
-    dynamic_cast<ScriptComponent*>(parent->GetComponentByType(COMPONENT_SCRIPT))
-        ->OnCollision(otherObject, collisionNormal);
+    auto script = parent->GetComponent<ScriptComponent*>();
+    if (script) script->OnCollision(otherObject, collisionNormal);
 }
 
 void CapsuleColliderComponent::DeleteRigidBody()

--- a/SobrassadaEngine/Scene/Components/Standalone/Physics/CubeColliderComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/Physics/CubeColliderComponent.cpp
@@ -236,8 +236,9 @@ void CubeColliderComponent::OnCollision(GameObject* otherObject, float3 collisio
 {
     if (!enabled) return;
 
-    dynamic_cast<ScriptComponent*>(parent->GetComponentByType(COMPONENT_SCRIPT))
-        ->OnCollision(otherObject, collisionNormal);
+    auto script = dynamic_cast<ScriptComponent*>(parent->GetComponentByType(COMPONENT_SCRIPT));
+    
+    if (script) script->OnCollision(otherObject, collisionNormal);
 }
 
 void CubeColliderComponent::DeleteRigidBody()

--- a/SobrassadaEngine/Scene/Components/Standalone/Physics/CubeColliderComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/Physics/CubeColliderComponent.cpp
@@ -236,7 +236,7 @@ void CubeColliderComponent::OnCollision(GameObject* otherObject, float3 collisio
 {
     if (!enabled) return;
 
-    auto script = dynamic_cast<ScriptComponent*>(parent->GetComponentByType(COMPONENT_SCRIPT));
+    auto script = parent->GetComponent<ScriptComponent*>();
     
     if (script) script->OnCollision(otherObject, collisionNormal);
 }

--- a/SobrassadaEngine/Scene/Components/Standalone/Physics/SphereColliderComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/Physics/SphereColliderComponent.cpp
@@ -230,8 +230,9 @@ void SphereColliderComponent::OnCollision(GameObject* otherObject, float3 collis
 {
     if (!enabled) return;
 
-    dynamic_cast<ScriptComponent*>(parent->GetComponentByType(COMPONENT_SCRIPT))
-        ->OnCollision(otherObject, collisionNormal);
+    auto script = parent->GetComponent<ScriptComponent*>();
+
+    if (script) script->OnCollision(otherObject, collisionNormal);
 }
 
 void SphereColliderComponent::DeleteRigidBody()

--- a/SobrassadaEngine/Scene/Components/Standalone/UI/ButtonComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/UI/ButtonComponent.cpp
@@ -63,15 +63,11 @@ ButtonComponent::~ButtonComponent()
 
 void ButtonComponent::Init()
 {
-    Component* transform = parent->GetComponentByType(COMPONENT_TRANSFORM_2D);
+    Transform2DComponent* transform = parent->GetComponent<Transform2DComponent*>();
     if (transform == nullptr)
     {
         parent->CreateComponent(COMPONENT_TRANSFORM_2D);
-        transform2D = static_cast<Transform2DComponent*>(parent->GetComponentByType(COMPONENT_TRANSFORM_2D));
-    }
-    else
-    {
-        transform2D = static_cast<Transform2DComponent*>(transform);
+        transform2D = parent->GetComponent<Transform2DComponent*>();
     }
 
     parentCanvas = transform2D->GetParentCanvas();
@@ -86,15 +82,11 @@ void ButtonComponent::Init()
     }
 
     // Get the image
-    Component* linkedImage = parent->GetComponentByType(COMPONENT_IMAGE);
+    ImageComponent* linkedImage = parent->GetComponent<ImageComponent*>();
     if (linkedImage == nullptr)
     {
         parent->CreateComponent(COMPONENT_IMAGE);
-        image = static_cast<ImageComponent*>(parent->GetComponentByType(COMPONENT_IMAGE));
-    }
-    else
-    {
-        image = static_cast<ImageComponent*>(linkedImage);
+        image = parent->GetComponent<ImageComponent*>();
     }
 }
 

--- a/SobrassadaEngine/Scene/Components/Standalone/UI/CanvasComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/UI/CanvasComponent.cpp
@@ -153,14 +153,14 @@ void CanvasComponent::RenderUI()
         if (!child->IsGloballyEnabled()) continue;
 
         // Only render UI components
-        Component* uiWidget = child->GetComponentByType(COMPONENT_TRANSFORM_2D);
-        if (uiWidget) static_cast<const Transform2DComponent*>(uiWidget)->RenderWidgets();
+        Transform2DComponent* transform = child->GetComponent<Transform2DComponent*>();
+        if (transform) transform->RenderWidgets();
 
-        uiWidget = child->GetComponentByType(COMPONENT_LABEL);
-        if (uiWidget) static_cast<const UILabelComponent*>(uiWidget)->RenderUI(view, proj);
+        UILabelComponent* uiLabel = child->GetComponent<UILabelComponent*>();
+        if (uiLabel) uiLabel->RenderUI(view, proj);
 
-        uiWidget = child->GetComponentByType(COMPONENT_IMAGE);
-        if (uiWidget) static_cast<const ImageComponent*>(uiWidget)->RenderUI(view, proj);
+        ImageComponent* image = child->GetComponent<ImageComponent*>();
+        if (image) image->RenderUI(view, proj);
     }
 }
 
@@ -191,14 +191,6 @@ void CanvasComponent::OnWindowResize(const float width, const float height)
             parent->GetGlobalTransform().TranslatePart().y + (height / 4.0f), 0
         )
     );
-
-    // parent->UpdateTransformForGOBranch();
-
-    for (const GameObject* child : sortedChildren)
-    {
-        // Only render UI components
-        Component* transform2D = child->GetComponentByType(COMPONENT_TRANSFORM_2D);
-    }
 }
 
 void CanvasComponent::UpdateChildren()
@@ -242,15 +234,11 @@ void CanvasComponent::UpdateMousePosition(const float2& mousePos)
     for (int i = (int)sortedChildren.size() - 1; i >= 0; --i)
     {
         // Update all buttons
-        Component* button = sortedChildren[i]->GetComponentByType(COMPONENT_BUTTON);
-        if (button)
+        ButtonComponent* currentButton = sortedChildren[i]->GetComponent<ButtonComponent*>();
+        if (currentButton && currentButton->UpdateMousePosition(mousePos, buttonFound))
         {
-            ButtonComponent* currentButton = static_cast<ButtonComponent*>(button);
-            if (currentButton->UpdateMousePosition(mousePos, buttonFound))
-            {
-                hoveredButton = currentButton;
-                buttonFound   = true;
-            }
+            hoveredButton = currentButton;
+            buttonFound   = true;
         }
     }
 }

--- a/SobrassadaEngine/Scene/Components/Standalone/UI/ImageComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/UI/ImageComponent.cpp
@@ -58,15 +58,13 @@ ImageComponent::~ImageComponent()
 
 void ImageComponent::Init()
 {
-    Component* transform = parent->GetComponentByType(COMPONENT_TRANSFORM_2D);
-    if (transform == nullptr)
+    // Component* transform = parent->GetComponentByType(COMPONENT_TRANSFORM_2D);
+    transform2D = parent->GetComponent<Transform2DComponent*>();
+
+    if (transform2D == nullptr)
     {
         parent->CreateComponent(COMPONENT_TRANSFORM_2D);
-        transform2D = static_cast<Transform2DComponent*>(parent->GetComponentByType(COMPONENT_TRANSFORM_2D));
-    }
-    else
-    {
-        transform2D = static_cast<Transform2DComponent*>(transform);
+        transform2D = parent->GetComponent<Transform2DComponent*>();
     }
 
     parentCanvas = transform2D->GetParentCanvas();
@@ -117,14 +115,12 @@ void ImageComponent::Clone(const Component* other)
 
 void ImageComponent::RenderDebug(float deltaTime)
 {
-
 }
 
 void ImageComponent::Update(float deltaTime)
 {
     if (matchParentSize) MatchParentSize();
 }
-
 
 void ImageComponent::RenderEditorInspector()
 {
@@ -263,12 +259,11 @@ void ImageComponent::MatchParentSize()
 {
     if (transform2D == nullptr) return;
 
-    const UID parentUID        = parent->GetParent();
+    const UID parentUID  = parent->GetParent();
     GameObject* parentGO = App->GetSceneModule()->GetScene()->GetGameObjectByUID(parentUID);
 
     // Check if parent has transform 2D
-    if (Transform2DComponent* parentT2D =
-            static_cast<Transform2DComponent*>(parentGO->GetComponentByType(COMPONENT_TRANSFORM_2D)))
+    if (Transform2DComponent* parentT2D = parentGO->GetComponent<Transform2DComponent*>())
     {
         transform2D->size     = parentT2D->size;
         transform2D->position = float2(0, 0);
@@ -276,7 +271,7 @@ void ImageComponent::MatchParentSize()
     }
 
     // Check if parent is a canvas
-    if (CanvasComponent* canvas = static_cast<CanvasComponent*>(parentGO->GetComponentByType(COMPONENT_CANVAS)))
+    if (CanvasComponent* canvas = parentGO->GetComponent<CanvasComponent*>())
     {
         transform2D->size     = float2(canvas->GetWidth(), canvas->GetHeight());
         transform2D->position = float2(0, 0);

--- a/SobrassadaEngine/Scene/Components/Standalone/UI/UILabelComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/UI/UILabelComponent.cpp
@@ -73,16 +73,11 @@ UILabelComponent::~UILabelComponent()
 
 void UILabelComponent::Init()
 {
-    Transform2DComponent* transform =
-        static_cast<Transform2DComponent*>(parent->GetComponentByType(COMPONENT_TRANSFORM_2D));
-    if (transform == nullptr)
+    transform2D  = parent->GetComponent<Transform2DComponent*>();
+    if (transform2D == nullptr)
     {
         parent->CreateComponent(COMPONENT_TRANSFORM_2D);
-        transform2D = static_cast<Transform2DComponent*>(parent->GetComponentByType(COMPONENT_TRANSFORM_2D));
-    }
-    else
-    {
-        transform2D = transform;
+        transform2D = parent->GetComponent<Transform2DComponent*>();
     }
 
     parentCanvas = transform2D->GetParentCanvas();

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
@@ -132,6 +132,24 @@ template <std::size_t I = 0, typename... Tp>
     SaveComponentsTuple<I + 1, Tp...>(tuple, componentsJSON, allocator);
 }
 
+// EDITOR INSPECTOR COMPONENTS
+template <std::size_t I = 0, typename... Tp>
+inline typename std::enable_if<I == sizeof...(Tp), void>::type
+RenderEditorComponentsTuple(std::tuple<Tp...>& tuple, ComponentType selectedType)
+{
+}
+
+template <std::size_t I = 0, typename... Tp>
+    inline typename std::enable_if <
+    I<sizeof...(Tp), void>::type RenderEditorComponentsTuple(std::tuple<Tp...>& tuple, ComponentType selectedType)
+{
+    if (std::get<I>(tuple) && std::get<I>(tuple)->GetType() == selectedType)
+    {
+        std::get<I>(tuple)->RenderEditorInspector();
+    }
+    RenderEditorComponentsTuple<I + 1, Tp...>(tuple, selectedType);
+}
+
 GameObject::GameObject(const std::string& name) : name(name)
 {
     compTuple = std::make_tuple(COMPONENTS_NULLPTR);
@@ -473,10 +491,7 @@ void GameObject::RenderEditorInspector()
             "ComponentInspectorWrapper", ImVec2(0, 50), ImGuiChildFlags_Borders | ImGuiChildFlags_ResizeY
         );
 
-        if (components.find(selectedComponentIndex) != components.end())
-        {
-            components.at(selectedComponentIndex)->RenderEditorInspector();
-        }
+        RenderEditorComponentsTuple(compTuple, selectedComponentIndex);
 
         ImGui::EndChild();
         ImGui::PopStyleVar();

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
@@ -65,6 +65,7 @@ GameObject::GameObject(UID parentUID, GameObject* refObject)
     rotation         = refObject->rotation;
     scale            = refObject->scale;
     prefabUID        = refObject->prefabUID;
+    navMeshValid     = refObject->navMeshValid;
 
     // Must make a copy of each manually
     for (const auto& component : refObject->components)
@@ -89,6 +90,7 @@ GameObject::GameObject(const rapidjson::Value& initialState) : uid(initialState[
     if (initialState.HasMember("IsTopParent")) isTopParent = initialState["IsTopParent"].GetBool();
 
     if (initialState.HasMember("PrefabUID")) prefabUID = initialState["PrefabUID"].GetUint64();
+    if (initialState.HasMember("NavmeshValid")) navMeshValid = initialState["NavmeshValid"].GetBool();
 
     if (initialState.HasMember("LocalTransform") && initialState["LocalTransform"].IsArray() &&
         initialState["LocalTransform"].Size() == 16)
@@ -185,6 +187,7 @@ void GameObject::Save(rapidjson::Value& targetState, rapidjson::Document::Alloca
     targetState.AddMember("Mobility", mobilitySettings, allocator);
     targetState.AddMember("IsTopParent", isTopParent, allocator);
     targetState.AddMember("Enabled", enabled, allocator);
+    targetState.AddMember("NavmeshValid", navMeshValid, allocator);
 
     if (prefabUID != INVALID_UID) targetState.AddMember("PrefabUID", prefabUID, allocator);
 
@@ -253,8 +256,10 @@ void GameObject::RenderEditorInspector()
     {
         ImGui::SameLine();
         if (ImGui::Checkbox("Draw nodes", &drawNodes)) OnDrawConnectionsToggle();
-        ImGui::SameLine();
         ImGui::Checkbox("Is top parent", &isTopParent);
+        ImGui::SameLine();
+        ImGui::Checkbox("Navmesh valid", &navMeshValid);
+
         if (ImGui::Button("Add Component"))
         {
             ImGui::OpenPopup("ComponentSelection");

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.h
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.h
@@ -75,6 +75,8 @@ class SOBRASADA_API_ENGINE GameObject
     void UpdateGameObjectHierarchy(UID sourceUID);
     void RenameGameObjectHierarchy();
     bool TargetIsChildren(UID uidTarget);
+    void UpdateComponents(float deltaTime);
+    void RenderDebugComponents(float deltaTime);
 
     const std::string& GetName() const { return name; }
     void SetName(const std::string& newName) { name = newName; }
@@ -132,7 +134,7 @@ class SOBRASADA_API_ENGINE GameObject
     bool IsGloballyEnabled() const;
     UID GetPrefabUID() const { return prefabUID; }
     void SetPrefabUID(const UID uid) { prefabUID = uid; }
-    void UpdateComponents();
+    void ParentUpdatedComponents();
     void OnTransformUpdated();
     void SetPosition(float3& newPosition) { position = newPosition; };
     void SetWillUpdate(bool willUpdate) { this->willUpdate = willUpdate; };

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.h
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.h
@@ -37,6 +37,7 @@ class SOBRASADA_API_ENGINE GameObject
 
     bool IsStatic() const { return mobilitySettings == MobilitySettings::STATIC; };
     bool IsTopParent() const { return isTopParent; };
+    bool IsNavMeshValid() const { return navMeshValid; };
 
     bool AddGameObject(UID gameObjectUID);
     bool RemoveGameObject(UID gameObjectUID);
@@ -155,4 +156,5 @@ class SOBRASADA_API_ENGINE GameObject
     bool isTopParent                     = false;
     bool willUpdate                      = false;
     bool enabled                         = true;
+    bool navMeshValid                    = false;
 };

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -36,7 +36,6 @@
 #include "Standalone/Lights/SpotLightComponent.h"
 #include "Standalone/MeshComponent.h"
 
-
 #include "SDL_mouse.h"
 #include "glew.h"
 #include "imgui.h"
@@ -64,8 +63,7 @@ Scene::Scene(const rapidjson::Value& initialState, UID loadedSceneUID) : sceneUI
     this->sceneName       = initialState["Name"].GetString();
     gameObjectRootUID     = initialState["RootGameObject"].GetUint64();
     selectedGameObjectUID = gameObjectRootUID;
-    if (initialState.HasMember("NavmeshUID"))
-        navmeshUID = initialState["NavmeshUID"].GetUint64();
+    if (initialState.HasMember("NavmeshUID")) navmeshUID = initialState["NavmeshUID"].GetUint64();
 
     App->GetPhysicsModule()->LoadLayerData(&initialState);
 
@@ -145,8 +143,8 @@ void Scene::Init()
     // Initialize the skinning for all the gameObjects that need it
     for (const auto& gameObject : gameObjectsContainer)
     {
-        MeshComponent* mesh = gameObject.second->GetMeshComponent();
-        if (mesh != nullptr) mesh->InitSkin();
+        MeshComponent* mesh = gameObject.second->GetComponent<MeshComponent*>();
+        if (mesh) mesh->InitSkin();
     }
 
     for (auto& gameObject : gameObjectsContainer)
@@ -158,7 +156,7 @@ void Scene::Init()
     lightsConfig->InitSkybox();
     lightsConfig->InitLightBuffers();
 
-    //Load navmesh from scene.
+    // Load navmesh from scene.
     if (navmeshUID != INVALID_UID)
     {
         std::string navmeshName = App->GetLibraryModule()->GetResourceName(navmeshUID);
@@ -903,7 +901,7 @@ void Scene::GeometryPassRender(
 
     for (const auto& gameObject : objectsToRender)
     {
-        MeshComponent* mesh = gameObject->GetMeshComponent();
+        MeshComponent* mesh = gameObject->GetComponent<MeshComponent*>();
         if (mesh != nullptr && mesh->GetEnabled() && mesh->GetBatch() != nullptr) meshesToRender.push_back(mesh);
     }
 
@@ -1157,7 +1155,7 @@ void Scene::LoadModel(const UID modelUID)
                                 AddGameObject(meshObject->GetUID(), meshObject);
                             }
 
-                            MeshComponent* meshComponent = meshObject->GetMeshComponent();
+                            MeshComponent* meshComponent = meshObject->GetComponent<MeshComponent*>();
                             meshComponent->SetModelUID(modelUID);
                             meshComponent->AddMesh(mesh.first);
                             meshComponent->AddMaterial(mesh.second);
@@ -1197,7 +1195,7 @@ void Scene::LoadModel(const UID modelUID)
             if (!animUIDs.empty())
             {
                 rootGameObject->CreateComponent(COMPONENT_ANIMATION);
-                AnimationComponent* animComponent = rootGameObject->GetAnimationComponent();
+                AnimationComponent* animComponent = rootGameObject->GetComponent<AnimationComponent*>();
 
                 GLOG("Model has %zu animations", animUIDs.size());
                 for (UID uid : animUIDs)
@@ -1262,7 +1260,7 @@ void Scene::LoadPrefab(const UID prefabUID, const ResourcePrefab* prefab, const 
         // Then do a second loop to update all components UIDs reference (ex. skinning)
         for (int i = 0; i < newObjects.size(); ++i)
         {
-            MeshComponent* mesh = referenceObjects[i]->GetMeshComponent();
+            MeshComponent* mesh = referenceObjects[i]->GetComponent<MeshComponent*>();
             if (mesh != nullptr && mesh->GetBones().size() > 0)
             {
                 // Remap the bones references
@@ -1278,12 +1276,12 @@ void Scene::LoadPrefab(const UID prefabUID, const ResourcePrefab* prefab, const 
                 }
 
                 // This should never be nullptr
-                MeshComponent* newMesh = newObjects[i]->GetMeshComponent();
+                MeshComponent* newMesh = newObjects[i]->GetComponent<MeshComponent*>();
                 newMesh->SetBones(newBonesObjects, newBonesUIDs);
             }
 
             // If has animations, map them here
-            AnimationComponent* animComp = newObjects[i]->GetAnimationComponent();
+            AnimationComponent* animComp = newObjects[i]->GetComponent<AnimationComponent*>();
             if (animComp) animComp->SetBoneMapping();
         }
 
@@ -1339,24 +1337,24 @@ void Scene::OverridePrefabs(const UID prefabUID)
     App->GetResourcesModule()->ReleaseResource(prefab);
 }
 
-template <typename T> std::vector<T*> Scene::GetEnabledComponentsOfType() const
+template <typename T> std::vector<T> Scene::GetEnabledComponentsOfType() const
 {
-    std::vector<T*> result;
+    std::vector<T> result;
 
     for (const auto& [uid, go] : gameObjectsContainer)
     {
         if (!go || !go->IsGloballyEnabled()) continue;
 
-        Component* comp = go->GetComponentByType(T::STATIC_TYPE);
+        T comp = go->GetComponent<T>();
         if (comp && comp->GetEnabled())
         {
-            result.push_back(static_cast<T*>(comp));
+            result.push_back(comp);
         }
     }
 
     return result;
 }
 
-template std::vector<DirectionalLightComponent*> Scene::GetEnabledComponentsOfType<DirectionalLightComponent>() const;
-template std::vector<PointLightComponent*> Scene::GetEnabledComponentsOfType<PointLightComponent>() const;
-template std::vector<SpotLightComponent*> Scene::GetEnabledComponentsOfType<SpotLightComponent>() const;
+template std::vector<DirectionalLightComponent*> Scene::GetEnabledComponentsOfType<DirectionalLightComponent*>() const;
+template std::vector<PointLightComponent*> Scene::GetEnabledComponentsOfType<PointLightComponent*>() const;
+template std::vector<SpotLightComponent*> Scene::GetEnabledComponentsOfType<SpotLightComponent*>() const;

--- a/SobrassadaEngine/Scene/Scene.h
+++ b/SobrassadaEngine/Scene/Scene.h
@@ -86,7 +86,7 @@ class SOBRASADA_API_ENGINE Scene
     LightsConfig* GetLightsConfig() const { return lightsConfig; }
     CameraComponent* GetMainCamera() const { return mainCamera; }
 
-    template <typename T> std::vector<T*> GetEnabledComponentsOfType() const;
+    template <typename T> std::vector<T> GetEnabledComponentsOfType() const;
 
     bool GetDoInputs() const { return doInputs; }
     bool GetDoMouseInputs() const { return doMouseInputs; }

--- a/SobrassadaEngine/Scene/Scene.h
+++ b/SobrassadaEngine/Scene/Scene.h
@@ -79,7 +79,6 @@ class SOBRASADA_API_ENGINE Scene
     UID GetSelectedGameObjectUID() const { return selectedGameObjectUID; }
 
     const std::unordered_map<UID, GameObject*>& GetAllGameObjects() const { return gameObjectsContainer; }
-    const std::vector<Component*> GetAllComponents() const;
 
     GameObject* GetGameObjectByUID(UID gameObjectUID); // TODO: Change when filesystem defined
 
@@ -129,17 +128,17 @@ class SOBRASADA_API_ENGINE Scene
     ) const;
 
   private:
-    std::string sceneName                       = DEFAULT_SCENE_NAME;
-    UID sceneUID                                = INVALID_UID;
-    UID navmeshUID                              = INVALID_UID;
-    UID gameObjectRootUID                       = INVALID_UID;
-    UID selectedGameObjectUID                   = INVALID_UID;
-    CameraComponent* mainCamera                 = nullptr;
-    bool stopPlaying                            = false;
-    bool doInputs                               = false;
-    bool doMouseInputs                          = false;
-    bool sceneVisible                           = false;
-    bool isFocused                              = false;
+    std::string sceneName       = DEFAULT_SCENE_NAME;
+    UID sceneUID                = INVALID_UID;
+    UID navmeshUID              = INVALID_UID;
+    UID gameObjectRootUID       = INVALID_UID;
+    UID selectedGameObjectUID   = INVALID_UID;
+    CameraComponent* mainCamera = nullptr;
+    bool stopPlaying            = false;
+    bool doInputs               = false;
+    bool doMouseInputs          = false;
+    bool sceneVisible           = false;
+    bool isFocused              = false;
 
     std::unordered_map<UID, GameObject*> gameObjectsContainer;
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/ButtonScript.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/ButtonScript.cpp
@@ -23,12 +23,21 @@ bool ButtonScript::Init()
         return false;
     }
 
-    Component* button = parent->GetComponentByType(COMPONENT_BUTTON);
+    //Component* button = parent->GetComponentByType(COMPONENT_BUTTON);
+    ButtonComponent* button = parent->GetComponent<ButtonComponent*>();
+    //if (button)
+    //{
+    //    std::function<void(void)> function = std::bind(&ButtonScript::OnClick, this);
+    //    Delegate<void> delegate(function);
+    //    delegateID            = static_cast<ButtonComponent*>(button)->AddOnClickCallback(delegate);
+    //    hasRegisteredCallback = true;
+    //}
+    
     if (button)
     {
         std::function<void(void)> function = std::bind(&ButtonScript::OnClick, this);
         Delegate<void> delegate(function);
-        delegateID            = static_cast<ButtonComponent*>(button)->AddOnClickCallback(delegate);
+        delegateID            = button->AddOnClickCallback(delegate);
         hasRegisteredCallback = true;
     }
 
@@ -40,11 +49,14 @@ ButtonScript::~ButtonScript()
 {
     if (hasRegisteredCallback)
     {
-        Component* button = parent->GetComponentByType(COMPONENT_BUTTON);
-        if (button)
-        {
-            static_cast<ButtonComponent*>(button)->RemoveOnClickCallback(delegateID);
-        }
+        //Component* button = parent->GetComponentByType(COMPONENT_BUTTON);
+        //if (button)
+        //{
+        //    static_cast<ButtonComponent*>(button)->RemoveOnClickCallback(delegateID);
+        //}
+
+        ButtonComponent* button = parent->GetComponent<ButtonComponent*>();
+        if (button) button->RemoveOnClickCallback(delegateID);
     }
 }
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Character.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Character.cpp
@@ -26,7 +26,7 @@ Character::Character(
 
 bool Character::Init()
 {
-    animComponent = parent->GetAnimationComponent();
+    animComponent = parent->GetComponent<AnimationComponent*>();
     if (!animComponent)
     {
         GLOG("Animation component not found for %s", parent->GetName().c_str());
@@ -34,14 +34,14 @@ bool Character::Init()
     }
     animComponent->OnPlay(false);
 
-    characterCollider = dynamic_cast<CapsuleColliderComponent*>(parent->GetComponentByType(COMPONENT_CAPSULE_COLLIDER));
+    characterCollider = parent->GetComponent<CapsuleColliderComponent*>();
     if (!characterCollider)
     {
         GLOG("Character capsule collider component not found for %s", parent->GetName().c_str());
         return false;
     }
 
-    weaponCollider = dynamic_cast<CubeColliderComponent*>(parent->GetComponentChildByType(COMPONENT_CUBE_COLLIDER));
+    weaponCollider = parent->GetComponentChild<CubeColliderComponent*>(AppEngine);
     if (!weaponCollider)
     {
         GLOG("Weapon cube collider component not found for %s", parent->GetName().c_str());
@@ -98,10 +98,10 @@ void Character::OnCollision(GameObject* otherObject, const float3& collisionNorm
 {
     // cube collider should be only if is enabled here already checked by OnCollision of cubeColliderComponent
     // GLOG("COLLISION %s with %s", parent->GetName().c_str(), otherObject->GetName().c_str())
-    CubeColliderComponent* enemyWeapon =
-        dynamic_cast<CubeColliderComponent*>(otherObject->GetComponentByType(COMPONENT_CUBE_COLLIDER));
-    ScriptComponent* enemyScriptComponent =
-        dynamic_cast<ScriptComponent*>(otherObject->GetComponentParentByType(COMPONENT_SCRIPT));
+
+    CubeColliderComponent* enemyWeapon    = otherObject->GetComponent<CubeColliderComponent*>();
+
+    ScriptComponent* enemyScriptComponent = otherObject->GetComponentParent<ScriptComponent*>(AppEngine);
 
     if (!isInvulnerable && enemyScriptComponent != nullptr && enemyWeapon != nullptr && enemyWeapon->GetEnabled())
     {

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -24,14 +24,22 @@ bool CuChulainn::Init()
 
     Character::Init();
 
-    Component* agent = parent->GetComponentByType(COMPONENT_CHARACTER_CONTROLLER);
-    if (!agent)
+    // Component* agent = parent->GetComponentByType(COMPONENT_CHARACTER_CONTROLLER);
+    // if (!agent)
+    //{
+    //     GLOG("CharacterController component not found for CuChulainn");
+    //     return false;
+    // }
+
+    // character = dynamic_cast<CharacterControllerComponent*>(agent);
+
+    character = parent->GetComponent<CharacterControllerComponent*>();
+    if (!character)
     {
         GLOG("CharacterController component not found for CuChulainn");
         return false;
     }
 
-    character = dynamic_cast<CharacterControllerComponent*>(agent);
     character->SetSpeed(speed);
 
     return true;
@@ -101,7 +109,6 @@ void CuChulainn::HandleState(float time)
         {
             animComponent->UseTrigger("idle");
         }
-
     }
     // If(Input de dash){
     // stateMachine->UseTrigger("Dash");

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/ExitGameScript.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/ExitGameScript.cpp
@@ -9,12 +9,21 @@
 
 bool ExitGameScript::Init()
 {
-    Component* button = parent->GetComponentByType(COMPONENT_BUTTON);
+    // Component* button = parent->GetComponentByType(COMPONENT_BUTTON);
+    // if (button)
+    //{
+    //     std::function<void(void)> function = std::bind(&ExitGameScript::OnClick, this);
+    //     Delegate<void> delegate(function);
+    //     delegateID            = static_cast<ButtonComponent*>(button)->AddOnClickCallback(delegate);
+    //     hasRegisteredCallback = true;
+    // }
+
+    ButtonComponent* button = parent->GetComponent<ButtonComponent*>();
     if (button)
     {
         std::function<void(void)> function = std::bind(&ExitGameScript::OnClick, this);
         Delegate<void> delegate(function);
-        delegateID            = static_cast<ButtonComponent*>(button)->AddOnClickCallback(delegate);
+        delegateID            = button->AddOnClickCallback(delegate);
         hasRegisteredCallback = true;
     }
 
@@ -39,11 +48,14 @@ ExitGameScript::~ExitGameScript()
 {
     if (hasRegisteredCallback)
     {
-        Component* button = parent->GetComponentByType(COMPONENT_BUTTON);
+        /*Component* button = parent->GetComponentByType(COMPONENT_BUTTON);
         if (button)
         {
             static_cast<ButtonComponent*>(button)->RemoveOnClickCallback(delegateID);
-        }
+        }*/
+
+        ButtonComponent* button = parent->GetComponent<ButtonComponent*>();
+        if (button) button->RemoveOnClickCallback(delegateID);
     }
 }
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/FullscreenToggleScript.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/FullscreenToggleScript.cpp
@@ -1,15 +1,30 @@
 #include "pch.h"
 
-#include "FullscreenToggleScript.h"
 #include "Application.h"
 #include "EditorUIModule.h"
+#include "FullscreenToggleScript.h"
 #include "GameObject.h"
 #include "Standalone/UI/ButtonComponent.h"
 
 bool FullscreenToggleScript::Init()
 {
-    Component* button = parent->GetComponentByType(COMPONENT_BUTTON);
+    // Component* button = parent->GetComponentByType(COMPONENT_BUTTON);
 
+    // if (button)
+    //{
+    //     FullscreenToggleScript* self   = this;
+
+    //    std::function<void()> function = [self]()
+    //    {
+    //        if (self) self->OnClick();
+    //    };
+
+    //    Delegate<void> delegate(function);
+    //    delegateID            = static_cast<ButtonComponent*>(button)->AddOnClickCallback(delegate);
+    //    hasRegisteredCallback = true;
+    //}
+
+    ButtonComponent* button = parent->GetComponent<ButtonComponent*>();
     if (button)
     {
         FullscreenToggleScript* self   = this;
@@ -20,13 +35,12 @@ bool FullscreenToggleScript::Init()
         };
 
         Delegate<void> delegate(function);
-        delegateID            = static_cast<ButtonComponent*>(button)->AddOnClickCallback(delegate);
+        delegateID            = button->AddOnClickCallback(delegate);
         hasRegisteredCallback = true;
     }
 
     return true;
 }
-
 
 void FullscreenToggleScript::Update(float deltaTime)
 {
@@ -45,11 +59,14 @@ FullscreenToggleScript::~FullscreenToggleScript()
 {
     if (hasRegisteredCallback)
     {
-        Component* button = parent->GetComponentByType(COMPONENT_BUTTON);
+        /*Component* button = parent->GetComponentByType(COMPONENT_BUTTON);
         if (button)
         {
             static_cast<ButtonComponent*>(button)->RemoveOnClickCallback(delegateID);
-        }
+        }*/
+
+        ButtonComponent* button = parent->GetComponent<ButtonComponent*>();
+        if (button) button->RemoveOnClickCallback(delegateID);
     }
 }
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/GodMode.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/GodMode.cpp
@@ -10,14 +10,17 @@
 
 bool GodMode::Init()
 {
-    characterController =
-        dynamic_cast<CharacterControllerComponent*>(parent->GetComponentByType(COMPONENT_CHARACTER_CONTROLLER));
+    //characterController =
+    //    dynamic_cast<CharacterControllerComponent*>(parent->GetComponentByType(COMPONENT_CHARACTER_CONTROLLER));
+    characterController = parent->GetComponent<CharacterControllerComponent*>();
     if (!characterController)
     {
         GLOG("GodMode character controller component not found for %s", parent->GetName().c_str());
         return false;
     }
-    godCamera = dynamic_cast<CameraComponent*>(parent->GetComponentChildByType(COMPONENT_CAMERA));
+
+    //godCamera = dynamic_cast<CameraComponent*>(parent->GetComponentChildByType(COMPONENT_CAMERA));
+    godCamera = parent->GetComponentChild<CameraComponent*>(AppEngine);
     if (!godCamera)
     {
         GLOG("GodMode camera component not found for %s", parent->GetName().c_str());

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MainMenuSelectorScript.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MainMenuSelectorScript.cpp
@@ -55,11 +55,14 @@ void MainMenuSelectorScript::Update(float deltaTime)
     if (keys[SDL_SCANCODE_RETURN] == KEY_DOWN || keys[SDL_SCANCODE_SPACE] == KEY_DOWN)
     {
         GameObject* selectedItem = menuItems[selectedIndex];
-        Component* button        = selectedItem->GetComponentByType(COMPONENT_BUTTON);
+        /*Component* button        = selectedItem->GetComponentByType(COMPONENT_BUTTON);
         if (button)
         {
             static_cast<ButtonComponent*>(button)->OnClick();
-        }
+        }*/
+
+        ButtonComponent* button  = selectedItem->GetComponent<ButtonComponent*>();
+        if (button) button->OnClick();
     }
 }
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/ScriptExport.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/ScriptExport.cpp
@@ -2,18 +2,17 @@
 
 #include "ButtonScript.h"
 #include "CuChulainn.h"
-#include "Globals.h"
-#include "ButtonScript.h"
 #include "ExitGameScript.h"
 #include "FullscreenToggleScript.h"
-#include "VSyncToggleScript.h"
-#include "PauseMenuScript.h"
-#include "OptionsMenuSwitcherScript.h"
-#include "MainMenuSelectorScript.h"
-#include "PressAnyKeyScript.h"
+#include "Globals.h"
 #include "GodMode.h"
+#include "MainMenuSelectorScript.h"
+#include "OptionsMenuSwitcherScript.h"
+#include "PauseMenuScript.h"
+#include "PressAnyKeyScript.h"
 #include "RotateGameObject.h"
 #include "Soldier.h"
+#include "VSyncToggleScript.h"
 
 #include <string>
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.cpp
@@ -22,14 +22,22 @@ bool Soldier::Init()
 
     Character::Init();
 
-    Component* agent = parent->GetComponentByType(COMPONENT_AIAGENT);
+    /*Component* agent = parent->GetComponentByType(COMPONENT_AIAGENT);
     if (!agent)
     {
         GLOG("AIAgent component not found for Soldier");
         return false;
     }
 
-    agentAI = dynamic_cast<AIAgentComponent*>(agent);
+    agentAI = dynamic_cast<AIAgentComponent*>(agent);*/
+
+    agentAI = parent->GetComponent<AIAgentComponent*>();
+    if (!agentAI)
+    {
+        GLOG("AIAgent component not found for Soldier");
+        return false;
+    }
+
     agentAI->SetSpeed(speed);
 
     return true;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/VSyncToggleScript.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/VSyncToggleScript.cpp
@@ -1,20 +1,29 @@
 #include "pch.h"
 
-#include "VSyncToggleScript.h"
 #include "Application.h"
 #include "EditorUIModule.h"
 #include "GameObject.h"
 #include "Scene/Components/Standalone/UI/ButtonComponent.h"
 #include "Utils/Delegate.h"
+#include "VSyncToggleScript.h"
 
 bool VSyncToggleScript::Init()
 {
-    Component* button = parent->GetComponentByType(COMPONENT_BUTTON);
+    // Component* button = parent->GetComponentByType(COMPONENT_BUTTON);
+    // if (button)
+    //{
+    //     std::function<void(void)> function = std::bind(&VSyncToggleScript::OnClick, this);
+    //     Delegate<void> delegate(function);
+    //     delegateID            = static_cast<ButtonComponent*>(button)->AddOnClickCallback(delegate);
+    //     hasRegisteredCallback = true;
+    // }
+
+    ButtonComponent* button = parent->GetComponent<ButtonComponent*>();
     if (button)
     {
         std::function<void(void)> function = std::bind(&VSyncToggleScript::OnClick, this);
         Delegate<void> delegate(function);
-        delegateID            = static_cast<ButtonComponent*>(button)->AddOnClickCallback(delegate);
+        delegateID            = button->AddOnClickCallback(delegate);
         hasRegisteredCallback = true;
     }
 
@@ -38,11 +47,14 @@ VSyncToggleScript::~VSyncToggleScript()
 {
     if (hasRegisteredCallback)
     {
-        Component* button = parent->GetComponentByType(COMPONENT_BUTTON);
+        /*Component* button = parent->GetComponentByType(COMPONENT_BUTTON);
         if (button)
         {
             static_cast<ButtonComponent*>(button)->RemoveOnClickCallback(delegateID);
-        }
+        }*/
+
+        ButtonComponent* button = parent->GetComponent<ButtonComponent*>();
+        if (button) button->RemoveOnClickCallback(delegateID);
     }
 }
 

--- a/SobrassadaEngine/Utils/LightsConfig.cpp
+++ b/SobrassadaEngine/Utils/LightsConfig.cpp
@@ -661,15 +661,15 @@ void LightsConfig::GetAllSceneLights()
         Scene* scene          = App->GetSceneModule()->GetScene();
 
         // Directional
-        const auto& dirLights = scene->GetEnabledComponentsOfType<DirectionalLightComponent>();
+        const auto& dirLights = scene->GetEnabledComponentsOfType<DirectionalLightComponent*>();
         directionalLight      = dirLights.empty() ? nullptr : dirLights[0];
 
         // Point
-        pointLights           = scene->GetEnabledComponentsOfType<PointLightComponent>();
+        pointLights           = scene->GetEnabledComponentsOfType<PointLightComponent*>();
         // GLOG("Point lights count: %d", pointLights.size());
 
         // Spot
-        spotLights            = scene->GetEnabledComponentsOfType<SpotLightComponent>();
+        spotLights            = scene->GetEnabledComponentsOfType<SpotLightComponent*>();
         // GLOG("Spot lights count: %d", spotLights.size());
 
         glBindBuffer(GL_SHADER_STORAGE_BUFFER, pointBufferId);

--- a/SobrassadaEngine/Utils/RaycastController.cpp
+++ b/SobrassadaEngine/Utils/RaycastController.cpp
@@ -38,7 +38,8 @@ namespace RaycastController
         {
             LineSegment localRay(ray.a, ray.b);
 
-            const MeshComponent* meshComponent = gameObject->GetMeshComponent();
+            //const MeshComponent* meshComponent = gameObject->GetMeshComponent();
+            const MeshComponent* meshComponent = gameObject->GetComponent<MeshComponent*>();
             if (meshComponent == nullptr) continue; // TODO REMOVE WHEN EMPTY GAMEOBJECT DON'T CONTAIN AN AABB
 
             const ResourceMesh* resourceMesh = meshComponent->GetResourceMesh();


### PR DESCRIPTION
This PR changes the navmesh creation to only use the game objects that have the navmesh checkbox activated, important, in order to take effect the checkbox must be in the GO that contains the mesh. 

Also changes the storage of Components to a tuple so dynamics casts can be avoided everywhere components are needed. There is a templated GetComponent now, just ask for the specific component*.

Also fixes a crash for not checking if script components inside the onCollision functions weren't nullptr.