### PR TITLE
THO-484 Meta animation wrong file path

### DIFF
--- a/SobrassadaEngine/FileSystem/Importers/AnimationImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/AnimationImporter.cpp
@@ -219,7 +219,7 @@ namespace AnimationImporter
             finalAnimUID = App->GetLibraryModule()->GetUIDFromMetaFile(savePath);
             if (finalAnimUID == INVALID_UID) finalAnimUID = animationUID;
             
-            const std::string assetPath = ANIMATIONS_PATH + FileSystem::GetFileNameWithExtension(sourceFilePath);
+            const std::string assetPath = ANIMATIONS_ASSETS_PATH + FileSystem::GetFileNameWithExtension(sourceFilePath);
             MetaAnimation meta(finalAnimUID, assetPath);
 
             meta.Save(fileName, assetPath);

--- a/SobrassadaEngine/FileSystem/Importers/AnimationImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/AnimationImporter.cpp
@@ -219,7 +219,7 @@ namespace AnimationImporter
             finalAnimUID = App->GetLibraryModule()->GetUIDFromMetaFile(savePath);
             if (finalAnimUID == INVALID_UID) finalAnimUID = animationUID;
             
-            const std::string assetPath = ANIMATIONS_ASSETS_PATH + FileSystem::GetFileNameWithExtension(sourceFilePath);
+            const std::string assetPath = ASSETS_PATH + FileSystem::GetFileNameWithExtension(sourceFilePath);
             MetaAnimation meta(finalAnimUID, assetPath, animationIndex);
 
             meta.Save(fileName, assetPath);

--- a/SobrassadaEngine/FileSystem/Importers/AnimationImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/AnimationImporter.cpp
@@ -286,9 +286,10 @@ namespace AnimationImporter
 
         GLOG("Loading animation with %d channels from %s", channelCount, path.c_str());
 
-       
-        ResourceAnimation* animation =
-            new ResourceAnimation(animationUID, FileSystem::GetFileNameWithoutExtension(path));
+        const auto& map = App->GetLibraryModule()->GetAnimMap();
+        std::string animName = App->GetLibraryModule()->GetResourceName(animationUID);
+
+        ResourceAnimation* animation = new ResourceAnimation(animationUID, animName);
 
         // Parse channels
         for (uint32_t i = 0; i < channelCount; ++i)

--- a/SobrassadaEngine/FileSystem/Importers/AnimationImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/AnimationImporter.cpp
@@ -222,7 +222,7 @@ namespace AnimationImporter
             const std::string assetPath = ANIMATIONS_ASSETS_PATH + FileSystem::GetFileNameWithExtension(sourceFilePath);
             MetaAnimation meta(finalAnimUID, assetPath);
 
-            meta.Save(fileName, assetPath);
+            meta.Save(animation.name, assetPath);
         }
         else
         {

--- a/SobrassadaEngine/FileSystem/Importers/AnimationImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/AnimationImporter.cpp
@@ -46,7 +46,7 @@ namespace AnimationImporter
             if (input.byteOffset + inputView.byteOffset >= inputBuffer.data.size() ||
                 output.byteOffset + outputView.byteOffset >= outputBuffer.data.size())
             {
-                //GLOG("Error: Invalid buffer access for animation channel");
+                // GLOG("Error: Invalid buffer access for animation channel");
                 continue; // Skip this channel
             }
 
@@ -105,7 +105,7 @@ namespace AnimationImporter
                 reinterpret_cast<const char*>(&keyframeCount) + sizeof(uint32_t)
             );
 
