### PR TITLE
Updated fireball trap to work with new hierarchy THO-634

### DIFF
--- a/SobrassadaEngine/Scene/Components/Standalone/CharacterControllerComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/CharacterControllerComponent.cpp
@@ -118,7 +118,7 @@ void CharacterControllerComponent::Update(float time) // SO many navmesh getters
 {
     if (!IsEffectivelyEnabled() || !inputDown) return;
 
-    if (!App->GetSceneModule()->GetInPlayMode() || !inputDown) return;
+    if (!App->GetSceneModule()->GetInPlayMode()) return;
 
     float deltaTime = App->GetGameTimer()->GetDeltaTime() / 1000.0f;
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/FireballTrap.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/FireballTrap.cpp
@@ -23,7 +23,6 @@ FireballTrap::FireballTrap(GameObject* parent) : Script(parent)
     fields.push_back({"Max Attack Cooldown", InspectorField::FieldType::Float, &maxAttackCooldown, 0.0f, 30.0f});
     fields.push_back({"Trap Damage", InspectorField::FieldType::Int, &damage, 0, 5});
     fields.push_back({"Damage Duration", InspectorField::FieldType::Float, &damageDuration, 0.0f, 10.0f});
-    fields.push_back({"Fireball Name", InspectorField::FieldType::InputText, &fireballName});
     fields.push_back({"Rotation Speed", InspectorField::FieldType::Float, &rotationSpeed, 0.0f, 100.0f});
     fields.push_back({"Falling Height", InspectorField::FieldType::Float, &fallingHeight, 0.0f, 200.0f});
     fields.push_back({"Max Fall Speed", InspectorField::FieldType::Float, &editableMaxFallSpeed, 0.0f, 100.0f});
@@ -40,9 +39,12 @@ bool FireballTrap::Init()
     if (damageCollider) damageCollider->SetEnabled(false);
     else GLOG("[WARNING] FireballTrap without sphere collider component.");
 
-    fireball = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(fireballName);
-    if (fireball) fireball->SetEnabled(false);
-    else GLOG("[WARNING] No fireball found by the name: %s", fireballName.c_str())
+    if (parent->GetChildren().size() > 0)
+    {
+        fireball = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByUID(parent->GetChildren()[0]);
+        if (fireball) fireball->SetEnabled(false);
+        else GLOG("[WARNING] No fireball found as child of base")
+    }
 
     lastAttackTime += -maxAttackCooldown;
     srand(static_cast<unsigned>(time(0))); // random seed
@@ -58,8 +60,8 @@ void FireballTrap::Update(float deltaTime)
     maxFallSpeed         = -editableMaxFallSpeed;
     gravity              = -editableGravity;
 
-    const float distance = character->GetLastPosition().Distance(parent->GetGlobalTransform().TranslatePart());
-    activated            = (distance <= activationRange);
+    const float distance = character->GetLastPosition().DistanceSq(parent->GetGlobalTransform().TranslatePart());
+    activated            = (distance <= activationRange * activationRange);
 
     if (!activated && !attacking && !isDealingDamage) return;
 
@@ -89,8 +91,7 @@ void FireballTrap::Update(float deltaTime)
 void FireballTrap::StartAttack(float gameTime)
 {
     fireball->SetEnabled(true);
-    const float3 startPos = parent->GetGlobalTransform().TranslatePart() + float3(0.0f, fallingHeight, 0.0f);
-    fireball->SetLocalPosition(startPos);
+    fireball->SetLocalPosition(float3(0.0f, fallingHeight, 0.0f));
 
     lastAttackTime = gameTime;
     verticalSpeed  = 0.0f;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/FireballTrap.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/FireballTrap.h
@@ -40,7 +40,6 @@ class FireballTrap : public Script
     bool isDealingDamage                    = false;
 
     // fireball
-    std::string fireballName                = "";
     GameObject* fireball                    = nullptr;
     float verticalSpeed                     = 0.0f;
     bool hasImpacted                        = false;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj.filters
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj.filters
@@ -19,14 +19,14 @@
     <Filter Include="Characters\Enemies">
       <UniqueIdentifier>{7c5918da-d273-43d8-987f-06ca46cebfbc}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Characters\Traps">
-      <UniqueIdentifier>{542608f8-4ab9-4512-8882-308a6eaeec76}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Characters\Camera">
       <UniqueIdentifier>{b8735c84-329e-48d9-9802-05cfa1b5f7ef}</UniqueIdentifier>
     </Filter>
     <Filter Include="Environment">
       <UniqueIdentifier>{9afcd9ac-fa5f-45af-ac0b-16d450c5873d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Environment\Traps">
+      <UniqueIdentifier>{542608f8-4ab9-4512-8882-308a6eaeec76}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -89,7 +89,7 @@
       <Filter>Utils</Filter>
     </ClInclude>
     <ClInclude Include="FireballTrap.h">
-      <Filter>Characters\Traps</Filter>
+      <Filter>Environment\Traps</Filter>
     </ClInclude>
     <ClInclude Include="FreeCamera.h">
       <Filter>Utils</Filter>
@@ -739,7 +739,7 @@
       <Filter>Characters\Enemies</Filter>
     </ClCompile>
     <ClCompile Include="FireballTrap.cpp">
-      <Filter>Characters\Traps</Filter>
+      <Filter>Environment\Traps</Filter>
     </ClCompile>
     <ClCompile Include="FreeCamera.cpp">
       <Filter>Utils</Filter>


### PR DESCRIPTION
Now the fire trap base serves as the main position anchor, so the pivot for moving it around is in the middle of the trap itself. 
Also improved efficency of distance calculation to the player.
For testing, go to dev-test and open the Fire ball scene and check that the pivot for the trap is at the center and the trap still works