### PR TITLE
THO-496 Added new projectile layers for player and enemy

### DIFF
--- a/SobrassadaEngine/Modules/PhysicsModule.cpp
+++ b/SobrassadaEngine/Modules/PhysicsModule.cpp
@@ -312,9 +312,17 @@ void PhysicsModule::LoadLayerData(const rapidjson::Value* initialState)
         colliderLayerConfig[2] |= config;
 
         // PLAYER
-        config =
-            1 << (int)ColliderLayer::ENEMY | 1 << (int)ColliderLayer::WORLD_OBJECTS | 1 << (int)ColliderLayer::TRIGGERS;
+        config = 1 << (int)ColliderLayer::ENEMY | 1 << (int)ColliderLayer::WORLD_OBJECTS |
+                 1 << (int)ColliderLayer::TRIGGERS | 1 << (int)ColliderLayer::ENEMY_PROJECTILE;
         colliderLayerConfig[3] |= config;
+
+        // PLAYER PROJECTILE
+        config                  = 1 << (int)ColliderLayer::ENEMY;
+        colliderLayerConfig[4] |= config;
+
+        // ENEMY PROJECTILE
+        config                  = 1 << (int)ColliderLayer::PLAYER;
+        colliderLayerConfig[5] |= config;
     }
     else
     {
@@ -349,6 +357,20 @@ void PhysicsModule::LoadLayerData(const rapidjson::Value* initialState)
 
             colliderLayerConfig[3] |= currentMask;
         }
+
+        if (initialStateRef.HasMember("PlayerProjectileMask"))
+        {
+            currentMask             = initialStateRef["PlayerProjectileMask"].GetInt();
+
+            colliderLayerConfig[4] |= currentMask;
+        }
+
+        if (initialStateRef.HasMember("EnemyProjectileMask"))
+        {
+            currentMask             = initialStateRef["EnemyProjectileMask"].GetInt();
+
+            colliderLayerConfig[5] |= currentMask;
+        }
     }
 }
 
@@ -372,6 +394,8 @@ void PhysicsModule::SaveLayerData(rapidjson::Value& targetState, rapidjson::Docu
     targetState.AddMember("TriggerMask", masks[1], allocator);
     targetState.AddMember("EnemyMask", masks[2], allocator);
     targetState.AddMember("PlayerMask", masks[3], allocator);
+    targetState.AddMember("PlayerProjectileMask", masks[4], allocator);
+    targetState.AddMember("EnemyProjectileMask", masks[5], allocator);
 }
 
 void PhysicsModule::EmptyWorld()
@@ -386,13 +410,6 @@ void PhysicsModule::EmptyWorld()
     }
 
     bodiesToRemove.clear();
-
-   /* for (int i = dynamicsWorld->getNumCollisionObjects() - 1; i >= 0; i--)
-    {
-        btCollisionObject* obj = dynamicsWorld->getCollisionObjectArray()[i];
-        dynamicsWorld->removeCollisionObject(obj);
-        delete obj;
-    }*/
 }
 
 void PhysicsModule::RebuildWorld()

--- a/SobrassadaEngine/Scene/Components/ComponentUtils.h
+++ b/SobrassadaEngine/Scene/Components/ComponentUtils.h
@@ -55,9 +55,12 @@ enum class ColliderLayer : uint8_t
     TRIGGERS,
     ENEMY,
     PLAYER,
+    PLAYER_PROJECTILE,
+    ENEMY_PROJECTILE
 };
 
-constexpr const char* ColliderLayerStrings[] = {"World Objects", "Triggers", "Enemies", "Player"};
+constexpr const char* ColliderLayerStrings[] = {"World Objects", "Triggers",          "Enemies",
+                                                "Player",        "Player projectile", "Enemy projectile"};
 
 typedef Delegate<void, GameObject*, float3> CollisionDelegate;
 


### PR DESCRIPTION
Added two new physics layers the player and enemy projectile.

**Important!** If you load an existing scene you will need to add the collision config on the editor settings, if a new scene is created it will take the default values.

![image](https://github.com/user-attachments/assets/ee272973-50d3-41aa-854c-3dbf7c343ad8)

Default values:
Player projectile -> enemies
Enemy projectile -> player
Player-> also interacts with enemy projectile

