### PR TITLE
THO-61 debug view navmesh meshes prefab

### DIFF
--- a/Game/EngineDefaults/Shader/Fragment/DepthFragment.glsl
+++ b/Game/EngineDefaults/Shader/Fragment/DepthFragment.glsl
@@ -1,5 +1,7 @@
+#version 460
+
 uniform sampler2D u_Texture;
-in vec2 TexCoords;
+in vec2 uv0;
 out vec4 FragColor;
 uniform float nearPlane;
 uniform float farPlane;
@@ -11,7 +13,8 @@ float LinearizeDepth(float depth)
 
 void main()
 {
-    float depth = texture(u_Texture, TexCoords).r;
+    float depth = texture(u_Texture, uv0).r;
     float linearDepth = LinearizeDepth(depth);
     FragColor = vec4(vec3(linearDepth), 1.0);
+    //FragColor = vec4(vec3(pow(linearDepth, 0.2)), 1.0);
 }

--- a/Game/EngineDefaults/Shader/Fragment/DepthFragment.glsl
+++ b/Game/EngineDefaults/Shader/Fragment/DepthFragment.glsl
@@ -1,0 +1,17 @@
+uniform sampler2D u_Texture;
+in vec2 TexCoords;
+out vec4 FragColor;
+uniform float nearPlane;
+uniform float farPlane;
+
+float LinearizeDepth(float depth)
+{
+    return (2.0 * nearPlane) / (farPlane + nearPlane - depth * (farPlane - nearPlane));
+}
+
+void main()
+{
+    float depth = texture(u_Texture, TexCoords).r;
+    float linearDepth = LinearizeDepth(depth);
+    FragColor = vec4(vec3(linearDepth), 1.0);
+}

--- a/Game/EngineDefaults/Shader/Fragment/QuadFragment.glsl
+++ b/Game/EngineDefaults/Shader/Fragment/QuadFragment.glsl
@@ -1,0 +1,9 @@
+#version 460
+
+in vec2 uv0;
+out vec4 FragColor;
+uniform sampler2D u_Texture;
+
+void main() {
+    FragColor = texture(u_Texture, uv0);
+}

--- a/SobrassadaEngine/FileSystem/Batching/BatchManager.cpp
+++ b/SobrassadaEngine/FileSystem/Batching/BatchManager.cpp
@@ -121,7 +121,7 @@ GeometryBatch* BatchManager::RequestBatch(const MeshComponent* component)
     for (GeometryBatch* it : batches)
     {
         if (it->GetMode() == mesh->GetMode() && it->GetIsMetallic() == material->GetIsMetallicRoughness() &&
-            it->GetHasBones() == component->GetHasBones())
+            it->GetHasBones() == component->GetHasBones() && it->IsNavmeshValid() == component->GetParent()->IsNavMeshValid())
         {
             return it;
         }

--- a/SobrassadaEngine/FileSystem/Batching/GeometryBatch.cpp
+++ b/SobrassadaEngine/FileSystem/Batching/GeometryBatch.cpp
@@ -27,6 +27,7 @@ GeometryBatch::GeometryBatch(const MeshComponent* component)
     mode       = component->GetResourceMesh()->GetMode();
     isMetallic = component->GetResourceMaterial()->GetIsMetallicRoughness();
     hasBones   = component->GetHasBones();
+    isNavmeshValid = component->GetParent()->IsNavMeshValid();
     glGenVertexArrays(1, &vao);
     glGenBuffers(1, &indirect);
     glGenBuffers(1, &vbo);

--- a/SobrassadaEngine/FileSystem/Batching/GeometryBatch.h
+++ b/SobrassadaEngine/FileSystem/Batching/GeometryBatch.h
@@ -32,6 +32,7 @@ class GeometryBatch
     const unsigned int GetMode() const { return mode; }
     const bool GetIsMetallic() const { return isMetallic; }
     const bool GetHasBones() const { return hasBones; }
+    const bool IsNavmeshValid() const { return isNavmeshValid; }
     const unsigned int GetVertexCount() const { return totalVertexCount; }
     const unsigned int GetIndexCount() const { return totalIndexCount; }
     void ResetUpdatedOnce() { updatedOnce = false; }
@@ -79,4 +80,5 @@ class GeometryBatch
     unsigned int mode             = 0;
     bool isMetallic               = false;
     bool hasBones                 = false;
