### PR TITLE
Task/Respawn-THO-487

### DIFF
--- a/SobrassadaEngine/Scene/Components/ScriptComponent.h
+++ b/SobrassadaEngine/Scene/Components/ScriptComponent.h
@@ -20,6 +20,7 @@ enum ScriptType
     SCRIPT_CAMERA_MOVEMENT,
     SCRIPT_PROJECTILE,
     SCRIPT_FREE_CAMERA,
+    SCRIPT_SPAWN_POINT,
 
     SCRIPT_TYPE_COUNT // Add at the end
 };
@@ -46,8 +47,9 @@ constexpr const char* scripts[] = {
     "MainMenuSelectorScript",    // SCRIPT_MAIN_MENU_SELECTOR
     "PressAnyKeyScript",         // SCRIPT_PRESS_ANY_KEY
     "CameraMovement",            // SCRIPT_CAMERA_MOVEMENT
-    "Projectile",                 // SCRIPT_PROJECTILE
-    "FreeCamera"                 // SCRIPT_FREE_CAMERA
+    "Projectile",                // SCRIPT_PROJECTILE
+    "FreeCamera",                // SCRIPT_FREE_CAMERA
+    "SpawnPoint"                 // SCRIPT_SPAWN_POINT
 };
 
 static_assert(

--- a/SobrassadaEngine/Scene/Components/Standalone/CharacterControllerComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/CharacterControllerComponent.cpp
@@ -269,7 +269,7 @@ void CharacterControllerComponent::Move(float deltaTime)
 
     if (!navMeshQuery || currentPolyRef == 0) return;
 
-    const float3& currentPos = parent->GetPosition();
+    const float3& currentPos = parent->GetGlobalTransform().TranslatePart();
     currentSpeed          = targetDirection.LengthSq() > 0.001f ? Lerp(currentSpeed, maxSpeed, acceleration * deltaTime)
                                                                 : Lerp(currentSpeed, 0, 100 * deltaTime);
 
@@ -300,7 +300,7 @@ void CharacterControllerComponent::Move(float deltaTime)
     desiredPos.x   = nearest[0];
     desiredPos.z   = nearest[2];
 
-    parent->SetLocalPosition(desiredPos);
+    parent->SetLocalPosition(desiredPos - parent->GetParentGlobalTransform().TranslatePart());
 }
 
 void CharacterControllerComponent::LookAtMovement(const float3& moveDir, float deltaTime)

--- a/SobrassadaEngine/Scene/Components/Standalone/CharacterControllerComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/CharacterControllerComponent.cpp
@@ -148,13 +148,13 @@ void CharacterControllerComponent::Update(float deltaTime) // SO many navmesh ge
     verticalSpeed     += gravity * deltaTime;
     verticalSpeed      = std::max(verticalSpeed, maxFallSpeed); // Clamp fall speed
 
-    float3 currentPos  = parent->GetPosition();
+    float3 currentPos  = parent->GetGlobalTransform().TranslatePart();
     currentPos.y      += (verticalSpeed * deltaTime);
 
     AdjustHeightToNavMesh(currentPos);
 
     lastPosition = currentPos;
-    parent->SetLocalPosition(currentPos);
+    parent->SetLocalPosition(currentPos - parent->GetParentGlobalTransform().TranslatePart());
 
     if (isRotating)
     {

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CameraMovement.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CameraMovement.cpp
@@ -80,3 +80,8 @@ void CameraMovement::FollowTarget(float deltaTime)
 
     parent->SetLocalPosition(finalPosition);
 }
+
+void CameraMovement::SetPosition(const float3& newPos)
+{
+    parent->SetLocalPosition(newPos);
+}

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CameraMovement.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CameraMovement.cpp
@@ -48,14 +48,14 @@ void CameraMovement::FollowTarget(float deltaTime)
 {
     if (!target) return;
 
-    float3 desiredPosition        = target->GetPosition();
-    const float3& currentPosition = parent->GetPosition();
+    float3 desiredPosition        = target->GetGlobalTransform().TranslatePart();
+    const float3& currentPosition = parent->GetGlobalTransform().TranslatePart();
 
     if (mouseOffsetEnabled)
     {
         currentLookAhead = 0;
-        const float3 mouseWorldPos =
-            AppEngine->GetSceneModule()->GetScene()->GetMainCamera()->ScreenPointToXZ(parent->GetPosition().y);
+        float3 mouseWorldPos =
+            AppEngine->GetSceneModule()->GetScene()->GetMainCamera()->ScreenPointToXZ(currentPosition.y);
         const float3 mouseOffset  = (desiredPosition + (mouseWorldPos)) * 0.5f - desiredPosition;
         desiredPosition          += mouseOffset * mouseOffsetIntensity;
     }
@@ -78,7 +78,7 @@ void CameraMovement::FollowTarget(float deltaTime)
     }
     finalPosition = Lerp(currentPosition, desiredPosition, smoothnessVelocity * deltaTime);
 
