### PR TITLE
Tho 495 Engine debugs in game build

### DIFF
--- a/SobrassadaEngine/Application.cpp
+++ b/SobrassadaEngine/Application.cpp
@@ -1,5 +1,6 @@
 #include "Application.h"
 
+#include "AudioModule.h"
 #include "CameraModule.h"
 #include "ComponentUtils.h"
 #include "Config/EngineConfig.h"
@@ -7,6 +8,7 @@
 #include "EditorUIModule.h"
 #include "EngineTimer.h"
 #include "Framebuffer.h"
+#include "GameDebugUIModule.h"
 #include "GameTimer.h"
 #include "GameUIModule.h"
 #include "InputModule.h"
@@ -20,7 +22,6 @@
 #include "ScriptModule.h"
 #include "ShaderModule.h"
 #include "WindowModule.h"
-#include "AudioModule.h"
 
 #ifdef OPTICK
 #include "optick.h"
@@ -46,6 +47,7 @@ Application::Application()
     modules.push_back(cameraModule = new CameraModule());
     modules.push_back(debugDraw = new DebugDrawModule());
     modules.push_back(editorUIModule = new EditorUIModule());
+    modules.push_back(gameDebugUI = new GameDebugUIModule());
 
     engineTimer = new EngineTimer();
     engineTimer->Start();
@@ -113,6 +115,10 @@ update_status Application::Update()
         for (std::list<Module*>::iterator it = modules.begin(); it != modules.end() && returnStatus == UPDATE_CONTINUE;
              ++it)
             returnStatus = (*it)->RenderEditor(deltaTime);
+#endif
+#ifdef GAME
+        App->GetOpenGLModule()->GetFramebuffer()->Unbind();
+        GetGameDebugUIModule()->RenderEditor(deltaTime);
 #endif
     }
 

--- a/SobrassadaEngine/Application.h
+++ b/SobrassadaEngine/Application.h
@@ -22,6 +22,7 @@ class ScriptModule;
 class PhysicsModule;
 class PathfinderModule;
 class AudioModule;
+class GameDebugUIModule;
 
 class EngineTimer;
 class GameTimer;
@@ -53,6 +54,7 @@ class SOBRASADA_API_ENGINE Application
     PhysicsModule* GetPhysicsModule() { return physicsModule; }
     PathfinderModule* GetPathfinderModule() { return pathModule; }
     AudioModule* GetAudioModule() { return audioModule; }
+    GameDebugUIModule* GetGameDebugUIModule() { return gameDebugUI; }
 
     EngineTimer* GetEngineTimer() { return engineTimer; }
     GameTimer* GetGameTimer() { return gameTimer; }
@@ -78,6 +80,7 @@ class SOBRASADA_API_ENGINE Application
     PhysicsModule* physicsModule     = nullptr;
     PathfinderModule* pathModule     = nullptr;
     AudioModule* audioModule         = nullptr;
+    GameDebugUIModule* gameDebugUI   = nullptr;
 
     EngineTimer* engineTimer         = nullptr;
     GameTimer* gameTimer             = nullptr;

