### PR TITLE
task/FireTrapRandomizer-THO-615

### DIFF
--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/FireballTrap.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/FireballTrap.cpp
@@ -12,18 +12,22 @@
 #include "Standalone/Physics/SphereColliderComponent.h"
 
 #include <algorithm>
+#include <cstdlib>
+#include <ctime>
 
 FireballTrap::FireballTrap(GameObject* parent) : Script(parent)
 {
     fields.push_back({"Trap Activated", InspectorField::FieldType::Bool, &activated});
-    fields.push_back({"Activation Range", InspectorField::FieldType::Float, &activationRange, 0.0f, 20.0f});
-    fields.push_back({"Attack Cooldown", InspectorField::FieldType::Float, &attackCooldown, 0.0f, 10.0f});
+    fields.push_back({"Activation Range", InspectorField::FieldType::Float, &activationRange, 0.0f, 100.0f});
+    fields.push_back({"Min Attack Cooldown", InspectorField::FieldType::Float, &minAttackCooldown, 0.0f, 10.0f});
+    fields.push_back({"Max Attack Cooldown", InspectorField::FieldType::Float, &maxAttackCooldown, 0.0f, 30.0f});
     fields.push_back({"Trap Damage", InspectorField::FieldType::Int, &damage, 0, 5});
-    fields.push_back({"Damage Duration", InspectorField::FieldType::Float, &damageDuration, 0.0f, 4.0f});
+    fields.push_back({"Damage Duration", InspectorField::FieldType::Float, &damageDuration, 0.0f, 10.0f});
     fields.push_back({"Fireball Name", InspectorField::FieldType::InputText, &fireballName});
-    fields.push_back({"Rotation Speed", InspectorField::FieldType::Float, &rotationSpeed, 0.0f, 4.0f});
-    fields.push_back({"Falling Height", InspectorField::FieldType::Float, &fallingHeight, 0.0f, 50.0f});
-    fields.push_back({"Max Fall Speed", InspectorField::FieldType::Float, &editableMaxFallSpeed, 0.0f, 40.0f});
+    fields.push_back({"Rotation Speed", InspectorField::FieldType::Float, &rotationSpeed, 0.0f, 100.0f});
+    fields.push_back({"Falling Height", InspectorField::FieldType::Float, &fallingHeight, 0.0f, 200.0f});
+    fields.push_back({"Max Fall Speed", InspectorField::FieldType::Float, &editableMaxFallSpeed, 0.0f, 100.0f});
+    fields.push_back({"Gravity", InspectorField::FieldType::Float, &editableGravity, 0.0f, 20.0f});
 }
 
 bool FireballTrap::Init()
@@ -40,7 +44,8 @@ bool FireballTrap::Init()
     if (fireball) fireball->SetEnabled(false);
     else GLOG("[WARNING] No fireball found by the name: %s", fireballName.c_str())
 
-    lastAttackTime += -attackCooldown;
+    lastAttackTime += -maxAttackCooldown;
+    srand(static_cast<unsigned>(time(0))); // random seed
 
     return true;
 }
@@ -51,13 +56,16 @@ void FireballTrap::Update(float deltaTime)
 
     const float gameTime = AppEngine->GetGameTimer()->GetTime() / 1000.0f;
     maxFallSpeed         = -editableMaxFallSpeed;
+    gravity              = -editableGravity;
 
     const float distance = character->GetLastPosition().Distance(parent->GetPosition());
     activated            = (distance <= activationRange);
 
     if (!activated && !attacking && !isDealingDamage) return;
 
-    if (activated && !attacking && gameTime - lastAttackTime >= attackCooldown)
+    if (randomAttackTime < 0.0f) randomAttackTime = GenerateRandomAttackTime(minAttackCooldown, maxAttackCooldown);
+
+    if (activated && !attacking && gameTime - lastAttackTime >= randomAttackTime)
     {
         StartAttack(gameTime);
     }
@@ -88,6 +96,10 @@ void FireballTrap::StartAttack(float gameTime)
     verticalSpeed  = 0.0f;
     attacking      = true;
     hasImpacted    = false;
+
+    //GLOG("Random time: %.2f", randomAttackTime);
+
+    randomAttackTime = -1.0f;
 }
 
 void FireballTrap::HandleImpact(float gameTime)
@@ -127,4 +139,9 @@ void FireballTrap::UpdateFireball(float deltaTime)
     newTransform.SetTranslatePart(currentPos);
 
     fireball->SetLocalTransform(newTransform);
+}
+
+float FireballTrap::GenerateRandomAttackTime(float min, float max)
+{
+    return min + static_cast<float>(rand()) / (static_cast<float>(RAND_MAX / (max - min)));
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/FireballTrap.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/FireballTrap.h
@@ -20,16 +20,19 @@ class FireballTrap : public Script
     void HandleImpact(float gameTime);
     void DisableDamage();
     void UpdateFireball(float deltaTime);
+    float GenerateRandomAttackTime(float min, float max);
 
   private:
     bool activated                          = false;
     float activationRange                   = 10.0f;
-    float attackCooldown                    = 5.0f;
+    float minAttackCooldown                 = 0.5f;
+    float maxAttackCooldown                 = 3.0f;
+    float randomAttackTime                  = -1.0f;
     int damage                              = 1;
     float damageDuration                    = 1.5f;
     bool attacking                          = false;
 
-    MeshComponent* groundMesh                 = nullptr;
+    MeshComponent* groundMesh               = nullptr;
     SphereColliderComponent* damageCollider = nullptr;
 
     float lastAttackTime                    = -1.0f;
@@ -40,11 +43,11 @@ class FireballTrap : public Script
     std::string fireballName                = "";
     GameObject* fireball                    = nullptr;
     float verticalSpeed                     = 0.0f;
-    float gravity                           = -9.81f;
-    float maxFallSpeed                      = -20.0f;
     bool hasImpacted                        = false;
-
     float rotationSpeed                     = 1.0f;
     float fallingHeight                     = 20.0f;
+    float maxFallSpeed                      = -20.0f;
     float editableMaxFallSpeed              = 20.0f;
+    float gravity                           = -9.81f;
+    float editableGravity                   = 9.81f;
 };


### PR DESCRIPTION
Things done:
· Trap attack cooldown is random now.
· Gravity can be changed through editor in case we want to fall faster/slower.

I tried using LCG rng from globals but have many problems to implement it to the script because of being a external library so I used srand() standard library. Also, I made in a way that this randomizer between a range of two floats can be used in other scripts.

How to test:
There is still a scene in EngineTests repository and branch dev-testing named FireTrapTesting where this new changes can be tested properly. Try changing min and max attack cooldown times to see that randomizer works and same with the gravity for the speed of the fireball falling.