-    parent->SetLocalPosition(finalPosition);
+    parent->SetLocalPosition(finalPosition - parent->GetParentGlobalTransform().TranslatePart());
 }
 
 void CameraMovement::SetPosition(const float3& newPos)

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CameraMovement.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CameraMovement.cpp
@@ -54,7 +54,7 @@ void CameraMovement::FollowTarget(float deltaTime)
     if (mouseOffsetEnabled)
     {
         currentLookAhead = 0;
-        float3 mouseWorldPos =
+        const float3 mouseWorldPos =
             AppEngine->GetSceneModule()->GetScene()->GetMainCamera()->ScreenPointToXZ(currentPosition.y);
         const float3 mouseOffset  = (desiredPosition + (mouseWorldPos)) * 0.5f - desiredPosition;
         desiredPosition          += mouseOffset * mouseOffsetIntensity;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CameraMovement.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CameraMovement.h
@@ -15,6 +15,7 @@ class CameraMovement : public Script
     void Update(float deltaTime) override;
 
     void EnableMouseOffset(bool enable) { mouseOffsetEnabled = enable; }
+    void SetPosition(const float3& newPos);
 
   private:
     void FollowTarget(float deltaTime);

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -196,7 +196,7 @@ void CuChulainn::LookAtMouse()
     const float3 mouseWorldPos = AppEngine->GetSceneModule()->GetScene()->GetMainCamera()->ScreenPointToXZ(
         parent->GetGlobalTransform().TranslatePart().y
     );
-    float3 direction = mouseWorldPos - parent->GetPosition();
+    float3 direction = mouseWorldPos - parent->GetGlobalTransform().TranslatePart();
     direction.y      = 0;
     direction.Normalize();
     character->LookAt(direction);

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -132,6 +132,14 @@ void CuChulainn::GetInputs()
     {
         if (state == CharacterStates::AIM) ThrowSpear();
     }
+    if (keyboard[SDL_SCANCODE_F5])
+    {
+        Respawn();
+    }
+    if (keyboard[SDL_SCANCODE_F6])
+    {
+        spawnPos = parent->GetPosition();
+    }
 }
 
 bool CuChulainn::CanDash()
@@ -274,4 +282,10 @@ void CuChulainn::Move()
         if (state != CharacterStates::IDLE && animComponent) animComponent->UseTrigger("idle");
         state = CharacterStates::IDLE;
     }
+}
+
+void CuChulainn::Respawn()
+{
+    parent->SetLocalPosition(spawnPos);
+    if (camera) camera->SetPosition(spawnPos);
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
@@ -26,6 +26,8 @@ class CuChulainn : public Character
     bool Init() override;
     void Update(float deltaTime) override;
 
+    void SetSpawnPosition(const float3& newPos) { spawnPos = newPos; }
+
   private:
     void OnDeath() override;
     void OnDamageTaken(int amount) override;
@@ -45,6 +47,7 @@ class CuChulainn : public Character
     void Dash();
     void Aim();
     void Move();
+    void Respawn();
 
   private:
     std::string cameraName  = "";
@@ -74,6 +77,7 @@ class CuChulainn : public Character
     bool resetWeapon        = false;
 
     CharacterStates state   = CharacterStates::IDLE;
+    float3 spawnPos         = float3::zero;
 };
 
 extern CharacterControllerComponent* character;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/ScriptExport.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/ScriptExport.cpp
@@ -15,6 +15,7 @@
 #include "Projectile.h"
 #include "RotateGameObject.h"
 #include "Soldier.h"
+#include "SpawnPoint.h"
 #include "VSyncToggleScript.h"
 
 #include <string>
