### PR TITLE
THO-624 two sided rendering

### DIFF
--- a/Game/EngineDefaults/Shader/Fragment/gBufferMetallicFragment.glsl
+++ b/Game/EngineDefaults/Shader/Fragment/gBufferMetallicFragment.glsl
@@ -33,6 +33,7 @@ struct Material
 };
 
 uniform bool isWireframe;
+uniform bool isAlpha;
 
 readonly layout(std430, binding = 11) buffer Materials {
     Material materials[];
@@ -52,7 +53,7 @@ void main()
     vec4 texColor = texture(sampler2D(mat.diffuseTex), uv0);
     const float alpha = texColor.a;
 
-    if (!isWireframe)
+    if (!isWireframe && isAlpha)
     {
         if(alpha < 0.1) discard;
     }

--- a/Game/EngineDefaults/Shader/Fragment/gBufferSpecularFragment.glsl
+++ b/Game/EngineDefaults/Shader/Fragment/gBufferSpecularFragment.glsl
@@ -16,6 +16,7 @@ in vec4 tangent;
 flat in int instance_index;
 
 uniform bool isWireframe;
+uniform bool isAlpha;
 
 struct Material
 {
@@ -53,7 +54,7 @@ void main()
     vec4 texColor = texture(sampler2D(mat.diffuseTex), uv0);
     const float alpha = texColor.a;
 
-    if (!isWireframe)
+    if (!isWireframe && isAlpha)
     {
         if(alpha < 0.1) discard;
     }

--- a/SobrassadaEngine/FileSystem/Batching/BatchManager.cpp
+++ b/SobrassadaEngine/FileSystem/Batching/BatchManager.cpp
@@ -120,8 +120,12 @@ void BatchManager::Render(const std::vector<MeshComponent*>& meshesToRender, Cam
         if (it->IsAlpha()) glUniform1i(glGetUniformLocation(program, "isAlpha"), 1);
         else glUniform1i(glGetUniformLocation(program, "isAlpha"), 0);
 
+        if (it->IsDoubleSided()) glDisable(GL_CULL_FACE);
+
         it->ResetUpdatedOnce();
         it->Render(batchMeshes);
+
+        if (it->IsDoubleSided()) glEnable(GL_CULL_FACE);
 
         const auto end                             = std::chrono::high_resolution_clock::now();
         const std::chrono::duration<float> elapsed = end - start;

--- a/SobrassadaEngine/FileSystem/Batching/BatchManager.cpp
+++ b/SobrassadaEngine/FileSystem/Batching/BatchManager.cpp
@@ -200,8 +200,9 @@ void BatchManager::RenderTransparent(const std::vector<MeshComponent*>& meshesTo
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
     currentBatchMeshes.push_back(batchMeshes[0]);
-    if (batchMeshes[0]->GetRenderMode() == 1) glEnable(GL_BLEND);
-    else glDisable(GL_BLEND);
+    glEnable(GL_BLEND);
+
+    if (batchMeshes[0]->GetResourceMaterial()->IsDoubleSided()) glDisable(GL_CULL_FACE);
 
     for (size_t i = 1; i < batchMeshes.size(); ++i)
     {
@@ -217,8 +218,8 @@ void BatchManager::RenderTransparent(const std::vector<MeshComponent*>& meshesTo
             currentBatch->Render(currentBatchMeshes);
             currentBatchMeshes.clear();
 
-            if (batchMeshes[0]->GetRenderMode() == 1) glEnable(GL_BLEND);
-            else glDisable(GL_BLEND);
+            if (batchMeshes[i]->GetResourceMaterial()->IsDoubleSided()) glDisable(GL_CULL_FACE);
+            else glEnable(GL_CULL_FACE);
             currentBatch = batch;
             currentBatchMeshes.push_back(mesh);
         }
@@ -230,6 +231,9 @@ void BatchManager::RenderTransparent(const std::vector<MeshComponent*>& meshesTo
         currentBatch->Render(currentBatchMeshes);
         currentBatchMeshes.clear();
     }
+
+    glEnable(GL_CULL_FACE);
+    glDisable(GL_BLEND);
 }
 
 // We can change that now
@@ -255,7 +259,8 @@ GeometryBatch* BatchManager::RequestBatch(const MeshComponent* component)
         {
             if (it->GetMode() == mesh->GetMode() && it->GetIsMetallic() == material->GetIsMetallicRoughness() &&
                 it->GetHasBones() == component->GetHasBones() &&
-                it->IsNavmeshValid() == component->GetParent()->IsNavMeshValid() && it->IsAlpha() == (component->GetRenderMode() == 2))
+                it->IsNavmeshValid() == component->GetParent()->IsNavMeshValid() &&
+                it->IsAlpha() == (component->GetRenderMode() == 2) && material->IsDoubleSided() == it->IsDoubleSided())
             {
                 return it;
             }

--- a/SobrassadaEngine/FileSystem/Batching/BatchManager.cpp
+++ b/SobrassadaEngine/FileSystem/Batching/BatchManager.cpp
@@ -117,6 +117,9 @@ void BatchManager::Render(const std::vector<MeshComponent*>& meshesToRender, Cam
         if (isWireframe) glUniform1i(glGetUniformLocation(program, "isWireframe"), 1);
         else glUniform1i(glGetUniformLocation(program, "isWireframe"), 0);
 
+        if (it->IsAlpha()) glUniform1i(glGetUniformLocation(program, "isAlpha"), 1);
+        else glUniform1i(glGetUniformLocation(program, "isAlpha"), 0);
+
         it->ResetUpdatedOnce();
         it->Render(batchMeshes);
 
@@ -252,7 +255,7 @@ GeometryBatch* BatchManager::RequestBatch(const MeshComponent* component)
         {
             if (it->GetMode() == mesh->GetMode() && it->GetIsMetallic() == material->GetIsMetallicRoughness() &&
                 it->GetHasBones() == component->GetHasBones() &&
-                it->IsNavmeshValid() == component->GetParent()->IsNavMeshValid())
+                it->IsNavmeshValid() == component->GetParent()->IsNavMeshValid() && it->IsAlpha() == (component->GetRenderMode() == 2))
             {
                 return it;
             }

--- a/SobrassadaEngine/FileSystem/Batching/GeometryBatch.cpp
+++ b/SobrassadaEngine/FileSystem/Batching/GeometryBatch.cpp
@@ -30,6 +30,7 @@ GeometryBatch::GeometryBatch(const MeshComponent* component)
     hasBones   = component->GetHasBones();
     isNavmeshValid = component->GetParent()->IsNavMeshValid();
     isAlpha        = component->GetRenderMode() == 2;
+    isDoubleSided  = component->GetResourceMaterial()->IsDoubleSided();
     glGenVertexArrays(1, &vao);
     glGenBuffers(1, &indirect);
     glGenBuffers(1, &vbo);

--- a/SobrassadaEngine/FileSystem/Batching/GeometryBatch.cpp
+++ b/SobrassadaEngine/FileSystem/Batching/GeometryBatch.cpp
@@ -29,6 +29,7 @@ GeometryBatch::GeometryBatch(const MeshComponent* component)
     isMetallic = component->GetResourceMaterial()->GetIsMetallicRoughness();
     hasBones   = component->GetHasBones();
     isNavmeshValid = component->GetParent()->IsNavMeshValid();
+    isAlpha        = component->GetRenderMode() == 2;
     glGenVertexArrays(1, &vao);
     glGenBuffers(1, &indirect);
     glGenBuffers(1, &vbo);

--- a/SobrassadaEngine/FileSystem/Batching/GeometryBatch.h
+++ b/SobrassadaEngine/FileSystem/Batching/GeometryBatch.h
@@ -35,6 +35,7 @@ class GeometryBatch
     const bool GetHasBones() const { return hasBones; }
     const bool IsNavmeshValid() const { return isNavmeshValid; }
     const bool IsTransparent() const { return isTransparent; }
+    const bool IsAlpha() const { return isAlpha; }
     const unsigned int GetVertexCount() const { return totalVertexCount; }
     const unsigned int GetIndexCount() const { return totalIndexCount; }
     void ResetUpdatedOnce() { updatedOnce = false; }
@@ -85,4 +86,5 @@ class GeometryBatch
     bool hasBones                 = false;
     bool isNavmeshValid           = false;
     bool isTransparent            = false;
+    bool isAlpha                  = false;
 };

--- a/SobrassadaEngine/FileSystem/Batching/GeometryBatch.h
+++ b/SobrassadaEngine/FileSystem/Batching/GeometryBatch.h
@@ -36,6 +36,7 @@ class GeometryBatch
     const bool IsNavmeshValid() const { return isNavmeshValid; }
     const bool IsTransparent() const { return isTransparent; }
     const bool IsAlpha() const { return isAlpha; }
+    const bool IsDoubleSided() const { return isDoubleSided; }
     const unsigned int GetVertexCount() const { return totalVertexCount; }
     const unsigned int GetIndexCount() const { return totalIndexCount; }
     void ResetUpdatedOnce() { updatedOnce = false; }
@@ -87,4 +88,5 @@ class GeometryBatch
     bool isNavmeshValid           = false;
     bool isTransparent            = false;
     bool isAlpha                  = false;
+    bool isDoubleSided            = false;
 };

--- a/SobrassadaEngine/FileSystem/Importers/MaterialImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/MaterialImporter.cpp
@@ -25,6 +25,8 @@ UID MaterialImporter::ImportMaterial(
     const tinygltf::Material& gltfMaterial = model.materials[materialIndex];
     std::string materialName               = gltfMaterial.name;
     const bool isTransparent               = gltfMaterial.alphaMode == "BLEND";
+    const bool isDoubleSided               = gltfMaterial.doubleSided;
+    
 
     int sizeofStrings                      = 0;
     auto it                                = gltfMaterial.extensions.find("KHR_materials_pbrSpecularGlossiness");
@@ -170,6 +172,7 @@ UID MaterialImporter::ImportMaterial(
     }
 
     material.SetTransparent(isTransparent);
+    material.SetDoubleSide(isDoubleSided);
 
     unsigned int size = sizeof(Material);
     char* fileBuffer  = new char[size];
@@ -194,7 +197,7 @@ UID MaterialImporter::ImportMaterial(
         if (materialName.empty()) materialName = "MaterialType_" + std::to_string(tmpName);
 
         std::string assetPath = ASSETS_PATH + FileSystem::GetFileNameWithExtension(sourceFilePath);
-        MetaMaterial meta(finalMaterialUID, assetPath, tmpNameString, useOcclusion, defaultTextureUID, isTransparent);
+        MetaMaterial meta(finalMaterialUID, assetPath, tmpNameString, useOcclusion, defaultTextureUID, isTransparent, isDoubleSided);
         meta.Save(materialName, assetPath);
     }
     else finalMaterialUID = sourceUID;

--- a/SobrassadaEngine/FileSystem/Material.h
+++ b/SobrassadaEngine/FileSystem/Material.h
@@ -26,6 +26,7 @@ class Material
     const UID GetOcclusionTexture() const { return occlusionTexture; }
 
     const bool IsTransparent() const { return isTransparent; }
+    const bool IsDoubleSided() const { return isDoubleSided; }
 
     const UID GetMaterialUID() const { return materialUID; }
 
@@ -44,6 +45,7 @@ class Material
     void SetOcclusionTexture(UID texture) { occlusionTexture = texture; }
 
     void SetTransparent(bool transparent) { isTransparent = transparent; }
+    void SetDoubleSide(bool isDoubleSided) { isDoubleSided = isDoubleSided; }
 
     void SetMaterialUID(UID uid) { materialUID = uid; }
 
@@ -67,4 +69,5 @@ class Material
     UID metallicRoughnessTexture  = INVALID_UID;
 
     bool isTransparent            = false;
+    bool isDoubleSided            = false;
 };

--- a/SobrassadaEngine/FileSystem/Meta/MetaMaterial.cpp
+++ b/SobrassadaEngine/FileSystem/Meta/MetaMaterial.cpp
@@ -1,8 +1,8 @@
 #include "MetaMaterial.h"
 
-MetaMaterial::MetaMaterial(UID uid, const std::string& assetPath, const std::string& shader, bool useOcclusion, UID defaultTextureUID, bool isTransparent)
+MetaMaterial::MetaMaterial(UID uid, const std::string& assetPath, const std::string& shader, bool useOcclusion, UID defaultTextureUID, bool isTransparent, bool isDoubleSided)
     : MetaFile(uid, assetPath), shader(shader), useOcclusion(useOcclusion), defaultTextureUID(defaultTextureUID),
-      isTransparent(isTransparent)
+      isTransparent(isTransparent), isDoubleSided(isDoubleSided)
 {
 }
 
@@ -13,5 +13,6 @@ void MetaMaterial::AddImportOptions(rapidjson::Document& doc, rapidjson::Documen
     importOptions.AddMember("useOcclusion", useOcclusion, allocator);
     importOptions.AddMember("defaultTextureUID", defaultTextureUID, allocator);
     importOptions.AddMember("isTransparent", isTransparent, allocator);
+    importOptions.AddMember("isDoubleSided", isDoubleSided, allocator);
     doc.AddMember("importOptions", importOptions, allocator);
 }

--- a/SobrassadaEngine/FileSystem/Meta/MetaMaterial.h
+++ b/SobrassadaEngine/FileSystem/Meta/MetaMaterial.h
@@ -5,13 +5,14 @@
 class MetaMaterial : public MetaFile
 {
   public:
-    MetaMaterial(UID uid, const std::string& assetPath, const std::string& shader, bool useOcclusion, UID defaultTextureUID, bool isTransparent);
+    MetaMaterial(UID uid, const std::string& assetPath, const std::string& shader, bool useOcclusion, UID defaultTextureUID, bool isTransparent, bool isDoubleSided);
     void AddImportOptions(rapidjson::Document& doc, rapidjson::Document::AllocatorType& allocator) const override;
 
   private:
     std::string shader;
     bool useOcclusion;
     bool isTransparent;
+    bool isDoubleSided;
 
     UID defaultTextureUID = INVALID_UID;
 };

--- a/SobrassadaEngine/ResourceManagement/Resources/ResourceMaterial.cpp
+++ b/SobrassadaEngine/ResourceManagement/Resources/ResourceMaterial.cpp
@@ -22,6 +22,10 @@ ResourceMaterial::ResourceMaterial(UID uid, const std::string& name, const rapid
     if (importOptions.HasMember("isTransparent") && importOptions["isTransparent"].IsBool())
         isTransparent = importOptions["isTransparent"].GetBool();
     else isTransparent = false;
+
+    if (importOptions.HasMember("isDoubleSided") && importOptions["isDoubleSided"].IsBool())
+        doubleSided = importOptions["isDoubleSided"].GetBool();
+    else doubleSided = false;
 }
 
 ResourceMaterial::~ResourceMaterial()
@@ -216,6 +220,7 @@ void ResourceMaterial::LoadMaterialData(Material mat)
     material.roughnessFactor     = mat.GetRoughnessFactor();
     material.shininessInAlpha    = false;
     isTransparent                = mat.IsTransparent();
+    doubleSided                  = mat.IsDoubleSided();
 
     ResourceTexture* diffTexture = TextureImporter::LoadTexture(mat.GetDiffuseTexture());
     if (diffTexture != nullptr)

--- a/SobrassadaEngine/ResourceManagement/Resources/ResourceMaterial.cpp
+++ b/SobrassadaEngine/ResourceManagement/Resources/ResourceMaterial.cpp
@@ -4,12 +4,16 @@
 #include "EditorUIModule.h"
 #include "FileSystem/Material.h"
 #include "LibraryModule.h"
-
+#include "ProjectModule.h"
+#include "FileSystem.h"
 #include "ResourceTexture.h"
 #include "TextureImporter.h"
 
 #include "glew.h"
 #include "imgui.h"
+#include <rapidjson/prettywriter.h>
+#include <rapidjson/stringbuffer.h>
+
 
 ResourceMaterial::ResourceMaterial(UID uid, const std::string& name, const rapidjson::Value& importOptions)
     : Resource(uid, name, ResourceType::Material)
@@ -37,6 +41,7 @@ void ResourceMaterial::OnEditorUpdate()
 {
     bool updated = false;
 
+    updated |= ImGui::Checkbox("Double Sided", &doubleSided);
     if (diffuseTexture.textureID != 0)
     {
         ImGui::Text("Diffuse Texture");
@@ -46,7 +51,7 @@ void ResourceMaterial::OnEditorUpdate()
             ImGui::SetTooltip("Texture Dimensions: %d, %d", diffuseTexture.width, diffuseTexture.height);
         }
 
-        // ImGui::SameLine();
+         ImGui::SameLine();
 
         // TODO: commented all select buttons until save data to meta is implemented
         /*if (ImGui::Button("Select Diffuse Texture"))
@@ -179,8 +184,59 @@ void ResourceMaterial::OnEditorUpdate()
         }*/
     }
 
-    // TODO: override metadata material
-    // if (updated)
+    if (updated) SaveToMeta();
+}
+
+void ResourceMaterial::SaveToMeta()
+{
+    std::string path               = App->GetLibraryModule()->GetResourcePath(uid);
+    const std::string& projectPath = App->GetProjectModule()->GetLoadedProjectPath();
+    rapidjson::Document doc;
+    for (const auto& entry : std::filesystem::recursive_directory_iterator(projectPath + METADATA_PATH))
+    {
+        if (FileSystem::GetFileExtension(entry.path().string()) == META_EXTENSION)
+        {
+            std::string filePath = entry.path().string();
+            if (!FileSystem::LoadJSON(filePath.c_str(), doc)) continue;
+
+            UID assetUID = doc["UID"].GetUint64();
+
+            if (uid == assetUID)
+            {
+                rapidjson::Document::AllocatorType& allocator = doc.GetAllocator();
+
+                // Read
+                UID shaderUID                                 = 0;
+                bool useOcclusion                             = false;
+                if (doc.HasMember("importOptions") && doc["importOptions"].IsObject())
+                {
+                    const auto& opts = doc["importOptions"];
+                    if (opts.HasMember("shader") && opts["shader"].IsUint64()) shaderUID = opts["shader"].GetUint64();
+                    if (opts.HasMember("useOcclusion") && opts["useOcclusion"].IsBool())
+                        useOcclusion = opts["useOcclusion"].GetBool();
+                }
+
+                rapidjson::Value importOptions(rapidjson::kObjectType);
+                importOptions.AddMember("shader", rapidjson::Value().SetUint64(shaderUID), allocator);
+                importOptions.AddMember("useOcclusion", useOcclusion, allocator);
+                importOptions.AddMember(
+                    "defaultTextureUID", rapidjson::Value().SetUint64(defaultTextureUID), allocator
+                );
+                importOptions.AddMember("isTransparent", isTransparent, allocator);
+                importOptions.AddMember("isDoubleSided", doubleSided, allocator);
+
+                if (doc.HasMember("importOptions")) doc["importOptions"] = importOptions;
+                else doc.AddMember("importOptions", importOptions, allocator);
+
+                rapidjson::StringBuffer buffer;
+                rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(buffer);
+                doc.Accept(writer);
+
+                FileSystem::Save(filePath.c_str(), buffer.GetString(), (unsigned int)buffer.GetSize(), false);
+                return;
+            }
+        }
+    }
 }
 
 UID ResourceMaterial::ChangeTexture(UID newTexture, TextureInfo& textureToChange, UID textureGPU)

--- a/SobrassadaEngine/ResourceManagement/Resources/ResourceMaterial.cpp
+++ b/SobrassadaEngine/ResourceManagement/Resources/ResourceMaterial.cpp
@@ -220,7 +220,6 @@ void ResourceMaterial::LoadMaterialData(Material mat)
     material.roughnessFactor     = mat.GetRoughnessFactor();
     material.shininessInAlpha    = false;
     isTransparent                = mat.IsTransparent();
-    doubleSided                  = mat.IsDoubleSided();
 
     ResourceTexture* diffTexture = TextureImporter::LoadTexture(mat.GetDiffuseTexture());
     if (diffTexture != nullptr)

--- a/SobrassadaEngine/ResourceManagement/Resources/ResourceMaterial.h
+++ b/SobrassadaEngine/ResourceManagement/Resources/ResourceMaterial.h
@@ -44,6 +44,7 @@ class ResourceMaterial : public Resource
 
     UID ChangeTexture(UID newTexture, TextureInfo& textureToChange, UID textureGPU);
     void ChangeFallBackTexture();
+    void SaveToMeta();
 
     void SetTransparent(const bool transparent) { isTransparent = transparent; }
 

--- a/SobrassadaEngine/ResourceManagement/Resources/ResourceMaterial.h
+++ b/SobrassadaEngine/ResourceManagement/Resources/ResourceMaterial.h
@@ -51,6 +51,7 @@ class ResourceMaterial : public Resource
     const bool GetIsMetallicRoughness() const { return metallicTexture.textureID != 0 ? true : false; }
     const MaterialGPU GetMaterial() const { return material; }
     const bool IsTransparent() const { return isTransparent; }
+    const bool IsDoubleSided() const { return doubleSided; }
 
     unsigned int GetDiffuseColorID() const { return diffuseTexture.textureID; }
 
@@ -62,5 +63,6 @@ class ResourceMaterial : public Resource
 
     MaterialGPU material;
     bool isTransparent    = false;
+    bool doubleSided      = false;
     UID defaultTextureUID = INVALID_UID;
 };


### PR DESCRIPTION
Testing: Added double side rendering. It has a checkbox in the material for already imported meshes.
Also added a condition in opaque objects to solve the bug of seeing transparent instead of black.
I added the plants as a good example of a double side render. You can enable/disable to check the rendering
[TEST.zip](https://github.com/user-attachments/files/20401154/TEST.zip)