-            // Insert timestamps 
+            // Insert timestamps
             if (keyframeCount > 0)
             {
                 GLOG("  Timestamps range: %.3f to %.3f", timeStamps[0], timeStamps[keyframeCount - 1]);
@@ -124,7 +124,7 @@ namespace AnimationImporter
             {
                 outputStride = (outputView.byteStride > 0) ? outputView.byteStride : sizeof(float3);
 
-                // Copy with proper stride 
+                // Copy with proper stride
                 std::vector<float3> positionValues(keyframeCount);
                 for (size_t i = 0; i < keyframeCount; i++)
                 {
@@ -133,14 +133,14 @@ namespace AnimationImporter
                 }
 
                 // Debug output
-               /* GLOG("  Position data for node %s:", nodeName.c_str());
-                for (size_t i = 0; i < std::min(keyframeCount, size_t(3)); i++)
-                {
-                    GLOG(
-                        "    Frame %zu: (%.3f, %.3f, %.3f) at time %.3f", i, positionValues[i].x, positionValues[i].y,
-                        positionValues[i].z, timeStamps[i]
-                    );
-                }*/
+                /* GLOG("  Position data for node %s:", nodeName.c_str());
+                 for (size_t i = 0; i < std::min(keyframeCount, size_t(3)); i++)
+                 {
+                     GLOG(
+                         "    Frame %zu: (%.3f, %.3f, %.3f) at time %.3f", i, positionValues[i].x, positionValues[i].y,
+                         positionValues[i].z, timeStamps[i]
+                     );
+                 }*/
 
                 buffer.insert(
                     buffer.end(), reinterpret_cast<const char*>(positionValues.data()),
@@ -151,18 +151,16 @@ namespace AnimationImporter
             {
                 outputStride = (outputView.byteStride > 0) ? outputView.byteStride : sizeof(Quat);
 
-                
                 std::vector<Quat> rotationValues(keyframeCount);
                 for (size_t i = 0; i < keyframeCount; i++)
                 {
                     const Quat* srcRot = reinterpret_cast<const Quat*>(outputData + i * outputStride);
                     rotationValues[i]  = *srcRot;
-                    
+
                     rotationValues[i].Normalize();
                 }
 
-            
-                //GLOG("  Rotation data for node %s:", nodeName.c_str());
+                // GLOG("  Rotation data for node %s:", nodeName.c_str());
                 /*for (size_t i = 0; i < std::min(keyframeCount, size_t(3)); i++)
                 {
                     GLOG(
@@ -180,7 +178,6 @@ namespace AnimationImporter
             {
                 outputStride = (outputView.byteStride > 0) ? outputView.byteStride : sizeof(float3);
 
-               
                 std::vector<float3> scaleValues(keyframeCount);
                 for (size_t i = 0; i < keyframeCount; i++)
                 {
@@ -188,7 +185,6 @@ namespace AnimationImporter
                     scaleValues[i]         = *srcScale;
                 }
 
-        
                 /*GLOG("  Scale data for node %s:", nodeName.c_str());
                 for (size_t i = 0; i < std::min(keyframeCount, size_t(3)); i++)
                 {
@@ -210,15 +206,15 @@ namespace AnimationImporter
         UID finalAnimUID;
         if (sourceUID == INVALID_UID)
         {
-            UID animationUID      = GenerateUID();
-            animationUID                = App->GetLibraryModule()->AssignFiletypeUID(animationUID, FileType::Animation);
+            UID animationUID           = GenerateUID();
+            animationUID               = App->GetLibraryModule()->AssignFiletypeUID(animationUID, FileType::Animation);
 
             UID prefix                 = animationUID / UID_PREFIX_DIVISOR;
             const std::string savePath = App->GetProjectModule()->GetLoadedProjectPath() + METADATA_PATH +
                                          std::to_string(prefix) + FILENAME_SEPARATOR + fileName + META_EXTENSION;
             finalAnimUID = App->GetLibraryModule()->GetUIDFromMetaFile(savePath);
             if (finalAnimUID == INVALID_UID) finalAnimUID = animationUID;
-            
+
             const std::string assetPath = ASSETS_PATH + FileSystem::GetFileNameWithExtension(sourceFilePath);
             MetaAnimation meta(finalAnimUID, assetPath, animationIndex);
 
@@ -287,7 +283,7 @@ namespace AnimationImporter
         GLOG("Loading animation with %d channels from %s", channelCount, path.c_str());
 
         const auto& map = App->GetLibraryModule()->GetAnimMap();
-        std::string animName = App->GetLibraryModule()->GetResourceName(animationUID);
+        const std::string& animName    = App->GetLibraryModule()->GetResourceName(animationUID);
 
         ResourceAnimation* animation = new ResourceAnimation(animationUID, animName);
 
@@ -315,7 +311,6 @@ namespace AnimationImporter
             std::string nodeName(cursor, nameSize);
             cursor += nameSize;
 
-            
             if (cursor + sizeof(AnimationType) > bufferEnd)
             {
                 GLOG("Error: Unexpected end of file when reading channel %d animType", i);
@@ -334,15 +329,14 @@ namespace AnimationImporter
 
             uint32_t keyframeCount;
             memcpy(&keyframeCount, cursor, sizeof(uint32_t));
-            cursor += sizeof(uint32_t);
+            cursor               += sizeof(uint32_t);
 
-            //GLOG(
-            //    "Channel %d: Node='%s', Type=%d, Keyframes=%d", i, nodeName.c_str(), static_cast<int>(animType),
-            //    keyframeCount
+            // GLOG(
+            //     "Channel %d: Node='%s', Type=%d, Keyframes=%d", i, nodeName.c_str(), static_cast<int>(animType),
+            //     keyframeCount
             //);
 
-            
-            Channel& animChannel = animation->channels[nodeName];
+            Channel& animChannel  = animation->channels[nodeName];
 
             // Parse based on animation type
             if (animType == AnimationType::TRANSLATION)
@@ -361,21 +355,21 @@ namespace AnimationImporter
                     memcpy(animChannel.positions.data(), cursor, posDataSize);
 
                     // Debug log the loaded positions
-                   /* GLOG("  Loaded %d position keyframes for '%s'", keyframeCount, nodeName.c_str());
-                    for (int j = 0; j < std::min(3, (int)keyframeCount); j++)
-                    {
-                        GLOG(
-                            "    Frame %d: (%.3f, %.3f, %.3f) at time %.3f", j, animChannel.positions[j].x,
-                            animChannel.positions[j].y, animChannel.positions[j].z, animChannel.posTimeStamps[j]
-                        );
-                    }*/
+                    /* GLOG("  Loaded %d position keyframes for '%s'", keyframeCount, nodeName.c_str());
+                     for (int j = 0; j < std::min(3, (int)keyframeCount); j++)
+                     {
+                         GLOG(
+                             "    Frame %d: (%.3f, %.3f, %.3f) at time %.3f", j, animChannel.positions[j].x,
+                             animChannel.positions[j].y, animChannel.positions[j].z, animChannel.posTimeStamps[j]
+                         );
+                     }*/
 
                     cursor                   += posDataSize;
                     animChannel.numPositions  = keyframeCount;
                 }
                 else
                 {
-                    //GLOG("Error: Buffer overrun when reading position data for channel %d", i);
+                    // GLOG("Error: Buffer overrun when reading position data for channel %d", i);
                     break; // Stop parsing to avoid further issues
                 }
             }
@@ -384,7 +378,6 @@ namespace AnimationImporter
                 uint32_t rotTimestampSize = keyframeCount * sizeof(float);
                 uint32_t rotDataSize      = keyframeCount * sizeof(Quat);
 
-               
                 if (cursor + rotTimestampSize + rotDataSize <= bufferEnd)
                 {
                     animChannel.rotTimeStamps.resize(keyframeCount);
@@ -394,23 +387,22 @@ namespace AnimationImporter
                     animChannel.rotations.resize(keyframeCount);
                     memcpy(animChannel.rotations.data(), cursor, rotDataSize);
 
-                   
-                   /* GLOG("  Loaded %d rotation keyframes for '%s'", keyframeCount, nodeName.c_str());
-                    for (int j = 0; j < std::min(3, (int)keyframeCount); j++)
-                    {
-                        GLOG(
-                            "    Frame %d: (%.3f, %.3f, %.3f, %.3f) at time %.3f", j, animChannel.rotations[j].x,
-                            animChannel.rotations[j].y, animChannel.rotations[j].z, animChannel.rotations[j].w,
-                            animChannel.rotTimeStamps[j]
-                        );
-                    }*/
+                    /* GLOG("  Loaded %d rotation keyframes for '%s'", keyframeCount, nodeName.c_str());
+                     for (int j = 0; j < std::min(3, (int)keyframeCount); j++)
+                     {
+                         GLOG(
+                             "    Frame %d: (%.3f, %.3f, %.3f, %.3f) at time %.3f", j, animChannel.rotations[j].x,
+                             animChannel.rotations[j].y, animChannel.rotations[j].z, animChannel.rotations[j].w,
+                             animChannel.rotTimeStamps[j]
+                         );
+                     }*/
 
                     cursor                   += rotDataSize;
                     animChannel.numRotations  = keyframeCount;
                 }
                 else
                 {
-                    //GLOG("Error: Buffer overrun when reading rotation data for channel %d", i);
+                    // GLOG("Error: Buffer overrun when reading rotation data for channel %d", i);
                     break; // Stop parsing to avoid further issues
                 }
             }
@@ -419,7 +411,6 @@ namespace AnimationImporter
                 uint32_t scaleTimestampSize = keyframeCount * sizeof(float);
                 uint32_t scaleDataSize      = keyframeCount * sizeof(float3);
 
-                
                 if (cursor + scaleTimestampSize + scaleDataSize <= bufferEnd)
                 {
                     animChannel.scaleTimeStamps.resize(keyframeCount);
@@ -429,8 +420,7 @@ namespace AnimationImporter
                     animChannel.scales.resize(keyframeCount);
                     memcpy(animChannel.scales.data(), cursor, scaleDataSize);
 
-                    
-                    //GLOG("  Loaded %d scale keyframes for '%s'", keyframeCount, nodeName.c_str());
+                    // GLOG("  Loaded %d scale keyframes for '%s'", keyframeCount, nodeName.c_str());
                     for (int j = 0; j < std::min(3, (int)keyframeCount); j++)
                     {
                         /*GLOG(
@@ -444,7 +434,7 @@ namespace AnimationImporter
                 }
                 else
                 {
-                    //GLOG("Error: Buffer overrun when reading scale data for channel %d", i);
+                    // GLOG("Error: Buffer overrun when reading scale data for channel %d", i);
                     break; // Stop parsing to avoid further issues
                 }
             }

--- a/SobrassadaEngine/FileSystem/Importers/AnimationImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/AnimationImporter.cpp
@@ -16,7 +16,7 @@ namespace AnimationImporter
 {
     UID ImportAnimation(
         const tinygltf::Model& model, const tinygltf::Animation& animation, const std::string& name,
-        const char* sourceFilePath, const std::string& targetFilePath, UID sourceUID
+        const char* sourceFilePath, const std::string& targetFilePath, UID sourceUID, int animationIndex
     )
     {
         std::vector<char> buffer;
@@ -220,9 +220,9 @@ namespace AnimationImporter
             if (finalAnimUID == INVALID_UID) finalAnimUID = animationUID;
             
             const std::string assetPath = ANIMATIONS_ASSETS_PATH + FileSystem::GetFileNameWithExtension(sourceFilePath);
-            MetaAnimation meta(finalAnimUID, assetPath);
+            MetaAnimation meta(finalAnimUID, assetPath, animationIndex);
 
-            meta.Save(animation.name, assetPath);
+            meta.Save(fileName, assetPath);
         }
         else
         {

--- a/SobrassadaEngine/FileSystem/Importers/AnimationImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/AnimationImporter.cpp
@@ -213,7 +213,7 @@ namespace AnimationImporter
             const UID animationUID      = GenerateUID();
             finalAnimUID                = App->GetLibraryModule()->AssignFiletypeUID(animationUID, FileType::Animation);
 
-            const std::string assetPath = ANIMATIONS_PATH + FileSystem::GetFileNameWithExtension(sourceFilePath);
+            const std::string assetPath = ANIMATIONS_ASSETS_PATH + FileSystem::GetFileNameWithExtension(sourceFilePath);
             MetaAnimation meta(finalAnimUID, assetPath);
 
             meta.Save(fileName, assetPath);

--- a/SobrassadaEngine/FileSystem/Importers/AnimationImporter.h
+++ b/SobrassadaEngine/FileSystem/Importers/AnimationImporter.h
@@ -24,7 +24,7 @@ namespace AnimationImporter
 {
     UID ImportAnimation(
         const tinygltf::Model& model, const tinygltf::Animation& animation, const std::string& name,
-        const char* sourceFilePath, const std::string& targetFilePath, UID sourceUID
+        const char* sourceFilePath, const std::string& targetFilePath, UID sourceUID, int animationIndex
     );
     ResourceAnimation* LoadAnimation(UID animationUID);
    

--- a/SobrassadaEngine/FileSystem/Importers/ModelImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/ModelImporter.cpp
@@ -117,7 +117,7 @@ namespace ModelImporter
                 GLOG("Animation channels: %zu", anim.channels.size());
 
                 UID animUID =
-                    AnimationImporter::ImportAnimation(model, anim, anim.name, filePath, targetFilePath, sourceUID);
+                    AnimationImporter::ImportAnimation(model, anim, anim.name, filePath, targetFilePath, sourceUID, i);
 
                 GLOG("Imported animation UID: %llu", animUID);
 

--- a/SobrassadaEngine/FileSystem/Importers/SceneImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/SceneImporter.cpp
@@ -29,8 +29,7 @@ namespace SceneImporter
         importFolderPath.pop_back();
         std::string projectFolderPath = App->GetProjectModule()->GetLoadedProjectPath() + ASSETS_PATH;
         projectFolderPath.pop_back();
-        if (importFolderPath == projectFolderPath)
-            return;
+        if (importFolderPath == projectFolderPath) return;
         // TODO Is it necessary to create directories here? They should be already created
         const std::string engineDefaultPath = ENGINE_DEFAULT_ASSETS;
         CreateLibraryDirectories(App->GetProjectModule()->GetLoadedProjectPath());
@@ -197,21 +196,22 @@ namespace SceneImporter
     }
 
     void ImportAnimationFromMetadata(
-        const std::string& filePath, const std::string& targetFilePath, const std::string& name, UID sourceUID
+        const std::string& filePath, const std::string& targetFilePath, const std::string& name, UID sourceUID,
+        const rapidjson::Value& importOptions
     )
     {
-        tinygltf::Model model = LoadModelGLTF(filePath.c_str());
+        if (!importOptions.IsObject()) return;
 
-        // find material name that equals to name
-        for (int i = 0; i < model.animations.size(); i++)
+        tinygltf::Model model = LoadModelGLTF(filePath.c_str());
+         int animIndex = importOptions.HasMember("animationIndex") ? importOptions["animationIndex"].GetInt() : 0;
+
+        // ONLY IMPORT ANIMATION IF INDEX IS INSIDE ANIMATION RANGE
+        if (model.animations.size() > animIndex)
         {
-            if (model.animations[i].name == name)
-            {
-                AnimationImporter::ImportAnimation(
-                    model, model.animations[i], name, filePath.c_str(), targetFilePath, sourceUID
-                );
-                return; // only one animation with the same name
-            }
+            AnimationImporter::ImportAnimation(
+                model, model.animations[animIndex], name, filePath.c_str(), targetFilePath, sourceUID, animIndex
+            );
+            return;
         }
     }
 

--- a/SobrassadaEngine/FileSystem/Importers/SceneImporter.h
+++ b/SobrassadaEngine/FileSystem/Importers/SceneImporter.h
@@ -23,7 +23,8 @@ namespace SceneImporter
         const std::string& filePath, const std::string& targetFilePath, const std::string& name, UID sourceUID
     );
     void ImportAnimationFromMetadata(
-        const std::string& filePath, const std::string& targetFilePath, const std::string& name, UID sourceUID
+        const std::string& filePath, const std::string& targetFilePath, const std::string& name, UID sourceUID,
+        const rapidjson::Value& importOptions
     );
     void
     CopyPrefab(const std::string& filePath, const std::string& targetFilePath, const std::string& name, UID sourceUID);

--- a/SobrassadaEngine/FileSystem/Meta/MetaAnimation.cpp
+++ b/SobrassadaEngine/FileSystem/Meta/MetaAnimation.cpp
@@ -1,10 +1,13 @@
 #include "MetaAnimation.h"
-MetaAnimation::MetaAnimation(UID uid, const std::string& assetPath) : MetaFile(uid, assetPath)
+MetaAnimation::MetaAnimation(UID uid, const std::string& assetPath, int32_t index) : MetaFile(uid, assetPath)
 {
+    animationIndex = index;
 }
-
 
 void MetaAnimation::AddImportOptions(rapidjson::Document& doc, rapidjson::Document::AllocatorType& allocator) const
 {
-    
+    rapidjson::Value importOptions(rapidjson::kObjectType);
+
+    importOptions.AddMember("animationIndex", animationIndex, allocator);
+    doc.AddMember("importOptions", importOptions, allocator);
 }

--- a/SobrassadaEngine/FileSystem/Meta/MetaAnimation.h
+++ b/SobrassadaEngine/FileSystem/Meta/MetaAnimation.h
@@ -5,6 +5,9 @@
 class MetaAnimation : public MetaFile
 {
   public:
-    MetaAnimation(UID uid, const std::string& assetPath);
+    MetaAnimation(UID uid, const std::string& assetPath, int32_t index);
     void AddImportOptions(rapidjson::Document& doc, rapidjson::Document::AllocatorType& allocator) const override;
+
+    private:
+    int32_t animationIndex = -1;
 };

--- a/SobrassadaEngine/FileSystem/Meta/MetaAnimation.h
+++ b/SobrassadaEngine/FileSystem/Meta/MetaAnimation.h
@@ -5,8 +5,6 @@
 class MetaAnimation : public MetaFile
 {
   public:
-	MetaAnimation(UID uid, const std::string& assetPath);
+    MetaAnimation(UID uid, const std::string& assetPath);
     void AddImportOptions(rapidjson::Document& doc, rapidjson::Document::AllocatorType& allocator) const override;
-
-	
 };

--- a/SobrassadaEngine/Modules/LibraryModule.cpp
+++ b/SobrassadaEngine/Modules/LibraryModule.cpp
@@ -181,7 +181,7 @@ bool LibraryModule::LoadLibraryMaps(const std::string& projectPath)
                 AddName(assetName, assetUID);
                 libraryPath = projectPath + ANIMATIONS_PATH + std::to_string(assetUID) + ANIMATION_EXTENSION;
                 if (FileSystem::Exists(libraryPath.c_str())) AddResource(libraryPath, assetUID);
-                else SceneImporter::CopyModel(assetPath, projectPath, assetName, assetUID);
+                else SceneImporter::ImportAnimationFromMetadata(assetPath, projectPath, assetName, assetUID);
                 break;
             case 16:
                 AddPrefab(assetUID, assetName);

--- a/SobrassadaEngine/Modules/LibraryModule.cpp
+++ b/SobrassadaEngine/Modules/LibraryModule.cpp
@@ -181,7 +181,7 @@ bool LibraryModule::LoadLibraryMaps(const std::string& projectPath)
                 AddName(assetName, assetUID);
                 libraryPath = projectPath + ANIMATIONS_PATH + std::to_string(assetUID) + ANIMATION_EXTENSION;
                 if (FileSystem::Exists(libraryPath.c_str())) AddResource(libraryPath, assetUID);
-                else SceneImporter::ImportAnimationFromMetadata(assetPath, projectPath, assetName, assetUID);
+                else SceneImporter::ImportAnimationFromMetadata(assetPath, projectPath, assetName, assetUID, importOptions);
                 break;
             case 16:
                 AddPrefab(assetUID, assetName);

--- a/SobrassadaEngine/Scene/Components/Standalone/AnimationComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/AnimationComponent.cpp
@@ -256,7 +256,6 @@ void AnimationComponent::OnInspector()
 
     if (ImGui::CollapsingHeader("Animation Library"))
     {
-        std::string selectedZombunnyAnim = "";
 
         ImGui::Text("Available Animations:");
         const std::unordered_map<std::string, UID>& animationMap = App->GetLibraryModule()->GetAnimMap();
@@ -267,13 +266,12 @@ void AnimationComponent::OnInspector()
 
             if (animationName.rfind(originAnimation, 0) == 0)
             {
-                const bool isSelected = (selectedZombunnyAnim == animationName);
+                const bool isSelected = (currentAnimName == animationName);
 
                 if (ImGui::Selectable(animationName.c_str(), isSelected))
                 {
-                    selectedZombunnyAnim = animationName;
-                    resource             = pair.second;
-                    AddAnimation(resource);
+                    currentAnimName = pair.first;
+                    resource        = pair.second;
 
                     if (playing)
                     {

--- a/SobrassadaEngine/Scene/Components/Standalone/AnimationComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/AnimationComponent.cpp
@@ -311,6 +311,7 @@ void AnimationComponent::OnInspector()
                 {
                     selectedZombunnyAnim = animationName;
                     resource             = pair.second;
+                    AddAnimation(resource);
 
                     if (currentAnimComp->playing)
                     {

--- a/SobrassadaEngine/Scene/Components/Standalone/AnimationComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/AnimationComponent.cpp
@@ -89,7 +89,9 @@ void AnimationComponent::OnPlay(bool isTransition)
                         if (clip.clipName == currentState->clipName)
                         {
                             if (isTransition)
-                                animController->SetTargetAnimationResource(clip.animationResourceUID, transitionTime, clip.loop);
+                                animController->SetTargetAnimationResource(
+                                    clip.animationResourceUID, transitionTime, clip.loop
+                                );
                             else animController->Play(clip.animationResourceUID, clip.loop);
                             resource = clip.animationResourceUID;
                         }
@@ -184,111 +186,71 @@ void AnimationComponent::OnInspector()
 
     if (ImGui::CollapsingHeader("Object Selection", ImGuiTreeNodeFlags_DefaultOpen))
     {
-        GameObject* selectedObj = App->GetSceneModule()->GetScene()->GetSelectedGameObject();
-        if (selectedObj && selectedObj == parent) currentAnimComp = this;
 
-        if (selectedObj)
+        ImGui::Text("Selected Object: %s", parent->GetName().c_str());
+
+        if (currentAnimResource)
         {
-            ImGui::Text("Selected Object: %s", selectedObj->GetName().c_str());
+            ImGui::Text("Current Animation: %s", currentAnimResource->GetName().c_str());
+            animationDuration = currentAnimResource->GetDuration();
 
-            currentAnimComp = selectedObj->GetComponent<AnimationComponent*>();
+            // Display animation controls
+            ImGui::Separator();
+            ImGui::Text("Animation Controls");
 
-            if (currentAnimComp)
+            if (ImGui::Button("Play")) OnPlay(false);
+
+            ImGui::SameLine();
+
+            if (ImGui::Button("Pause")) OnPause();
+
+            ImGui::SameLine();
+
+            if (ImGui::Button("Stop")) OnStop();
+
+            if (ImGui::Button("Resume")) OnResume();
+
+            if (ImGui::SliderFloat("Timeline", &currentTime, 0.0f, animationDuration, "%.2f sec"))
             {
-                ImGui::Text("Animation Component Found");
-
-                // Get the current animation
-                ResourceAnimation* anim = currentAnimComp->GetCurrentAnimation();
-                if (anim)
+                // When user manually changes the time, update the animation controller
+                if (GetAnimationController())
                 {
-                    ImGui::Text("Current Animation: %s", anim->GetName().c_str());
-                    animationDuration = anim->GetDuration();
+                    GetAnimationController()->SetTime(currentTime);
+                }
+            }
 
-                    // Display animation controls
-                    ImGui::Separator();
-                    ImGui::Text("Animation Controls");
+            // Bone visualization
+            if (ImGui::TreeNode("Bone Mapping"))
+            {
 
-                    if (ImGui::Button("Play"))
-                    {
-                        currentAnimComp->OnPlay(false);
-                    }
+                const auto& boneMap = GetBoneMapping();
 
-                    ImGui::SameLine();
-
-                    if (ImGui::Button("Pause"))
-                    {
-                        currentAnimComp->OnPause();
-                    }
-
-                    ImGui::SameLine();
-
-                    if (ImGui::Button("Stop"))
-                    {
-                        currentAnimComp->OnStop();
-                    }
-
-                    if (ImGui::Button("Resume"))
-                    {
-                        currentAnimComp->OnResume();
-                    }
-
-                    if (ImGui::SliderFloat("Timeline", &currentTime, 0.0f, animationDuration, "%.2f sec"))
-                    {
-                        // When user manually changes the time, update the animation controller
-                        if (currentAnimComp->GetAnimationController())
-                        {
-                            currentAnimComp->GetAnimationController()->SetTime(currentTime);
-                        }
-                    }
-
-                    // Bone visualization
-                    if (ImGui::TreeNode("Bone Mapping"))
-                    {
-                        if (currentAnimComp)
-                        {
-                            const auto& boneMap = currentAnimComp->GetBoneMapping();
-
-                            if (boneMap.empty())
-                            {
-                                ImGui::Text("No bones mapped. Animation might not apply correctly.");
-                            }
-                            else
-                            {
-                                ImGui::Text("%d bones mapped:", boneMap.size());
-                                for (const auto& pair : boneMap)
-                                {
-                                    bool foundInAnimation = false;
-
-                                    if (currentAnimComp->GetCurrentAnimation())
-                                    {
-                                        foundInAnimation =
-                                            currentAnimComp->GetCurrentAnimation()->channels.find(pair.first) !=
-                                            currentAnimComp->GetCurrentAnimation()->channels.end();
-                                    }
-
-                                    ImGui::TextColored(
-                                        foundInAnimation ? ImVec4(0, 1, 0, 1) : ImVec4(1, 0, 0, 1), "%s -> %s",
-                                        pair.first.c_str(), pair.second ? pair.second->GetName().c_str() : "NULL"
-                                    );
-                                }
-                            }
-                        }
-                        ImGui::TreePop();
-                    }
+                if (boneMap.empty())
+                {
+                    ImGui::Text("No bones mapped. Animation might not apply correctly.");
                 }
                 else
                 {
-                    ImGui::Text("No animation assigned to component");
+                    ImGui::Text("%d bones mapped:", boneMap.size());
+                    for (const auto& pair : boneMap)
+                    {
+                        bool foundInAnimation = false;
+
+                        if (GetCurrentAnimation())
+                        {
+                            foundInAnimation = GetCurrentAnimation()->channels.find(pair.first) !=
+                                               GetCurrentAnimation()->channels.end();
+                        }
+
+                        ImGui::TextColored(
+                            foundInAnimation ? ImVec4(0, 1, 0, 1) : ImVec4(1, 0, 0, 1), "%s -> %s", pair.first.c_str(),
+                            pair.second ? pair.second->GetName().c_str() : "NULL"
+                        );
+                    }
                 }
+
+                ImGui::TreePop();
             }
-            else
-            {
-                ImGui::Text("No animation component found on selected object");
-            }
-        }
-        else
-        {
-            ImGui::Text("No object selected");
         }
     }
 
@@ -313,14 +275,12 @@ void AnimationComponent::OnInspector()
                     resource             = pair.second;
                     AddAnimation(resource);
 
-                    if (currentAnimComp->playing)
+                    if (playing)
                     {
                         playing     = false;
                         currentTime = 0.0f;
-                        currentAnimComp->OnStop();
+                        OnStop();
                     }
-
-                    GLOG("Selected animation: %s (UID: %llu)", animationName.c_str(), resource);
                 }
             }
         }
@@ -351,7 +311,6 @@ void AnimationComponent::OnInspector()
         ImGui::EndCombo();
     }
 
-
     if (resourceStateMachine)
     {
         ImGui::Separator();
@@ -365,7 +324,7 @@ void AnimationComponent::OnInspector()
                 bool triggerAvailable = false;
                 if (IsPlaying())
                 {
-                    //triggerAvailable = resourceStateMachine->UseTrigger(triggerName);
+                    // triggerAvailable = resourceStateMachine->UseTrigger(triggerName);
                     triggerAvailable = resourceStateMachine->UseTrigger(triggerName, currentState);
                     if (triggerAvailable)
                     {
@@ -376,9 +335,9 @@ void AnimationComponent::OnInspector()
         }
     }
 
-    if (playing && currentAnimComp && currentAnimComp->GetAnimationController())
+    if (playing && GetAnimationController())
     {
-        currentTime = currentAnimComp->GetAnimationController()->GetTime();
+        currentTime = GetAnimationController()->GetTime();
 
         if (currentTime >= animationDuration)
         {
@@ -601,7 +560,7 @@ bool AnimationComponent::UseTrigger(const std::string& triggerName)
     bool triggerDone = false;
     if (resourceStateMachine)
     {
-        //triggerDone = resourceStateMachine->UseTrigger(triggerName);
+        // triggerDone = resourceStateMachine->UseTrigger(triggerName);
         triggerDone = resourceStateMachine->UseTrigger(triggerName, currentState);
         if (triggerDone)
         {

--- a/SobrassadaEngine/Scene/Components/Standalone/AnimationComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/AnimationComponent.cpp
@@ -34,6 +34,7 @@ AnimationComponent::AnimationComponent(const rapidjson::Value& initialState, Gam
     {
         resource            = initialState["Animations"].GetUint64();
         currentAnimResource = static_cast<ResourceAnimation*>(App->GetResourcesModule()->RequestResource(resource));
+        int x               = 0;
     }
     else
     {

--- a/SobrassadaEngine/Scene/Components/Standalone/AnimationComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/AnimationComponent.cpp
@@ -34,7 +34,6 @@ AnimationComponent::AnimationComponent(const rapidjson::Value& initialState, Gam
     {
         resource            = initialState["Animations"].GetUint64();
         currentAnimResource = static_cast<ResourceAnimation*>(App->GetResourcesModule()->RequestResource(resource));
-        int x               = 0;
     }
     else
     {

--- a/SobrassadaEngine/Scene/Components/Standalone/AnimationComponent.h
+++ b/SobrassadaEngine/Scene/Components/Standalone/AnimationComponent.h
@@ -52,7 +52,6 @@ class SOBRASADA_API_ENGINE AnimationComponent : public Component
   private:
     UID resource                               = INVALID_UID;
     std::string currentAnimName                = "None";
-    AnimationComponent* currentAnimComp        = nullptr;
 
     AnimController* animController             = nullptr;
     ResourceAnimation* currentAnimResource     = nullptr;

--- a/SobrassadaEngine/Utils/Globals.h
+++ b/SobrassadaEngine/Utils/Globals.h
@@ -95,7 +95,7 @@ constexpr const char* SCENES_PATH                    = "Assets/Scenes/";
 constexpr const char* METADATA_PATH                  = "Assets/Metadata/";
 constexpr const char* PREFABS_ASSETS_PATH            = "Assets/Prefabs/";
 constexpr const char* MODELS_ASSETS_PATH             = "Assets/Models/";
-constexpr const char* ANIMATIONS_ASSETS_PATH         = "Assets/Animations/";
+constexpr const char* ANIMATIONS_ASSETS_PATH         = "Assets/";
 constexpr const char* STATEMACHINES_ASSETS_PATH      = "Assets/StateMachines/";
 
 constexpr const char* LIBRARY_PATH                   = "Library/";

--- a/SobrassadaEngine/Utils/Globals.h
+++ b/SobrassadaEngine/Utils/Globals.h
@@ -95,7 +95,6 @@ constexpr const char* SCENES_PATH                    = "Assets/Scenes/";
 constexpr const char* METADATA_PATH                  = "Assets/Metadata/";
 constexpr const char* PREFABS_ASSETS_PATH            = "Assets/Prefabs/";
 constexpr const char* MODELS_ASSETS_PATH             = "Assets/Models/";
-constexpr const char* ANIMATIONS_ASSETS_PATH         = "Assets/";
 constexpr const char* STATEMACHINES_ASSETS_PATH      = "Assets/StateMachines/";
 
 constexpr const char* LIBRARY_PATH                   = "Library/";


### PR DESCRIPTION
This PR fixes few things with the animation import and component.

Animation are now properly reimported from metafiles if the library is deleted, also selecting an animation in the dropdown of the component editor assigns that animation to the component.

In order for the changes to work existing models with animations need to be reimported so the metafile gets updated with the index in the model.

You can try with the artist model which contains one animation and with the fox which contains 3, once imported and deleting the library, once the scene is opened the models should mantain their animations.