### PR TITLE
Fixed crash when a broken prefab file is being loaded

### DIFF
--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -1278,6 +1278,9 @@ void Scene::LoadPrefab(const UID prefabUID, const ResourcePrefab* prefab, const 
 
         const ResourcePrefab* resourcePrefab =
             prefab == nullptr ? (const ResourcePrefab*)App->GetResourcesModule()->RequestResource(prefabUID) : prefab;
+
+        if (resourcePrefab == nullptr) return; // If the prefab file is corrupted or not available, loading is cancelled
+        
         const std::vector<GameObject*>& referenceObjects = resourcePrefab->GetGameObjectsVector();
         const std::vector<int>& parentIndices            = resourcePrefab->GetParentIndices();
 


### PR DESCRIPTION
This PR fixed a bug when the user attempts to load a prefab with a corrupted file. 

For testing, modify a prefab file so that the json syntax is broken. 
The engine should not crash and a log with the error is displayed in the console.