### PR TITLE
Fixed bug which loads meshes in the wrong order

### DIFF
--- a/SobrassadaEngine/FileSystem/Importers/SceneImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/SceneImporter.cpp
@@ -59,6 +59,8 @@ namespace SceneImporter
             {
                 std::vector<std::pair<UID, UID>> primitives;
 
+                if (srcNode.mesh >= gltfMeshes.size())
+                    gltfMeshes.resize(srcNode.mesh + 1);
                 const tinygltf::Mesh& srcMesh    = model.meshes[srcNode.mesh];
                 const float4x4& defaultTransform = MeshImporter::GetNodeTransform(srcNode);
                 int primitiveCounter             = 0;
@@ -95,7 +97,7 @@ namespace SceneImporter
                     //GLOG("New primitive with mesh UID: %d and Material UID: %d", meshUID, matUID);
                 }
 
-                gltfMeshes.push_back(primitives);
+                gltfMeshes[srcNode.mesh] = primitives;
             }
         }
 


### PR DESCRIPTION
Fixed bug which loads meshes in the wrong order. The order of the meshes in models in the engine was determined on the node order which broke links in specific cases. Now the mesh order is the same as it is in the gltf.

When importing the provided gltf, the animation should run perfectly.
[Attack1.zip](https://github.com/user-attachments/files/20163850/Attack1.zip)
