### PR TITLE
Meta override while keeping UID

### DIFF
--- a/SobrassadaEngine/FileSystem/Importers/AnimationImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/AnimationImporter.cpp
@@ -210,9 +210,15 @@ namespace AnimationImporter
         UID finalAnimUID;
         if (sourceUID == INVALID_UID)
         {
-            const UID animationUID      = GenerateUID();
-            finalAnimUID                = App->GetLibraryModule()->AssignFiletypeUID(animationUID, FileType::Animation);
+            UID animationUID      = GenerateUID();
+            animationUID                = App->GetLibraryModule()->AssignFiletypeUID(animationUID, FileType::Animation);
 
+            UID prefix                 = animationUID / UID_PREFIX_DIVISOR;
+            const std::string savePath = App->GetProjectModule()->GetLoadedProjectPath() + METADATA_PATH +
+                                         std::to_string(prefix) + FILENAME_SEPARATOR + name + META_EXTENSION;
+            finalAnimUID = App->GetLibraryModule()->GetUIDFromMetaFile(savePath);
+            if (finalAnimUID == INVALID_UID) finalAnimUID = animationUID;
+            
             const std::string assetPath = ANIMATIONS_PATH + FileSystem::GetFileNameWithExtension(sourceFilePath);
             MetaAnimation meta(finalAnimUID, assetPath);
 

--- a/SobrassadaEngine/FileSystem/Importers/AnimationImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/AnimationImporter.cpp
@@ -215,7 +215,7 @@ namespace AnimationImporter
 
             UID prefix                 = animationUID / UID_PREFIX_DIVISOR;
             const std::string savePath = App->GetProjectModule()->GetLoadedProjectPath() + METADATA_PATH +
-                                         std::to_string(prefix) + FILENAME_SEPARATOR + name + META_EXTENSION;
+                                         std::to_string(prefix) + FILENAME_SEPARATOR + fileName + META_EXTENSION;
             finalAnimUID = App->GetLibraryModule()->GetUIDFromMetaFile(savePath);
             if (finalAnimUID == INVALID_UID) finalAnimUID = animationUID;
             

--- a/SobrassadaEngine/FileSystem/Importers/FontImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/FontImporter.cpp
@@ -4,6 +4,7 @@
 #include "FileSystem.h"
 #include "LibraryModule.h"
 #include "MetaFont.h"
+#include "ProjectModule.h"
 #include "ResourceFont.h"
 
 namespace FontImporter
@@ -22,15 +23,22 @@ namespace FontImporter
 
         UID fontUID           = GenerateUID();
         fontUID               = App->GetLibraryModule()->AssignFiletypeUID(fontUID, FileType::Font);
-
+        
+        UID prefix                 = fontUID / UID_PREFIX_DIVISOR;
+     
+        const std::string savePath = App->GetProjectModule()->GetLoadedProjectPath() + METADATA_PATH +
+                                     std::to_string(prefix) + FILENAME_SEPARATOR + name + META_EXTENSION;
+        UID finalFontUID = App->GetLibraryModule()->GetUIDFromMetaFile(savePath);
+        if (finalFontUID == INVALID_UID) finalFontUID = fontUID;
+        
         const std::string assetPath = ASSETS_PATH + FileSystem::GetFileNameWithExtension(filePath);
 
-        MetaFont meta(fontUID, assetPath);
+        MetaFont meta(finalFontUID, assetPath);
         meta.Save(name, assetPath);
 
-        CopyFont(filePath, targetFilePath, name, fontUID);
+        CopyFont(filePath, targetFilePath, name, finalFontUID);
 
-        return fontUID;
+        return finalFontUID;
     }
 
     void CopyFont(

--- a/SobrassadaEngine/FileSystem/Importers/MaterialImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/MaterialImporter.cpp
@@ -176,13 +176,19 @@ UID MaterialImporter::ImportMaterial(
     if (sourceUID == INVALID_UID)
     {
         UID materialUID           = GenerateUID();
-        finalMaterialUID          = App->GetLibraryModule()->AssignFiletypeUID(materialUID, FileType::Material);
+        materialUID          = App->GetLibraryModule()->AssignFiletypeUID(materialUID, FileType::Material);
 
+        UID prefix                 = materialUID / UID_PREFIX_DIVISOR;
+        const std::string savePath = App->GetProjectModule()->GetLoadedProjectPath() + METADATA_PATH +
+                                     std::to_string(prefix) + FILENAME_SEPARATOR + materialName + META_EXTENSION;
+        finalMaterialUID = App->GetLibraryModule()->GetUIDFromMetaFile(savePath);
+        if (finalMaterialUID == INVALID_UID) finalMaterialUID = materialUID;
+        
         // replace "" with shader used (example)
         UID tmpName               = GenerateUID();
         std::string tmpNameString = std::to_string(tmpName);
 
-        if (materialName.empty()) materialName = "MaterialType_" + std::to_string(finalMaterialUID);
+        if (materialName.empty()) materialName = "MaterialType_" + std::to_string(tmpName);
 
         std::string assetPath     = ASSETS_PATH + FileSystem::GetFileNameWithExtension(sourceFilePath);
         MetaMaterial meta(finalMaterialUID, assetPath, tmpNameString, useOcclusion, defaultTextureUID);

--- a/SobrassadaEngine/FileSystem/Importers/ModelImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/ModelImporter.cpp
@@ -88,8 +88,14 @@ namespace ModelImporter
         if (sourceUID == INVALID_UID)
         {
             UID modelUID  = GenerateUID();
-            finalModelUID = App->GetLibraryModule()->AssignFiletypeUID(modelUID, FileType::Model);
+            modelUID = App->GetLibraryModule()->AssignFiletypeUID(modelUID, FileType::Model);
 
+            UID prefix                 = modelUID / UID_PREFIX_DIVISOR;
+            const std::string savePath = App->GetProjectModule()->GetLoadedProjectPath() + METADATA_PATH +
+                                         std::to_string(prefix) + FILENAME_SEPARATOR + modelName + META_EXTENSION;
+            finalModelUID = App->GetLibraryModule()->GetUIDFromMetaFile(savePath);
+            if (finalModelUID == INVALID_UID) finalModelUID = modelUID;
+            
             MetaModel meta(finalModelUID, assetPath);
             meta.Save(modelName, assetPath);
         }

--- a/SobrassadaEngine/FileSystem/Importers/NavmeshImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/NavmeshImporter.cpp
@@ -52,12 +52,18 @@ UID NavmeshImporter::SaveNavmesh(const char* name, const ResourceNavMesh* resour
     UID navmeshUID = GenerateUID();
     navmeshUID     = App->GetLibraryModule()->AssignFiletypeUID(navmeshUID, FileType::Navmesh);
 
+    UID prefix                 = navmeshUID / UID_PREFIX_DIVISOR;
+    const std::string savePath = App->GetProjectModule()->GetLoadedProjectPath() + METADATA_PATH +
+                                 std::to_string(prefix) + FILENAME_SEPARATOR + name + META_EXTENSION;
+    UID finalNavmeshUID = App->GetLibraryModule()->GetUIDFromMetaFile(savePath);
+    if (finalNavmeshUID == INVALID_UID) finalNavmeshUID = navmeshUID;
+    
     const std::string metaNavPath = ASSETS_PATH + std::string(name) + META_EXTENSION;
     const std::string navPath =
         App->GetProjectModule()->GetLoadedProjectPath() + NAVMESHES_PATH + std::string(name) + NAVMESH_EXTENSION;
 
     // Save metadata
-    MetaNavmesh meta(navmeshUID, metaNavPath, config);
+    MetaNavmesh meta(finalNavmeshUID, metaNavPath, config);
     meta.Save(name, metaNavPath);
 
     // Write binary navmesh
@@ -66,13 +72,13 @@ UID NavmeshImporter::SaveNavmesh(const char* name, const ResourceNavMesh* resour
 
     delete[] fileBuffer;
 
-    App->GetLibraryModule()->AddNavmesh(navmeshUID, name);
-    App->GetLibraryModule()->AddResource(navPath, navmeshUID);
-    App->GetLibraryModule()->AddName(name, navmeshUID);
+    App->GetLibraryModule()->AddNavmesh(finalNavmeshUID, name);
+    App->GetLibraryModule()->AddResource(navPath, finalNavmeshUID);
+    App->GetLibraryModule()->AddName(name, finalNavmeshUID);
 
     GLOG("%s saved navmesh binary.", name);
 
-    return navmeshUID;
+    return finalNavmeshUID;
 }
 
 

--- a/SobrassadaEngine/FileSystem/Importers/SceneImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/SceneImporter.cpp
@@ -24,12 +24,19 @@ namespace SceneImporter
 {
     void Import(const char* filePath)
     {
+        // Don´t accept imports from the assets folder directly
+        std::string importFolderPath = FileSystem::GetFilePath(filePath);
+        importFolderPath.pop_back();
+        std::string projectFolderPath = App->GetProjectModule()->GetLoadedProjectPath() + ASSETS_PATH;
+        projectFolderPath.pop_back();
+        if (importFolderPath == projectFolderPath)
+            return;
         // TODO Is it necessary to create directories here? They should be already created
         const std::string engineDefaultPath = ENGINE_DEFAULT_ASSETS;
         CreateLibraryDirectories(App->GetProjectModule()->GetLoadedProjectPath());
         CreateLibraryDirectories(engineDefaultPath);
 
-        std::string extension = FileSystem::GetFileExtension(filePath);
+        const std::string& extension = FileSystem::GetFileExtension(filePath);
 
         if (extension == ASSET_EXTENSION) ImportGLTF(filePath, App->GetProjectModule()->GetLoadedProjectPath());
         else if (extension == FONT_EXTENSION)

--- a/SobrassadaEngine/FileSystem/Importers/TextureImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/TextureImporter.cpp
@@ -70,8 +70,14 @@ namespace TextureImporter
         if (sourceUID == INVALID_UID)
         {
             UID textureUID  = GenerateUID();
-            finalTextureUID = App->GetLibraryModule()->AssignFiletypeUID(textureUID, FileType::Texture);
+            textureUID = App->GetLibraryModule()->AssignFiletypeUID(textureUID, FileType::Texture);
 
+            UID prefix                 = textureUID / UID_PREFIX_DIVISOR;
+            const std::string savePath = App->GetProjectModule()->GetLoadedProjectPath() + METADATA_PATH +
+                                         std::to_string(prefix) + FILENAME_SEPARATOR + fileName + META_EXTENSION;
+            finalTextureUID = App->GetLibraryModule()->GetUIDFromMetaFile(savePath);
+            if (finalTextureUID == INVALID_UID) finalTextureUID = textureUID;
+            
             MetaTexture meta(finalTextureUID, relativePath, (int)image.GetMetadata().mipLevels);
             meta.Save(fileName, relativePath);
         }


### PR DESCRIPTION
All metafiles now keep their UID if they existed before and are overwritten by a new import.
This ensures that previous established links, for example between a mesh and its material, are not broken after a reimport.
Test with importing various files and see if the meta files keep their UID