--- a/SobrassadaEngine/Modules/DebugDrawModule.cpp
+++ b/SobrassadaEngine/Modules/DebugDrawModule.cpp
@@ -764,10 +764,13 @@ void DebugDrawModule::DrawCone(const float3& center, const float3& dir, const fl
 
 void DebugDrawModule::Draw3DText(const btVector3& location, const char* textString)
 {
-    CameraModule* cameraModule = App->GetCameraModule();
+    bool playMode              = App->GetSceneModule()->GetInPlayMode();
 
-    const float4x4& projection = cameraModule->GetProjectionMatrix();
-    const float4x4& view       = cameraModule->GetViewMatrix();
+    CameraModule* cameraModule = App->GetCameraModule();
+    CameraComponent* camera    = App->GetSceneModule()->GetScene()->GetMainCamera();
+
+    const float4x4& projection = playMode ? camera->GetProjectionMatrix() : cameraModule->GetProjectionMatrix();
+    const float4x4& view       = playMode ? camera->GetViewMatrix() : cameraModule->GetViewMatrix();
     const float3 pos           = float3(location);
 
     auto framebuffer           = App->GetOpenGLModule()->GetFramebuffer();
@@ -775,6 +778,11 @@ void DebugDrawModule::Draw3DText(const btVector3& location, const char* textStri
     int height                 = framebuffer->GetTextureHeight();
 
     dd::projectedText(textString, pos, float3::zero, view * projection, 0, 0, width, height);
+}
+
+void DebugDrawModule::Draw2DText(const char* textString, const float3& location)
+{
+    dd::screenText(textString, location, float3::zero);
 }
 
 void DebugDrawModule::DrawContactPoint(

--- a/SobrassadaEngine/Modules/DebugDrawModule.h
+++ b/SobrassadaEngine/Modules/DebugDrawModule.h
@@ -64,6 +64,7 @@ class DebugDrawModule : public Module
     void DrawPoint(const float3& center, const float size);
     void DrawCone(const float3& center, const float3& dir, const float baseRadius, const float apexRadius);
     void Draw3DText(const btVector3& location, const char* textString);
+    void Draw2DText(const char* textString, const float3& location);
     void DrawContactPoint(
         const btVector3& PointOnB, const btVector3& normalOnB, float distance, int lifeTime, const btVector3& color
     );

--- a/SobrassadaEngine/Modules/EditorUIModule.h
+++ b/SobrassadaEngine/Modules/EditorUIModule.h
@@ -103,6 +103,7 @@ class EditorUIModule : public Module
     SOBRASADA_API_ENGINE void ToggleFullscreen();
     SOBRASADA_API_ENGINE void ToggleVSync();
 
+    void Console(bool& consoleMenu) const;
   private:
     void RenderBasicTransformModifiers(
         float3& outputPosition, float3& outputRotation, float3& outputScale, bool& lockScaleAxis,
@@ -132,7 +133,6 @@ class EditorUIModule : public Module
     void LoadModelDialog(bool& loadModel);
     void LoadPrefabDialog(bool& loadPrefab);
     void SaveDialog(bool& save);
-    void Console(bool& consoleMenu) const;
     void About(bool& aboutMenu);
     void Navmesh(bool& navmesh);
     void CrowdControl(bool& crowdControl);

--- a/SobrassadaEngine/Modules/GameDebugUIModule.cpp
+++ b/SobrassadaEngine/Modules/GameDebugUIModule.cpp
@@ -1,0 +1,108 @@
+#include "GameDebugUIModule.h"
+
+#include "Application.h"
+#include "DebugDrawModule.h"
+#include "InputModule.h"
+#include "OpenGLModule.h"
+#include "PhysicsModule.h"
+
+#include "SDL.h"
+#include "glew.h"
+#include "imgui.h"
+#include "imgui_impl_opengl3.h"
+#include "imgui_impl_sdl2.h"
+#include "imgui_internal.h"
+
+GameDebugUIModule::GameDebugUIModule()
+{
+}
+
+GameDebugUIModule::~GameDebugUIModule()
+{
+}
+
+bool GameDebugUIModule::Init()
+{
+    return true;
+}
+
+update_status GameDebugUIModule::PreUpdate(float deltaTime)
+{
+#ifdef GAME
+
+    ImGui_ImplOpenGL3_NewFrame();
+    ImGui_ImplSDL2_NewFrame();
+    ImGui::NewFrame();
+
+#endif
+
+    return UPDATE_CONTINUE;
+}
+
+update_status GameDebugUIModule::Update(float deltaTime)
+{
+    return UPDATE_CONTINUE;
+}
+
+update_status GameDebugUIModule::RenderEditor(float deltaTime)
+{
+#ifdef GAME
+    Draw();
+
+    ImGui::Render();
+    ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+
+#endif
+    return UPDATE_CONTINUE;
+}
+
+update_status GameDebugUIModule::PostUpdate(float deltaTime)
+{
+    return UPDATE_CONTINUE;
+}
+
+bool GameDebugUIModule::ShutDown()
+{
+    return true;
+}
+
+void GameDebugUIModule::Draw()
+{
+    RenderOptions();
+}
+
+void GameDebugUIModule::RenderOptions()
+{
+    if (App->GetInputModule()->GetKeyboard()[SDL_SCANCODE_F9])
+    {
+        ImGui::OpenPopup("RenderOptions");
+    }
+
+    if (ImGui::BeginPopup("RenderOptions"))
+    {
+        int stringCount   = sizeof(DebugStrings) / sizeof(char*);
+        float listBoxSize = (float)stringCount + 0.5f;
+        if (ImGui::BeginListBox(
+                "##RenderOptionsList", ImVec2(ImGui::CalcItemWidth(), ImGui::GetFrameHeightWithSpacing() * listBoxSize)
+            ))
+        {
+            const auto& debugBitset = App->GetDebugDrawModule()->GetDebugOptionValues();
+            for (int i = 0; i < stringCount; ++i)
+            {
+                bool currentBitValue = debugBitset[i];
+                if (ImGui::Checkbox(DebugStrings[i], &currentBitValue))
+                {
+                    App->GetDebugDrawModule()->FlipDebugOptionValue(i);
+                    if (i == (int)DebugOptions::RENDER_WIREFRAME)
+                        App->GetOpenGLModule()->SetRenderWireframe(currentBitValue);
+                    else if (i == (int)DebugOptions::RENDER_PHYSICS_WORLD)
+                        App->GetPhysicsModule()->SetDebugOption(currentBitValue);
+                }
+            }
+
+            ImGui::EndListBox();
+        }
+
+        ImGui::EndPopup();
+    }
+}

--- a/SobrassadaEngine/Modules/GameDebugUIModule.cpp
+++ b/SobrassadaEngine/Modules/GameDebugUIModule.cpp
@@ -2,6 +2,8 @@
 
 #include "Application.h"
 #include "DebugDrawModule.h"
+#include "EditorUIModule.h"
+#include "GameTimer.h"
 #include "InputModule.h"
 #include "OpenGLModule.h"
 #include "PhysicsModule.h"
@@ -12,6 +14,13 @@
 #include "imgui_impl_opengl3.h"
 #include "imgui_impl_sdl2.h"
 #include "imgui_internal.h"
+
+// TESTING
+#include "CameraComponent.h"
+#include "Framebuffer.h"
+#include "Geometry/LineSegment.h"
+#include "SceneModule.h"
+#include "btVector3.h"
 
 GameDebugUIModule::GameDebugUIModule()
 {
@@ -41,14 +50,21 @@ update_status GameDebugUIModule::PreUpdate(float deltaTime)
 
 update_status GameDebugUIModule::Update(float deltaTime)
 {
+#ifdef GAME
+    if (App->GetInputModule()->GetKeyboard()[SDL_SCANCODE_F1] == KeyState::KEY_DOWN)
+    {
+        gameDebugMenu = !gameDebugMenu;
+    }
+
+#endif
     return UPDATE_CONTINUE;
 }
 
 update_status GameDebugUIModule::RenderEditor(float deltaTime)
 {
+
 #ifdef GAME
     Draw();
-
     ImGui::Render();
     ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 
@@ -58,6 +74,10 @@ update_status GameDebugUIModule::RenderEditor(float deltaTime)
 
 update_status GameDebugUIModule::PostUpdate(float deltaTime)
 {
+#ifdef GAME
+    if (closeApplication) return UPDATE_STOP;
+#endif
+
     return UPDATE_CONTINUE;
 }
 
@@ -68,12 +88,43 @@ bool GameDebugUIModule::ShutDown()
 
 void GameDebugUIModule::Draw()
 {
+    if (gameDebugMenu) GameDebugMenu();
     RenderOptions();
+}
+
+void GameDebugUIModule::GameDebugMenu()
+{
+    if (!ImGui::Begin("GameDebug", &gameDebugMenu))
+    {
+        ImGui::End();
+        return;
+    }
+
+    // Delta time comes in ms instead of s
+    const float deltaTime = App->GetGameTimer()->GetDeltaTime();
+    const float fps       = deltaTime ? 1000.f / deltaTime : 0;
+
+    ImGui::Text("FPS:");
+    ImGui::SameLine();
+    ImGui::TextColored(ImVec4(1.0f, 1.0f, 0.0f, 1.0f), std::to_string(fps).c_str());
+
+    ImGui::Checkbox("Console", &openConsole);
+
+    if (openConsole) App->GetEditorUIModule()->Console(openConsole);
+
+    ImGui::Separator();
+    ImGui::Spacing();
+    ImGui::Spacing();
+    ImGui::Spacing();
+
+    if (ImGui::Button("Close Game")) closeApplication = true;
+
+    ImGui::End();
 }
 
 void GameDebugUIModule::RenderOptions()
 {
-    if (App->GetInputModule()->GetKeyboard()[SDL_SCANCODE_F9])
+    if (App->GetInputModule()->GetKeyboard()[SDL_SCANCODE_F2])
     {
         ImGui::OpenPopup("RenderOptions");
     }

--- a/SobrassadaEngine/Modules/GameDebugUIModule.h
+++ b/SobrassadaEngine/Modules/GameDebugUIModule.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "Module.h"
+
+class GameDebugUIModule : public Module
+{
+  public:
+    GameDebugUIModule();
+    ~GameDebugUIModule() override;
+
+    bool Init() override;
+    update_status PreUpdate(float deltaTime) override;
+    update_status Update(float deltaTime) override;
+    update_status RenderEditor(float deltaTime) override;
+    update_status PostUpdate(float deltaTime) override;
+    bool ShutDown() override;
+
+  private:
+    void Draw();
+
+    void RenderOptions();
+};

--- a/SobrassadaEngine/Modules/GameDebugUIModule.h
+++ b/SobrassadaEngine/Modules/GameDebugUIModule.h
@@ -18,5 +18,13 @@ class GameDebugUIModule : public Module
   private:
     void Draw();
 
+    void GameDebugMenu();
     void RenderOptions();
+
+  private:
+    bool gameDebugMenu    = false;
+    bool closeApplication = false;
+
+    bool drawFPS = false;
+    bool openConsole = false;
 };

--- a/SobrassadaEngine/SobrassadaEngine.vcxproj
+++ b/SobrassadaEngine/SobrassadaEngine.vcxproj
@@ -361,6 +361,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="Application.cpp" />
+    <ClCompile Include="Modules\GameDebugUIModule.cpp" />
     <ClCompile Include="Scene\Components\Standalone\Audio\AudioListenerComponent.cpp" />
     <ClCompile Include="Libs\Wwise\samples\SoundEngine\Common\AkDefaultLowLevelIODispatcher.cpp" />
     <ClCompile Include="Libs\Wwise\samples\SoundEngine\Common\AkFileLocationBase.cpp" />
@@ -587,6 +588,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Application.h" />
+    <ClInclude Include="Modules\GameDebugUIModule.h" />
     <ClInclude Include="Scene\Components\Standalone\Audio\AudioListenerComponent.h" />
     <ClInclude Include="Libs\Wwise\samples\SoundEngine\Common\AkDefaultLowLevelIODispatcher.h" />
     <ClInclude Include="Libs\Wwise\samples\SoundEngine\Common\AkFileHelpersBase.h" />

--- a/SobrassadaEngine/SobrassadaEngine.vcxproj.filters
+++ b/SobrassadaEngine/SobrassadaEngine.vcxproj.filters
@@ -534,6 +534,9 @@
     <ClCompile Include="Utils\NavMeshConfig.cpp">
       <Filter>Utils</Filter>
     </ClCompile>
+    <ClCompile Include="Modules\GameDebugUIModule.cpp">
+      <Filter>Modules</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Modules">
@@ -1042,6 +1045,9 @@
     </ClInclude>
     <ClInclude Include="Utils\HashString.h">
       <Filter>Utils</Filter>
+    </ClInclude>
+    <ClInclude Include="Modules\GameDebugUIModule.h">
+      <Filter>Modules</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Added GameDebugUIModule, only renders stuff if in game or game debug build, in order to make the menu appear hit F1, there is only the fps, a checkbox to spawn the console and a button to close the game properly. Also, if you hit F2 the render options menu appears.