### PR TITLE
THO-485 camera in prefab not working

### DIFF
--- a/SobrassadaEngine/Scene/Components/CameraComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/CameraComponent.cpp
@@ -219,6 +219,11 @@ void CameraComponent::Clone(const Component* other)
 
         firstTime                          = otherCamera->firstTime;
         seePreview                         = otherCamera->seePreview;
+
+        glGenBuffers(1, &ubo);
+        glBindBuffer(GL_UNIFORM_BUFFER, ubo);
+        glBufferData(GL_UNIFORM_BUFFER, sizeof(CameraMatrices), nullptr, GL_DYNAMIC_DRAW);
+        glBindBuffer(GL_UNIFORM_BUFFER, 0);
     }
     else
     {
@@ -346,7 +351,7 @@ void CameraComponent::RenderCameraPreview(float deltaTime)
         App->GetOpenGLModule()->GetGBuffer()->Resize(previewWidth, previewHeight);
         App->GetOpenGLModule()->GetGBuffer()->CheckResize();
 
-            glViewport(0, 0, previewWidth, previewHeight);
+        glViewport(0, 0, previewWidth, previewHeight);
 
         previewFramebuffer->Bind();
         autorendering = true;
@@ -357,7 +362,6 @@ void CameraComponent::RenderCameraPreview(float deltaTime)
         App->GetOpenGLModule()->GetGBuffer()->CheckResize();
 
         App->GetOpenGLModule()->GetFramebuffer()->Bind();
-
 
         glViewport(0, 0, mainFramebufferWidth, mainFramebufferHeight);
     }

--- a/SobrassadaEngine/Scene/Components/CameraComponent.h
+++ b/SobrassadaEngine/Scene/Components/CameraComponent.h
@@ -40,7 +40,7 @@ class CameraComponent : public Component
     unsigned int GetUbo() const { return ubo; }
     const float4x4 GetProjectionMatrix() { return camera.ProjectionMatrix(); }
     const float4x4 GetViewMatrix() { return camera.ViewMatrix(); }
-    const int GetType() { return (camera.type == OrthographicFrustum) ? 1 : 0; }
+    const int GetFrustumType() { return (camera.type == OrthographicFrustum) ? 1 : 0; }
     Framebuffer* GetFramebuffer() { return previewFramebuffer; }
 
     void SetAspectRatio(float newAspectRatio);

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -919,7 +919,7 @@ void Scene::LightingPassRender(
         {
             bool change = false;
             // Cubemap does not support Ortographic projection
-            if (camera->GetType() == 1)
+            if (camera->GetFrustumType() == 1)
             {
                 change = true;
                 camera->ChangeToPerspective();

--- a/SobrassadaEngine/Utils/LightsConfig.cpp
+++ b/SobrassadaEngine/Utils/LightsConfig.cpp
@@ -87,7 +87,7 @@ void LightsConfig::InitSkybox()
     glBindVertexArray(0);
 
     // default skybox texture
-    if(skyboxID != 0) LoadSkyboxTexture(App->GetLibraryModule()->GetTextureUID("cubemap"));
+    if(skyboxID == 0) LoadSkyboxTexture(App->GetLibraryModule()->GetTextureUID("cubemap"));
 
     cubemapIrradiance = CubeMapToTexture(irradianceMapResolution, irradianceMapResolution);
     irradianceHandle  = glGetTextureHandleARB(cubemapIrradiance);


### PR DESCRIPTION
You can delete cameraComponent now. Also camera in prefabs works now. Also solved a bug where skybox does not work in a new scene
For testing: You can try all of these things