### PR TITLE
Allowed textures to be overwritten by new versions THO-502

### DIFF
--- a/SobrassadaEngine/FileSystem/Importers/MaterialImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/MaterialImporter.cpp
@@ -221,7 +221,7 @@ UID MaterialImporter::ImportMaterial(
 UID MaterialImporter::HandleTextureImport(const std::string& filePath, const std::string& targetFilePath)
 {
     UID textureUID = App->GetLibraryModule()->GetTextureUID(FileSystem::GetFileNameWithoutExtension(filePath));
-    if (textureUID == INVALID_UID) textureUID = TextureImporter::Import(filePath.c_str(), targetFilePath);
+    textureUID = TextureImporter::Import(filePath.c_str(), targetFilePath, textureUID, true);
     return textureUID;
 }
 

--- a/SobrassadaEngine/FileSystem/Importers/TextureImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/TextureImporter.cpp
@@ -12,15 +12,12 @@
 
 namespace TextureImporter
 {
-    UID Import(const char* sourceFilePath, const std::string& targetFilePath, UID sourceUID)
+    UID Import(const char* sourceFilePath, const std::string& targetFilePath, UID sourceUID, bool overwriteMeta)
     {
         // Copy image to Assets folder
         const std::string relativePath = ASSETS_PATH + FileSystem::GetFileNameWithExtension(sourceFilePath);
         std::string copyPath           = targetFilePath + relativePath;
-        if (!FileSystem::Exists(copyPath.c_str()))
-        {
-            FileSystem::Copy(sourceFilePath, copyPath.c_str());
-        }
+        FileSystem::Copy(sourceFilePath, copyPath.c_str());
 
         std::string textureStr = std::string(sourceFilePath);
         std::wstring wPath     = std::wstring(textureStr.begin(), textureStr.end());
@@ -66,22 +63,18 @@ namespace TextureImporter
             fileName += "_HDR";
         }
 
-        UID finalTextureUID;
-        if (sourceUID == INVALID_UID)
+        UID finalTextureUID = sourceUID;
+        if (sourceUID == INVALID_UID || overwriteMeta)
         {
-            UID textureUID  = GenerateUID();
-            textureUID = App->GetLibraryModule()->AssignFiletypeUID(textureUID, FileType::Texture);
-
-            UID prefix                 = textureUID / UID_PREFIX_DIVISOR;
-            const std::string savePath = App->GetProjectModule()->GetLoadedProjectPath() + METADATA_PATH +
-                                         std::to_string(prefix) + FILENAME_SEPARATOR + fileName + META_EXTENSION;
-            finalTextureUID = App->GetLibraryModule()->GetUIDFromMetaFile(savePath);
-            if (finalTextureUID == INVALID_UID) finalTextureUID = textureUID;
+            if (sourceUID == INVALID_UID)
+            {
+                finalTextureUID  = GenerateUID();
+                finalTextureUID = App->GetLibraryModule()->AssignFiletypeUID(finalTextureUID, FileType::Texture);
+            }
             
             MetaTexture meta(finalTextureUID, relativePath, (int)image.GetMetadata().mipLevels);
             meta.Save(fileName, relativePath);
         }
-        else finalTextureUID = sourceUID;
 
         std::string saveFilePath = targetFilePath + TEXTURES_PATH + std::to_string(finalTextureUID) + TEXTURE_EXTENSION;
         unsigned int bytesWritten =

--- a/SobrassadaEngine/FileSystem/Importers/TextureImporter.h
+++ b/SobrassadaEngine/FileSystem/Importers/TextureImporter.h
@@ -14,7 +14,7 @@ namespace DirectX
 
 namespace TextureImporter
 {
-    UID Import(const char* filePath, const std::string& targetFilePath, UID sourceUID = INVALID_UID);
+    UID Import(const char* filePath, const std::string& targetFilePath, UID sourceUID = INVALID_UID, bool overwriteMeta = false);
     ResourceTexture* LoadTexture(UID textureUID);
     ResourceTexture* LoadCubemap(UID textureUID);
     bool


### PR DESCRIPTION
This pr fixes an import problem which prevented textures with the same name to be overwritten by new versions. 

To test, go to the AssetOverview scene of the EngineTest repo and import the following gltf: 
https://drive.google.com/file/d/1xKrhXlu4QHt5E88QBw5jTtoMhnm1l2uw/view?usp=sharing

After importing, the pillars should switch from a blue texture to a grey texture. Before this change they stayed blue.