### PR TITLE
THO-476 Invert mouse picking

### DIFF
--- a/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
@@ -217,7 +217,7 @@ GameObject::GameObject(UID parentUID, GameObject* refObject)
 
     globalOBB        = OBB(localAABB);
     globalAABB       = AABB(globalOBB);
-    isTopParent      = refObject->isTopParent;
+    selectParent      = refObject->selectParent;
     mobilitySettings = refObject->mobilitySettings;
 
     position         = refObject->position;
@@ -249,7 +249,7 @@ GameObject::GameObject(const rapidjson::Value& initialState) : uid(initialState[
 
     if (initialState.HasMember("Enabled")) enabled = initialState["Enabled"].GetBool();
 
-    if (initialState.HasMember("IsTopParent")) isTopParent = initialState["IsTopParent"].GetBool();
+    if (initialState.HasMember("SelectParent")) selectParent = initialState["SelectParent"].GetBool();
 
     if (initialState.HasMember("PrefabUID")) prefabUID = initialState["PrefabUID"].GetUint64();
     if (initialState.HasMember("NavmeshValid")) navMeshValid = initialState["NavmeshValid"].GetBool();
@@ -363,7 +363,7 @@ void GameObject::Save(rapidjson::Value& targetState, rapidjson::Document::Alloca
     targetState.AddMember("ParentUID", parentUID, allocator);
     targetState.AddMember("Name", rapidjson::Value(name.c_str(), allocator), allocator);
     targetState.AddMember("Mobility", mobilitySettings, allocator);
-    targetState.AddMember("IsTopParent", isTopParent, allocator);
+    targetState.AddMember("SelectParent", selectParent, allocator);
     targetState.AddMember("Enabled", enabled, allocator);
     targetState.AddMember("NavmeshValid", navMeshValid, allocator);
 
@@ -423,7 +423,7 @@ void GameObject::RenderEditorInspector()
     {
         ImGui::SameLine();
         if (ImGui::Checkbox("Draw nodes", &drawNodes)) OnDrawConnectionsToggle();
-        ImGui::Checkbox("Is top parent", &isTopParent);
+        ImGui::Checkbox("Select parent", &selectParent);
         ImGui::SameLine();
         ImGui::Checkbox("Navmesh valid", &navMeshValid);
 

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
@@ -631,7 +631,7 @@ void GameObject::UpdateOpenNodeHierarchy(bool openValue)
 
     while (!gameObjectsToVisit.empty())
     {
-        UID currentUID = gameObjectsToVisit.top();
+        const UID currentUID = gameObjectsToVisit.top();
         gameObjectsToVisit.pop();
 
         GameObject* gameObjectToUpdate = App->GetSceneModule()->GetScene()->GetGameObjectByUID(currentUID);

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.h
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.h
@@ -59,7 +59,7 @@ class SOBRASADA_API_ENGINE GameObject
     const float4x4& GetParentGlobalTransform() const;
 
     bool IsStatic() const { return mobilitySettings == MobilitySettings::STATIC; };
-    bool IsTopParent() const { return isTopParent; };
+    bool HasSelectParent() const { return selectParent; };
     bool IsNavMeshValid() const { return navMeshValid; };
     bool IsComponentCreated(int i) const { return createdComponents[i]; };
 
@@ -139,6 +139,7 @@ class SOBRASADA_API_ENGINE GameObject
     void SetEnabled(bool state) { enabled = state; }
     void SetComponentCreated(int position) { createdComponents[position] = true; }
     void SetComponentRemoved(int position) { createdComponents[position] = false; }
+    void SetSelectParent(bool newSelectParent) { selectParent = newSelectParent; }
 
   private:
     void DrawNodes() const;
@@ -175,7 +176,7 @@ class SOBRASADA_API_ENGINE GameObject
 
     ComponentType selectedComponentIndex = COMPONENT_NONE;
     int mobilitySettings                 = STATIC;
-    bool isTopParent                     = false;
+    bool selectParent                    = false;
     bool willUpdate                      = false;
     bool enabled                         = true;
     bool navMeshValid                    = false;

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.h
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.h
@@ -111,6 +111,7 @@ class SOBRASADA_API_ENGINE GameObject
     void UpdateTransformForGOBranch();
     void UpdateMobilityHierarchy(MobilitySettings type);
     void UpdateLocalTransform(const float4x4& parentGlobalTransform);
+    void UpdateOpenNodeHierarchy(bool openValue);
 
     bool WillUpdate() const { return willUpdate; };
 
@@ -140,6 +141,7 @@ class SOBRASADA_API_ENGINE GameObject
     void SetComponentCreated(int position) { createdComponents[position] = true; }
     void SetComponentRemoved(int position) { createdComponents[position] = false; }
     void SetSelectParent(bool newSelectParent) { selectParent = newSelectParent; }
+    void SetOpenHierarchyNode(bool newOpen) { openHierarchyNode = newOpen; }
 
   private:
     void DrawNodes() const;
@@ -180,6 +182,7 @@ class SOBRASADA_API_ENGINE GameObject
     bool willUpdate                      = false;
     bool enabled                         = true;
     bool navMeshValid                    = false;
+    bool openHierarchyNode               = false;
 
     std::tuple<COMPONENTS> compTuple     = std::make_tuple(COMPONENTS_NULLPTR);
     std::bitset<std::tuple_size<decltype(compTuple)>::value> createdComponents;

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -1111,6 +1111,8 @@ void Scene::LoadModel(const UID modelUID)
                                 currentGameObject->GetName() + " Mesh " + std::to_string(meshNum)
                             );
                             ++meshNum;
+
+                            gameObjectsArray.push_back(meshObject);
                         }
                         else
                         {
@@ -1181,6 +1183,12 @@ void Scene::LoadModel(const UID modelUID)
                 GLOG("No animations found for this model");
             }
             rootGameObject->UpdateTransformForGOBranch();
+        }
+
+        // SET CHILD GAME OBJECTS TO SELECT THE PARENT
+        for (int i = 1; i < gameObjectsArray.size(); ++i)
+        {
+            gameObjectsArray[i]->SetSelectParent(true);
         }
     }
 }