@@ -50,6 +51,7 @@ extern "C" SOBRASSADA_API Script* CreateScript(const std::string& scriptType, Ga
     if (scriptType == "SoldierScript") return new Soldier(parent);
     if (scriptType == "CameraMovement") return new CameraMovement(parent);
     if (scriptType == "Projectile") return new Projectile(parent);
+    if (scriptType == "SpawnPoint") return new SpawnPoint(parent);
 
     /* Utils */
     if (scriptType == "RotateGameObject") return new RotateGameObject(parent);

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj
@@ -406,6 +406,7 @@
     <ClInclude Include="resource.h" />
     <ClInclude Include="RotateGameObject.h" />
     <ClInclude Include="Script.h" />
+    <ClInclude Include="SpawnPoint.h" />
     <ClInclude Include="VSyncToggleScript.h" />
     <ClInclude Include="Soldier.h" />
   </ItemGroup>
@@ -1776,6 +1777,7 @@
     <ClCompile Include="RotateGameObject.cpp" />
     <ClCompile Include="Script.cpp" />
     <ClCompile Include="ScriptExport.cpp" />
+    <ClCompile Include="SpawnPoint.cpp" />
     <ClCompile Include="VSyncToggleScript.cpp" />
     <ClCompile Include="Soldier.cpp" />
   </ItemGroup>

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj.filters
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj.filters
@@ -79,6 +79,9 @@
     <ClInclude Include="FreeCamera.h">
       <Filter>Utils</Filter>
     </ClInclude>
+    <ClInclude Include="SpawnPoint.h">
+      <Filter>Characters</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\Libs\MathGeoLib\include\Time\Clock.cpp">
@@ -713,6 +716,9 @@
     </ClCompile>
     <ClCompile Include="FreeCamera.cpp">
       <Filter>Utils</Filter>
+    </ClCompile>
+    <ClCompile Include="SpawnPoint.cpp">
+      <Filter>Characters</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SpawnPoint.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SpawnPoint.cpp
@@ -7,6 +7,7 @@
 #include "Scene.h"
 #include "SceneModule.h"
 #include "ScriptComponent.h"
+#include "Standalone/Physics/CubeColliderComponent.h"
 
 SpawnPoint::SpawnPoint(GameObject* parent) : Script(parent)
 {
@@ -37,7 +38,12 @@ void SpawnPoint::OnCollision(GameObject* otherObject, const float3& collisionNor
         if (playerScript)
         {
             playerScript->SetSpawnPosition(parent->GetPosition());
-            if (isOneUse) parent->SetEnabled(false);
+            if (isOneUse)
+            {
+                if (CubeColliderComponent* collider = parent->GetComponent<CubeColliderComponent*>())
+                    collider->SetEnabled(false);
+                parent->SetEnabled(false);
+            }
         }
     }
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SpawnPoint.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SpawnPoint.cpp
@@ -1,0 +1,43 @@
+#include "pch.h"
+
+#include "SpawnPoint.h"
+
+#include "CuChulainn.h"
+#include "GameObject.h"
+#include "Scene.h"
+#include "SceneModule.h"
+#include "ScriptComponent.h"
+
+SpawnPoint::SpawnPoint(GameObject* parent) : Script(parent)
+{
+    fields.push_back({"Player name", InspectorField::FieldType::InputText, &playerName});
+    fields.push_back({"Set only once", InspectorField::FieldType::Bool, &isOneUse});
+}
+
+bool SpawnPoint::Init()
+{
+    player = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(playerName);
+    if (!player)
+    {
+        GLOG("[WARNING] SpawnPoint: No player found by the name '%s'", playerName.c_str());
+        return false;
+    }
+
+    return true;
+}
+
+void SpawnPoint::OnCollision(GameObject* otherObject, const float3& collisionNormal)
+{
+    if (otherObject != player) return;
+
+    ScriptComponent* scriptComp = player->GetComponent<ScriptComponent*>();
+    if (scriptComp)
+    {
+        CuChulainn* playerScript = scriptComp->GetScriptByType<CuChulainn>();
+        if (playerScript)
+        {
+            playerScript->SetSpawnPosition(parent->GetPosition());
+            if (isOneUse) parent->SetEnabled(false);
+        }
+    }
+}

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SpawnPoint.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SpawnPoint.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "Script.h"
+
+class GameObject;
+class CharacterControllerComponent;
+
+class SpawnPoint : public Script
+{
+  public:
+    SpawnPoint(GameObject* parent);
+    virtual ~SpawnPoint() noexcept override { parent = nullptr; }
+
+    bool Init() override;
+    void Update(float deltaTime) override {}
+    void OnCollision(GameObject* otherObject, const float3& collisionNormal) override;
+
+  private:
+    std::string playerName   = "";
+    const GameObject* player = nullptr;
+
+    bool isOneUse;
+};

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SpawnPoint.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SpawnPoint.h
@@ -19,5 +19,5 @@ class SpawnPoint : public Script
     std::string playerName   = "";
     const GameObject* player = nullptr;
 
-    bool isOneUse;
+    bool isOneUse            = false;
 };


### PR DESCRIPTION
Added spawn points and respawn on key press for easier game navigation and debugging. Also fixed a bug that the characterController was going through the floor when not in y = 0 and being child of another object.

Pressing F6 saves the current player position as the spawn point, and pressing F5 spawns the player in the saved position. The default is 0,0,0. 

There is a new script SpawnPoint, which is basically a trigger that sets its position as the player spawn position when it enters the trigger. This can be used as the spawn points in the levels. 
In the EngineTests dev-testing branch there is a new scene with a Spawn prefab that has already the script and collider to work properly. This scene has also terrain in differen heights, to check the camera behaves as expected anywhere.

Known issue: Right now the player projectile collides with triggers, which disables it although it is not really colliding with anything. Probably a new physics layer should be added for projectiles so it doesn't collide with triggers.