+    bool isNavmeshValid           = false;
 };

--- a/SobrassadaEngine/Modules/CameraModule.h
+++ b/SobrassadaEngine/Modules/CameraModule.h
@@ -39,6 +39,11 @@ class CameraModule : public Module
     const FrustumPlanes& GetFrustrumPlanes() const { return frustumPlanes; }
     const float3& GetCameraPosition() const { return isCameraDetached ? detachedCamera.pos : camera.pos; }
 
+    float GetNearPlaneDistance() const
+    {
+        return isCameraDetached ? detachedCamera.nearPlaneDistance : camera.nearPlaneDistance;
+    }
+
     float GetFarPlaneDistance() const
     {
         return isCameraDetached ? detachedCamera.farPlaneDistance : camera.farPlaneDistance;

--- a/SobrassadaEngine/Modules/DebugDrawModule.h
+++ b/SobrassadaEngine/Modules/DebugDrawModule.h
@@ -23,7 +23,9 @@ enum class DebugOptions : uint8_t
     RENDER_CAMERA_RAY,
     RENDER_NAVMESH,
     RENDER_PHYSICS_WORLD,
-    RENDER_GBUFFERS
+    RENDER_GBUFFERS,
+    RENDER_DEPTH,
+    RENDER_NAVMESH_MESHES
 };
 
 enum DrawNavMeshFlags
@@ -33,8 +35,9 @@ enum DrawNavMeshFlags
     DRAWNAVMESH_COLOR_TILES = 0x04
 };
 
-constexpr const char* DebugStrings[] = {"Render Lights", "Render Wireframe", "AABB",    "OBB",           "Octree",
-                                        "Dynamic Tree",  "Camera Ray",       "Navmesh", "Physics World", "GBuffers"};
+constexpr const char* DebugStrings[] = {"Render Lights", "Render Wireframe", "AABB",       "OBB",
+                                        "Octree",        "Dynamic Tree",     "Camera Ray", "Navmesh",
+                                        "Physics World", "GBuffers",         "Depth",      "Navmesh Meshes"};
 
 class DebugDrawModule : public Module
 {
@@ -56,7 +59,7 @@ class DebugDrawModule : public Module
         bool enableDepth = true
     );
     void DrawLine(const btVector3& from, const btVector3& to, const btVector3& color);
-   
+
     void DrawFrustrum(float4x4 frustumProj, float4x4 frustumView);
     void DrawCircle(const float3& center, const float3& upVector, const float3& color, const float radius);
     void DrawSphere(const float3& center, const float3& color, const float radius);

--- a/SobrassadaEngine/Modules/DebugDrawModule.h
+++ b/SobrassadaEngine/Modules/DebugDrawModule.h
@@ -22,7 +22,8 @@ enum class DebugOptions : uint8_t
     RENDER_DYNAMICTREE,
     RENDER_CAMERA_RAY,
     RENDER_NAVMESH,
-    RENDER_PHYSICS_WORLD
+    RENDER_PHYSICS_WORLD,
+    RENDER_GBUFFERS
 };
 
 enum DrawNavMeshFlags
@@ -32,8 +33,8 @@ enum DrawNavMeshFlags
     DRAWNAVMESH_COLOR_TILES = 0x04
 };
 
-constexpr const char* DebugStrings[] = {"Render Lights", "Render Wireframe", "AABB",       "OBB",
-                                        "Octree",        "Dynamic Tree",     "Camera Ray", "Navmesh", "Physics World" };
+constexpr const char* DebugStrings[] = {"Render Lights", "Render Wireframe", "AABB",    "OBB",           "Octree",
+                                        "Dynamic Tree",  "Camera Ray",       "Navmesh", "Physics World", "GBuffers"};
 
 class DebugDrawModule : public Module
 {

--- a/SobrassadaEngine/Modules/ShaderModule.cpp
+++ b/SobrassadaEngine/Modules/ShaderModule.cpp
@@ -25,6 +25,8 @@ bool ShaderModule::Init()
     metallicGeometryPassProgram = CreateShaderProgram(LIGHTS_VERTEX_SHADER_PATH, GBUFFER_METALLIC_FRAGMENT_SHADER_PATH);
     specularGeometryPassProgram = CreateShaderProgram(LIGHTS_VERTEX_SHADER_PATH, GBUFFER_SPECULAR_FRAGMENT_SHADER_PATH);
     lightingPassProgram         = CreateShaderProgram(QUAD_VERTEX_SHADER_PATH, LIGHTINGPASS_FRAGMENT_SHADER_PATH);
+
+    quadProgram                 = CreateShaderProgram(QUAD_VERTEX_SHADER_PATH, QUAD_FRAGMENT_SHADER_PATH);
     return true;
 }
 