--- a/SobrassadaEngine/Utils/RaycastController.cpp
+++ b/SobrassadaEngine/Utils/RaycastController.cpp
@@ -38,9 +38,8 @@ namespace RaycastController
         {
             LineSegment localRay(ray.a, ray.b);
 
-            //const MeshComponent* meshComponent = gameObject->GetMeshComponent();
             const MeshComponent* meshComponent = gameObject->GetComponent<MeshComponent*>();
-            if (meshComponent == nullptr) continue; // TODO REMOVE WHEN EMPTY GAMEOBJECT DON'T CONTAIN AN AABB
+            if (meshComponent == nullptr) continue;
 
             const ResourceMesh* resourceMesh = meshComponent->GetResourceMesh();
 
@@ -73,7 +72,7 @@ namespace RaycastController
             }
         }
 
-        if (selectedGameObject && !selectedGameObject->IsTopParent())
+        if (selectedGameObject && selectedGameObject->HasSelectParent())
         {
             SceneModule* sceneModule     = App->GetSceneModule();
 
@@ -83,14 +82,14 @@ namespace RaycastController
             if (parentGameobject)
             {
                 while (parentGameobject && parentGameobject->GetUID() != rootGameObject &&
-                       !parentGameobject->IsTopParent() &&
+                       parentGameobject->HasSelectParent() &&
                        parentGameobject->GetUID() != sceneModule->GetScene()->GetMultiselectUID())
                 {
                     selectedGameObject = parentGameobject;
                     parentGameobject   = sceneModule->GetScene()->GetGameObjectByUID(selectedGameObject->GetParent());
                 }
 
-                if (parentGameobject && parentGameobject->IsTopParent()) selectedGameObject = parentGameobject;
+                if (parentGameobject && !parentGameobject->HasSelectParent()) selectedGameObject = parentGameobject;
             }
         }
 

--- a/SobrassadaEngine/Utils/RaycastController.cpp
+++ b/SobrassadaEngine/Utils/RaycastController.cpp
@@ -93,6 +93,9 @@ namespace RaycastController
             }
         }
 
+        if (selectedGameObject && !App->GetSceneModule()->GetScene()->IsMultiselecting())
+            selectedGameObject->UpdateOpenNodeHierarchy(true);
+
         return selectedGameObject;
     }
 } // namespace RaycastController


### PR DESCRIPTION
Mouse picking inverted, so now only nodes with select parent checkbox skip to the next parent, when loading a model, all children are set with this checkbox.

Also, now clicking on a game object expands the tree view upwards.