@@ -35,12 +37,17 @@ bool ShaderModule::ShutDown()
     glDeleteProgram(metallicRoughnessProgram);
     glDeleteProgram(metallicRoughnessProgramUnlit);
     glDeleteProgram(uiWidgetProgram);
+    glDeleteProgram(metallicGeometryPassProgram);
+    glDeleteProgram(specularGeometryPassProgram);
+    glDeleteProgram(lightingPassProgram);
+    glDeleteProgram(quadProgram);
+
     return true;
 }
 
 unsigned int ShaderModule::CreateShaderProgram(const char* vertexPath, const char* fragmentPath)
 {
-    //GLOG("Loading shaders")
+    // GLOG("Loading shaders")
     unsigned int program    = 0;
 
     char* vertexShader      = LoadShaderSource(vertexPath);
@@ -59,7 +66,7 @@ unsigned int ShaderModule::CreateShaderProgram(const char* vertexPath, const cha
 
 char* ShaderModule::LoadShaderSource(const char* shaderPath)
 {
-    //GLOG("Reading shader: %s", shaderPath)
+    // GLOG("Reading shader: %s", shaderPath)
     char* data = nullptr;
     FILE* file = nullptr;
 
@@ -80,7 +87,7 @@ char* ShaderModule::LoadShaderSource(const char* shaderPath)
 
 unsigned int ShaderModule::CompileShader(unsigned int shaderType, const char* source)
 {
-    //GLOG("Compiling %s", GL_VERTEX_SHADER == shaderType ? "vertex shader" : "fragment shader")
+    // GLOG("Compiling %s", GL_VERTEX_SHADER == shaderType ? "vertex shader" : "fragment shader")
     unsigned shaderId = glCreateShader(shaderType);
     glShaderSource(shaderId, 1, &source, 0);
     glCompileShader(shaderId);
@@ -108,7 +115,7 @@ unsigned int ShaderModule::CompileShader(unsigned int shaderType, const char* so
 
 unsigned int ShaderModule::CreateProgram(unsigned int vertexShader, unsigned fragmentShader)
 {
-    //GLOG("Creating shader program")
+    // GLOG("Creating shader program")
     unsigned programId = glCreateProgram();
     glAttachShader(programId, vertexShader);
     glAttachShader(programId, fragmentShader);

--- a/SobrassadaEngine/Modules/ShaderModule.cpp
+++ b/SobrassadaEngine/Modules/ShaderModule.cpp
@@ -27,6 +27,7 @@ bool ShaderModule::Init()
     lightingPassProgram         = CreateShaderProgram(QUAD_VERTEX_SHADER_PATH, LIGHTINGPASS_FRAGMENT_SHADER_PATH);
 
     quadProgram                 = CreateShaderProgram(QUAD_VERTEX_SHADER_PATH, QUAD_FRAGMENT_SHADER_PATH);
+    depthProgram                = CreateShaderProgram(QUAD_VERTEX_SHADER_PATH, DEPTH_FRAGMENT_SHADER_PATH);
     return true;
 }
 
@@ -41,6 +42,7 @@ bool ShaderModule::ShutDown()
     glDeleteProgram(specularGeometryPassProgram);
     glDeleteProgram(lightingPassProgram);
     glDeleteProgram(quadProgram);
+    glDeleteProgram(depthProgram);
 
     return true;
 }

--- a/SobrassadaEngine/Modules/ShaderModule.h
+++ b/SobrassadaEngine/Modules/ShaderModule.h
@@ -20,7 +20,8 @@ class ShaderModule : public Module
     int GetSpecularGeometryPassProgram() const;
     int GetLightingPassProgram() const;
     int GetUIWidgetProgram() const { return uiWidgetProgram; }
-        int GetQuadProgram() const { return quadProgram; };
+    int GetQuadProgram() const { return quadProgram; };
+    int GetDepthProgram() const { return depthProgram; };
 
   private:
     char* LoadShaderSource(const char* shaderPath);
@@ -41,4 +42,5 @@ class ShaderModule : public Module
     int uiWidgetProgram                = -1;
 
     int quadProgram                    = -1;
+    int depthProgram                   = -1;
 };

--- a/SobrassadaEngine/Modules/ShaderModule.h
+++ b/SobrassadaEngine/Modules/ShaderModule.h
@@ -20,6 +20,7 @@ class ShaderModule : public Module
     int GetSpecularGeometryPassProgram() const;
     int GetLightingPassProgram() const;
     int GetUIWidgetProgram() const { return uiWidgetProgram; }
+        int GetQuadProgram() const { return quadProgram; };
 
   private:
     char* LoadShaderSource(const char* shaderPath);
@@ -38,4 +39,6 @@ class ShaderModule : public Module
     int lightingPassProgram            = -1;
 
     int uiWidgetProgram                = -1;
+
+    int quadProgram                    = -1;
 };

--- a/SobrassadaEngine/Scene/Components/CameraComponent.h
+++ b/SobrassadaEngine/Scene/Components/CameraComponent.h
@@ -44,6 +44,8 @@ class CameraComponent : public Component
     const float4x4 GetViewMatrix() { return camera.ViewMatrix(); }
     const int GetFrustumType() { return (camera.type == OrthographicFrustum) ? 1 : 0; }
     Framebuffer* GetFramebuffer() { return previewFramebuffer; }
+    float GetNearPlaneDistance() const { return camera.nearPlaneDistance; }
+    float GetFarPlaneDistance() const { return camera.farPlaneDistance; }
 
     void SetAspectRatio(float newAspectRatio);
     void SetCameraPosition(const float3& position) { camera.pos = position; }
@@ -82,5 +84,5 @@ class CameraComponent : public Component
     bool autorendering              = false;
     bool firstFrame                 = false;
     bool freeCamera                 = false;
-    float currentPitchAngle   = 0.f;
+    float currentPitchAngle         = 0.f;
 };

--- a/SobrassadaEngine/Scene/Components/Standalone/MeshComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/MeshComponent.cpp
@@ -21,21 +21,10 @@
 
 MeshComponent::MeshComponent(const UID uid, GameObject* parent) : Component(uid, parent, "Mesh", COMPONENT_MESH)
 {
-    if (currentMesh != nullptr && currentMaterial != nullptr)
-    {
-        batch = App->GetResourcesModule()->GetBatchManager()->RequestBatch(this);
-        batch->AddComponent(this);
-    }
 }
 
 MeshComponent::MeshComponent(const rapidjson::Value& initialState, GameObject* parent) : Component(initialState, parent)
 {
-    if (currentMesh != nullptr && currentMaterial != nullptr)
-    {
-        batch = App->GetResourcesModule()->GetBatchManager()->RequestBatch(this);
-        batch->AddComponent(this);
-    }
-
     if (initialState.HasMember("Material"))
     {
         UID materialUID = initialState["Material"].GetUint64();
@@ -79,6 +68,11 @@ MeshComponent::~MeshComponent()
 
 void MeshComponent::Init()
 {
+    if (currentMesh != nullptr && currentMaterial != nullptr)
+    {
+        batch = App->GetResourcesModule()->GetBatchManager()->RequestBatch(this);
+        batch->AddComponent(this);
+    }
 }
 
 void MeshComponent::Save(rapidjson::Value& targetState, rapidjson::Document::AllocatorType& allocator) const
@@ -218,6 +212,7 @@ void MeshComponent::AddMesh(UID resource, bool updateParent)
         if (currentMaterial == nullptr)
         {
             const UID defaultMat = newMesh->GetDefaultMaterialUID();
+
             AddMaterial(defaultMat, true);
         }
 

--- a/SobrassadaEngine/Scene/Components/Standalone/MeshComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/MeshComponent.cpp
@@ -21,10 +21,21 @@
 
 MeshComponent::MeshComponent(const UID uid, GameObject* parent) : Component(uid, parent, "Mesh", COMPONENT_MESH)
 {
+    if (currentMesh != nullptr && currentMaterial != nullptr)
+    {
+        batch = App->GetResourcesModule()->GetBatchManager()->RequestBatch(this);
+        batch->AddComponent(this);
+    }
 }
 
 MeshComponent::MeshComponent(const rapidjson::Value& initialState, GameObject* parent) : Component(initialState, parent)
 {
+    if (currentMesh != nullptr && currentMaterial != nullptr)
+    {
+        batch = App->GetResourcesModule()->GetBatchManager()->RequestBatch(this);
+        batch->AddComponent(this);
+    }
+
     if (initialState.HasMember("Material"))
     {
         UID materialUID = initialState["Material"].GetUint64();
@@ -68,11 +79,6 @@ MeshComponent::~MeshComponent()
 
 void MeshComponent::Init()
 {
-    if (currentMesh != nullptr && currentMaterial != nullptr)
-    {
-        batch = App->GetResourcesModule()->GetBatchManager()->RequestBatch(this);
-        batch->AddComponent(this);
-    }
 }
 
 void MeshComponent::Save(rapidjson::Value& targetState, rapidjson::Document::AllocatorType& allocator) const

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
@@ -13,6 +13,7 @@
 #include "Standalone/AnimationComponent.h"
 #include "Standalone/Audio/AudioListenerComponent.h"
 #include "Standalone/Audio/AudioSourceComponent.h"
+#include "Standalone/BillboardComponent.h"
 #include "Standalone/CharacterControllerComponent.h"
 #include "Standalone/Lights/DirectionalLightComponent.h"
 #include "Standalone/Lights/PointLightComponent.h"
@@ -26,7 +27,6 @@
 #include "Standalone/UI/ImageComponent.h"
 #include "Standalone/UI/Transform2DComponent.h"
 #include "Standalone/UI/UILabelComponent.h"
-#include "Standalone/BillboardComponent.h"
 
 #include "imgui.h"
 #include <queue>
@@ -460,7 +460,13 @@ void GameObject::RenderEditorInspector()
         if (ImGui::Checkbox("Draw nodes", &drawNodes)) OnDrawConnectionsToggle();
         ImGui::Checkbox("Select parent", &selectParent);
         ImGui::SameLine();
-        ImGui::Checkbox("Navmesh valid", &navMeshValid);
+        if (ImGui::Checkbox("Navmesh valid", &navMeshValid))
+        {
+            if (MeshComponent* meshComp = this->GetComponent<MeshComponent*>())
+            {
+                meshComp->BatchEditorMode();
+            }
+        }
 
         if (ImGui::Button("Add Component"))
         {

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -302,6 +302,8 @@ void Scene::RenderScene(float deltaTime, CameraComponent* camera)
         GeometryPassRender(objectsToRender, camera, gbuffer);
         App->GetOpenGLModule()->SetRenderWireframe(false);
     }
+    else if (App->GetDebugDrawModule()->GetDebugOptionValue(static_cast<int>(DebugOptions::RENDER_NAVMESH_MESHES)))
+        NavMeshPassRender(objectsToRender, camera, gbuffer);
     else GeometryPassRender(objectsToRender, camera, gbuffer);
 
     if (App->GetDebugDrawModule()->GetDebugOptionValue(static_cast<int>(DebugOptions::RENDER_GBUFFERS)))
@@ -309,7 +311,7 @@ void Scene::RenderScene(float deltaTime, CameraComponent* camera)
         RenderGBufferDebug(gbuffer, framebuffer);
         return;
     }
-    if (App->GetDebugDrawModule()->GetDebugOptionValue(static_cast<int>(DebugOptions::RENDER_DEPTH)))
+    else if (App->GetDebugDrawModule()->GetDebugOptionValue(static_cast<int>(DebugOptions::RENDER_DEPTH)))
     {
         RenderDepthDebug(gbuffer, camera, framebuffer);
         return;
@@ -929,6 +931,40 @@ void Scene::GeometryPassRender(
     glEnable(GL_BLEND);
 }
 
+void Scene::NavMeshPassRender(const std::vector<GameObject*>& objectsToRender, CameraComponent* camera, GBuffer* gbuffer) const
+{
+    gbuffer->Bind();
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
+
+    glStencilFunc(GL_ALWAYS, 1, 0xFF);
+    glStencilMask(0xFF);
+
+    glDisable(GL_BLEND);
+
+    BatchManager* batchManager = App->GetResourcesModule()->GetBatchManager();
+    std::vector<MeshComponent*> navMeshesToRender;
+    std::vector<MeshComponent*> nonNavMeshesToRender;
+
+    for (const auto& gameObject : objectsToRender)
+    {
+        MeshComponent* mesh = gameObject->GetComponent<MeshComponent*>();
+        if (mesh != nullptr && mesh->GetEnabled() && mesh->GetBatch() != nullptr)
+        {
+            if (gameObject->IsNavMeshValid()) navMeshesToRender.push_back(mesh);
+            else nonNavMeshesToRender.push_back(mesh);
+        }
+    }
+
+    batchManager->Render(navMeshesToRender, camera);
+    App->GetOpenGLModule()->SetRenderWireframe(true);
+    batchManager->Render(nonNavMeshesToRender, camera);
+    App->GetOpenGLModule()->SetRenderWireframe(false);
+
+    gbuffer->Unbind();
+
+    glEnable(GL_BLEND);
+}
+
 void Scene::RenderGBufferDebug(GBuffer* gbuffer, Framebuffer* framebuffer) const
 {
     unsigned int width  = framebuffer->GetTextureWidth();
@@ -986,7 +1022,7 @@ void Scene::RenderDepthDebug(GBuffer* gbuffer, CameraComponent* camera, Framebuf
     if (camera == nullptr)
     {
         nearPlane = App->GetCameraModule()->GetNearPlaneDistance();
-        farPlane  = App->GetCameraModule()->GetFarPlaneDistance();
+        farPlane  = 100; // App->GetCameraModule()->GetFarPlaneDistance(); This is too much
     }
     else
     {
@@ -994,8 +1030,8 @@ void Scene::RenderDepthDebug(GBuffer* gbuffer, CameraComponent* camera, Framebuf
         farPlane  = camera->GetFarPlaneDistance();
     }
 
-    glUniform3fv(glGetUniformLocation(program, "nearPlane"), 1, &nearPlane);
-    glUniform3fv(glGetUniformLocation(program, "farPlane"), 1, &farPlane);
+    glUniform1f(glGetUniformLocation(program, "nearPlane"), nearPlane);
+    glUniform1f(glGetUniformLocation(program, "farPlane"), farPlane);
     glDrawArrays(GL_TRIANGLES, 0, 3);
 }
 

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -304,6 +304,12 @@ void Scene::RenderScene(float deltaTime, CameraComponent* camera)
     }
     else GeometryPassRender(objectsToRender, camera, gbuffer);
 
+    if (App->GetDebugDrawModule()->GetDebugOptionValue(static_cast<int>(DebugOptions::RENDER_GBUFFERS)))
+    {
+        RenderGBufferDebug(gbuffer, framebuffer);
+        return;
+    }
+
     LightingPassRender(objectsToRender, camera, gbuffer, framebuffer);
 
     {
@@ -918,6 +924,42 @@ void Scene::GeometryPassRender(
     glEnable(GL_BLEND);
 }
 
+void Scene::RenderGBufferDebug(GBuffer* gbuffer, Framebuffer* framebuffer) const
+{
+    unsigned int width  = framebuffer->GetTextureWidth();
+    unsigned int height = framebuffer->GetTextureHeight();
+    framebuffer->Bind();
+
+    const unsigned int program = App->GetShaderModule()->GetQuadProgram();
+    glUseProgram(program);
+
+    GLint loc = glGetUniformLocation(program, "u_Texture");
+    glUniform1i(loc, 0);
+
+    // Top-left: Diffuse
+    glViewport(0, height / 2, width / 2, height / 2);
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, gbuffer->diffuseTexture);
+    glDrawArrays(GL_TRIANGLES, 0, 3);
+
+    // Top-right: Specular
+    glViewport(width / 2, height / 2, width / 2, height / 2);
+    glBindTexture(GL_TEXTURE_2D, gbuffer->specularTexture);
+    glDrawArrays(GL_TRIANGLES, 0, 3);
+
+    // Bottom-left: Position
+    glViewport(0, 0, width / 2, height / 2);
+    glBindTexture(GL_TEXTURE_2D, gbuffer->positionTexture);
+    glDrawArrays(GL_TRIANGLES, 0, 3);
+
+    // Bottom-right: Normal
+    glViewport(width / 2, 0, width / 2, height / 2);
+    glBindTexture(GL_TEXTURE_2D, gbuffer->normalTexture);
+    glDrawArrays(GL_TRIANGLES, 0, 3);
+
+    glViewport(0, 0, width, height);
+}
+
 void Scene::LightingPassRender(
     const std::vector<GameObject*>& renderGameObjects, CameraComponent* camera, GBuffer* gbuffer,
     Framebuffer* framebuffer
@@ -1296,7 +1338,7 @@ void Scene::LoadPrefab(const UID prefabUID, const ResourcePrefab* prefab, const 
             prefab == nullptr ? (const ResourcePrefab*)App->GetResourcesModule()->RequestResource(prefabUID) : prefab;
 
         if (resourcePrefab == nullptr) return; // If the prefab file is corrupted or not available, loading is cancelled
-        
+
         const std::vector<GameObject*>& referenceObjects = resourcePrefab->GetGameObjectsVector();
         const std::vector<int>& parentIndices            = resourcePrefab->GetParentIndices();
 

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -309,6 +309,11 @@ void Scene::RenderScene(float deltaTime, CameraComponent* camera)
         RenderGBufferDebug(gbuffer, framebuffer);
         return;
     }
+    if (App->GetDebugDrawModule()->GetDebugOptionValue(static_cast<int>(DebugOptions::RENDER_DEPTH)))
+    {
+        RenderDepthDebug(gbuffer, camera, framebuffer);
+        return;
+    }
 
     LightingPassRender(objectsToRender, camera, gbuffer, framebuffer);
 
@@ -958,6 +963,40 @@ void Scene::RenderGBufferDebug(GBuffer* gbuffer, Framebuffer* framebuffer) const
     glDrawArrays(GL_TRIANGLES, 0, 3);
 
     glViewport(0, 0, width, height);
+}
+
+void Scene::RenderDepthDebug(GBuffer* gbuffer, CameraComponent* camera, Framebuffer* framebuffer) const
+{
+    unsigned int width  = framebuffer->GetTextureWidth();
+    unsigned int height = framebuffer->GetTextureHeight();
+    framebuffer->Bind();
+
+    const unsigned int program = App->GetShaderModule()->GetDepthProgram();
+    glUseProgram(program);
+
+    GLint loc = glGetUniformLocation(program, "u_Texture");
+    glUniform1i(loc, 0);
+
+    glViewport(0, 0, width, height);
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, gbuffer->GetDepthTexture());
+
+    float nearPlane;
+    float farPlane;
+    if (camera == nullptr)
+    {
+        nearPlane = App->GetCameraModule()->GetNearPlaneDistance();
+        farPlane  = App->GetCameraModule()->GetFarPlaneDistance();
+    }
+    else
+    {
+        nearPlane = camera->GetNearPlaneDistance();
+        farPlane  = camera->GetFarPlaneDistance();
+    }
+
+    glUniform3fv(glGetUniformLocation(program, "nearPlane"), 1, &nearPlane);
+    glUniform3fv(glGetUniformLocation(program, "farPlane"), 1, &farPlane);
+    glDrawArrays(GL_TRIANGLES, 0, 3);
 }
 
 void Scene::LightingPassRender(

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -149,6 +149,9 @@ void Scene::Init()
         if (it == prefabs.end()) prefabs.emplace_back(gameObject.second->GetPrefabUID());
     }
 
+    lightsConfig->InitSkybox();
+    lightsConfig->InitLightBuffers();
+
     for (const UID prefab : prefabs)
     {
         OverridePrefabs(prefab);
@@ -167,9 +170,6 @@ void Scene::Init()
         MeshComponent* mesh = gameObject.second->GetComponent<MeshComponent*>();
         if (mesh) mesh->InitSkin();
     }
-
-    lightsConfig->InitSkybox();
-    lightsConfig->InitLightBuffers();
 
     // Call this after overriding the prefabs to avoid duplicates in gameObjectsToUpdate
     GetGameObjectByUID(gameObjectRootUID)->UpdateTransformForGOBranch();
@@ -934,7 +934,9 @@ void Scene::GeometryPassRender(
     glEnable(GL_BLEND);
 }
 
-void Scene::NavMeshPassRender(const std::vector<GameObject*>& objectsToRender, CameraComponent* camera, GBuffer* gbuffer) const
+void Scene::NavMeshPassRender(
+    const std::vector<GameObject*>& objectsToRender, CameraComponent* camera, GBuffer* gbuffer
+) const
 {
     gbuffer->Bind();
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);

--- a/SobrassadaEngine/Scene/Scene.h
+++ b/SobrassadaEngine/Scene/Scene.h
@@ -133,6 +133,7 @@ class SOBRASADA_API_ENGINE Scene
         Framebuffer* framebuffer
     ) const;
     void RenderGBufferDebug(GBuffer* gbuffer, Framebuffer* framebuffer) const;
+    void RenderDepthDebug(GBuffer* gbuffer, CameraComponent* camera, Framebuffer* framebuffer) const;
 
   private:
     std::string sceneName       = DEFAULT_SCENE_NAME;

--- a/SobrassadaEngine/Scene/Scene.h
+++ b/SobrassadaEngine/Scene/Scene.h
@@ -128,6 +128,8 @@ class SOBRASADA_API_ENGINE Scene
     void CheckObjectsToRender(std::vector<GameObject*>& outRenderGameObjects, CameraComponent* camera) const;
     void GeometryPassRender(const std::vector<GameObject*>& objectsToRender, CameraComponent* camera, GBuffer* gbuffer)
         const;
+    void NavMeshPassRender(const std::vector<GameObject*>& objectsToRender, CameraComponent* camera, GBuffer* gbuffer)
+        const;
     void LightingPassRender(
         const std::vector<GameObject*>& renderGameObjects, CameraComponent* camera, GBuffer* gbuffer,
         Framebuffer* framebuffer

--- a/SobrassadaEngine/Scene/Scene.h
+++ b/SobrassadaEngine/Scene/Scene.h
@@ -132,6 +132,7 @@ class SOBRASADA_API_ENGINE Scene
         const std::vector<GameObject*>& renderGameObjects, CameraComponent* camera, GBuffer* gbuffer,
         Framebuffer* framebuffer
     ) const;
+    void RenderGBufferDebug(GBuffer* gbuffer, Framebuffer* framebuffer) const;
 
   private:
     std::string sceneName       = DEFAULT_SCENE_NAME;

--- a/SobrassadaEngine/Utils/GBuffer.h
+++ b/SobrassadaEngine/Utils/GBuffer.h
@@ -12,6 +12,7 @@ class GBuffer
     void Unbind();
     void Resize(int width, int height);
     void CheckResize();
+    unsigned int GetDepthTexture() const { return depthTexture; }
 
   private:
     void InitializeGBuffer();

--- a/SobrassadaEngine/Utils/Globals.h
+++ b/SobrassadaEngine/Utils/Globals.h
@@ -154,6 +154,7 @@ constexpr const char* GBUFFER_METALLIC_FRAGMENT_SHADER_PATH =
 constexpr const char* GBUFFER_SPECULAR_FRAGMENT_SHADER_PATH =
     "./EngineDefaults/Shader/Fragment/gBufferSpecularFragment.glsl";
 constexpr const char* LIGHTINGPASS_FRAGMENT_SHADER_PATH  = "./EngineDefaults/Shader/Fragment/IBLLightingPass.glsl";
+constexpr const char* QUAD_FRAGMENT_SHADER_PATH        = "./EngineDefaults/Shader/Fragment/QuadFragment.glsl";
 
 using UID                                                = uint64_t;
 

--- a/SobrassadaEngine/Utils/Globals.h
+++ b/SobrassadaEngine/Utils/Globals.h
@@ -155,6 +155,7 @@ constexpr const char* GBUFFER_SPECULAR_FRAGMENT_SHADER_PATH =
     "./EngineDefaults/Shader/Fragment/gBufferSpecularFragment.glsl";
 constexpr const char* LIGHTINGPASS_FRAGMENT_SHADER_PATH  = "./EngineDefaults/Shader/Fragment/IBLLightingPass.glsl";
 constexpr const char* QUAD_FRAGMENT_SHADER_PATH        = "./EngineDefaults/Shader/Fragment/QuadFragment.glsl";
+constexpr const char* DEPTH_FRAGMENT_SHADER_PATH        = "./EngineDefaults/Shader/Fragment/DepthFragment.glsl";
 
 using UID                                                = uint64_t;
 


### PR DESCRIPTION
Testing: There are 3 new render debugs. GBuffers, Depth where you see the textures and Navmesh meshes. All the meshes with NavMesh Valid are rendered normally and the ones without the checkbox is rendered as wireframe. Remember to have objects on scene with the option and without it to see anything