### PR TITLE
Task/fire trap improvements THO-640

### DIFF
--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/FireballTrap.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/FireballTrap.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <ctime>
+#include <Math/MathConstants.h>
 
 FireballTrap::FireballTrap(GameObject* parent) : Script(parent)
 {
@@ -62,34 +63,32 @@ void FireballTrap::Update(float deltaTime)
     // TODO Make all movement depended on the deltaTime
     if (!character || !groundMesh || !damageCollider || !fireball) return;
 
-    if (activationState == SLEEPING)
+    float distance; 
+    switch (activationState)
     {
-        const float distance = character->GetLastPosition().DistanceSq(parent->GetGlobalTransform().TranslatePart());
-        if (distance <= activationRange * activationRange)
-        {
-            randomAttackTime = GenerateRandomAttackTime(minAttackCooldown, maxAttackCooldown);
-            activationState = IDLE;
-        }
-        return;
+        case SLEEPING:
+            distance = character->GetLastPosition().DistanceSq(parent->GetGlobalTransform().TranslatePart());
+            if (distance <= activationRange * activationRange)
+            {
+                randomAttackTime = GenerateRandomAttackTime(minAttackCooldown, maxAttackCooldown);
+                activatedTime = 0.0f;
+                activationState = IDLE;
+            }
+            break;
+        case IDLE:
+            activatedTime += deltaTime;
+            if (activatedTime >= randomAttackTime)
+                StartAttack();
+            break;
+        case DROPPING:
+            UpdateFireball(deltaTime);
+            break;
+        case DAMAGING:
+            activatedTime += deltaTime;
+            if (activatedTime - randomAttackTime >= damageDuration) // Not fully accurate, but probably ok
+                DisableDamage();
+            break;
     }
-
-    if (!attacking && activatedTime >= randomAttackTime)
-    {
-        StartAttack();
-    } else if (attacking && !hasImpacted)
-    {
-        UpdateFireball(deltaTime);
-    } else if (attacking && fireball->GetGlobalTransform().TranslatePart().y <= parent->GetGlobalTransform().TranslatePart().y)
-    {
-        HandleImpact();
-    } else if (isDealingDamage && activatedTime - randomAttackTime >= damageDuration)
-    {
-        DisableDamage();
-        randomAttackTime = GenerateRandomAttackTime(minAttackCooldown, maxAttackCooldown);
-        activatedTime = 0;
-    }
-
-    activatedTime += deltaTime;
 }
 
 void FireballTrap::StartAttack()
@@ -100,12 +99,7 @@ void FireballTrap::StartAttack()
     if (fireballShadow != nullptr)  fireballShadow->SetEnabled(true);
 
     verticalSpeed  = 0.0f;
-    attacking      = true;
-    hasImpacted    = false;
-
-    // GLOG("Random time: %.2f", randomAttackTime);
-
-    randomAttackTime = -1.0f;
+    activationState = DROPPING;
 }
 
 void FireballTrap::HandleImpact()
@@ -115,9 +109,7 @@ void FireballTrap::HandleImpact()
     groundMesh->SetEnabled(true);
     damageCollider->SetEnabled(true);
 
-    attacking       = false;
-    isDealingDamage = true;
-    hasImpacted     = true;
+    activationState = DAMAGING;
 }
 
 void FireballTrap::DisableDamage()
@@ -125,26 +117,29 @@ void FireballTrap::DisableDamage()
     groundMesh->SetEnabled(false);
     damageCollider->SetEnabled(false);
 
-    isDealingDamage = false;
+    activationState = SLEEPING;
 }
 
 void FireballTrap::UpdateFireball(float deltaTime)
 {
     float4x4 newTransform = fireball->GetLocalTransform();
     float3 currentPos     = newTransform.TranslatePart();
-
-    if (deltaTime < 0.1f)
+    if (deltaTime < 0.5f)
     {
-        verticalSpeed += -editableGravity * deltaTime;
-        verticalSpeed  = std::max(verticalSpeed, -editableMaxFallSpeed); // Clamp fall speed
-
-        currentPos.y  += (verticalSpeed * deltaTime);
+        verticalSpeed = std::min(verticalSpeed + editableGravity * deltaTime, editableMaxFallSpeed); // Clamp fall speed
+        currentPos.y  -= verticalSpeed;
     }
 
-    newTransform = newTransform * float4x4::RotateX(rotationSpeed * deltaTime);
-    newTransform.SetTranslatePart(currentPos);
+    if (currentPos.y <= groundMesh->GetGlobalTransform().TranslatePart().y)
+    {
+        HandleImpact();
+    } else
+    {
+        newTransform = newTransform * float4x4::RotateX(rotationSpeed * deltaTime);
+        newTransform.SetTranslatePart(currentPos);
 
-    fireball->SetLocalTransform(newTransform);
+        fireball->SetLocalTransform(newTransform);
+    }
 }
 
 float FireballTrap::GenerateRandomAttackTime(float min, float max)

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/FireballTrap.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/FireballTrap.cpp
@@ -124,13 +124,14 @@ void FireballTrap::UpdateFireball(float deltaTime)
 {
     float4x4 newTransform = fireball->GetLocalTransform();
     float3 currentPos     = newTransform.TranslatePart();
+    
     if (deltaTime < 0.5f)
     {
         verticalSpeed = std::min(verticalSpeed + editableGravity * deltaTime, editableMaxFallSpeed); // Clamp fall speed
-        currentPos.y  -= verticalSpeed;
+        currentPos.y  -= verticalSpeed * deltaTime;
     }
-
-    if (currentPos.y <= groundMesh->GetGlobalTransform().TranslatePart().y)
+    
+    if (currentPos.y <= 0)
     {
         HandleImpact();
     } else

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/FireballTrap.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/FireballTrap.cpp
@@ -17,7 +17,6 @@
 
 FireballTrap::FireballTrap(GameObject* parent) : Script(parent)
 {
-    fields.push_back({"Trap Activated", InspectorField::FieldType::Bool, &activated});
     fields.push_back({"Activation Range", InspectorField::FieldType::Float, &activationRange, 0.0f, 100.0f});
     fields.push_back({"Min Attack Cooldown", InspectorField::FieldType::Float, &minAttackCooldown, 0.0f, 10.0f});
     fields.push_back({"Max Attack Cooldown", InspectorField::FieldType::Float, &maxAttackCooldown, 0.0f, 30.0f});
@@ -52,8 +51,7 @@ bool FireballTrap::Init()
         if (fireballShadow) fireballShadow->SetEnabled(false);
         else GLOG("[WARNING] No fireball shadow found as child of base")
     }
-
-    lastAttackTime += -maxAttackCooldown;
+    
     srand(static_cast<unsigned>(time(0))); // random seed
 
     return true;
@@ -61,48 +59,46 @@ bool FireballTrap::Init()
 
 void FireballTrap::Update(float deltaTime)
 {
+    // TODO Make all movement depended on the deltaTime
     if (!character || !groundMesh || !damageCollider || !fireball) return;
 
-    const float gameTime = AppEngine->GetGameTimer()->GetTime() / 1000.0f;
-    maxFallSpeed         = -editableMaxFallSpeed;
-    gravity              = -editableGravity;
-
-    const float distance = character->GetLastPosition().DistanceSq(parent->GetGlobalTransform().TranslatePart());
-    activated            = (distance <= activationRange * activationRange);
-
-    if (!activated && !attacking && !isDealingDamage) return;
-
-    if (randomAttackTime < 0.0f) randomAttackTime = GenerateRandomAttackTime(minAttackCooldown, maxAttackCooldown);
-
-    if (activated && !attacking && gameTime - lastAttackTime >= randomAttackTime)
+    if (activationState == SLEEPING)
     {
-        StartAttack(gameTime);
+        const float distance = character->GetLastPosition().DistanceSq(parent->GetGlobalTransform().TranslatePart());
+        if (distance <= activationRange * activationRange)
+        {
+            randomAttackTime = GenerateRandomAttackTime(minAttackCooldown, maxAttackCooldown);
+            activationState = IDLE;
+        }
+        return;
     }
 
-    if (attacking && !hasImpacted)
+    if (!attacking && activatedTime >= randomAttackTime)
+    {
+        StartAttack();
+    } else if (attacking && !hasImpacted)
     {
         UpdateFireball(deltaTime);
-    }
-
-    if (attacking && fireball->GetGlobalTransform().TranslatePart().y <= parent->GetGlobalTransform().TranslatePart().y)
+    } else if (attacking && fireball->GetGlobalTransform().TranslatePart().y <= parent->GetGlobalTransform().TranslatePart().y)
     {
-        HandleImpact(gameTime);
-    }
-
-    if (isDealingDamage && gameTime - lastHitTime >= damageDuration)
+        HandleImpact();
+    } else if (isDealingDamage && activatedTime - randomAttackTime >= damageDuration)
     {
         DisableDamage();
+        randomAttackTime = GenerateRandomAttackTime(minAttackCooldown, maxAttackCooldown);
+        activatedTime = 0;
     }
+
+    activatedTime += deltaTime;
 }
 
-void FireballTrap::StartAttack(float gameTime)
+void FireballTrap::StartAttack()
 {
     fireball->SetEnabled(true);
     fireball->SetLocalPosition(float3(0.0f, fallingHeight, 0.0f));
 
     if (fireballShadow != nullptr)  fireballShadow->SetEnabled(true);
 
-    lastAttackTime = gameTime;
     verticalSpeed  = 0.0f;
     attacking      = true;
     hasImpacted    = false;
@@ -112,7 +108,7 @@ void FireballTrap::StartAttack(float gameTime)
     randomAttackTime = -1.0f;
 }
 
-void FireballTrap::HandleImpact(float gameTime)
+void FireballTrap::HandleImpact()
 {
     fireball->SetEnabled(false);
     if (fireballShadow != nullptr)  fireballShadow->SetEnabled(false);
@@ -121,7 +117,6 @@ void FireballTrap::HandleImpact(float gameTime)
 
     attacking       = false;
     isDealingDamage = true;
-    lastHitTime     = gameTime;
     hasImpacted     = true;
 }
 
@@ -140,8 +135,8 @@ void FireballTrap::UpdateFireball(float deltaTime)
 
     if (deltaTime < 0.1f)
     {
-        verticalSpeed += gravity * deltaTime;
-        verticalSpeed  = std::max(verticalSpeed, maxFallSpeed); // Clamp fall speed
+        verticalSpeed += -editableGravity * deltaTime;
+        verticalSpeed  = std::max(verticalSpeed, -editableMaxFallSpeed); // Clamp fall speed
 
         currentPos.y  += (verticalSpeed * deltaTime);
     }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/FireballTrap.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/FireballTrap.cpp
@@ -46,6 +46,13 @@ bool FireballTrap::Init()
         else GLOG("[WARNING] No fireball found as child of base")
     }
 
+    if (parent->GetChildren().size() > 1)
+    {
+        fireballShadow = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByUID(parent->GetChildren()[1]);
+        if (fireballShadow) fireballShadow->SetEnabled(false);
+        else GLOG("[WARNING] No fireball shadow found as child of base")
+    }
+
     lastAttackTime += -maxAttackCooldown;
     srand(static_cast<unsigned>(time(0))); // random seed
 
@@ -93,6 +100,8 @@ void FireballTrap::StartAttack(float gameTime)
     fireball->SetEnabled(true);
     fireball->SetLocalPosition(float3(0.0f, fallingHeight, 0.0f));
 
+    if (fireballShadow != nullptr)  fireballShadow->SetEnabled(true);
+
     lastAttackTime = gameTime;
     verticalSpeed  = 0.0f;
     attacking      = true;
@@ -106,6 +115,7 @@ void FireballTrap::StartAttack(float gameTime)
 void FireballTrap::HandleImpact(float gameTime)
 {
     fireball->SetEnabled(false);
+    if (fireballShadow != nullptr)  fireballShadow->SetEnabled(false);
     groundMesh->SetEnabled(true);
     damageCollider->SetEnabled(true);
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/FireballTrap.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/FireballTrap.h
@@ -6,6 +6,14 @@ class GameObject;
 class MeshComponent;
 class SphereColliderComponent;
 
+enum ACTIVATION_STATE
+{
+    SLEEPING,
+    IDLE,
+    DROPPING,
+    DAMAGING,
+};
+
 class FireballTrap : public Script
 {
   public:
@@ -16,8 +24,8 @@ class FireballTrap : public Script
     int GetDamage() const { return damage; }
 
   private:
-    void StartAttack(float gameTime);
-    void HandleImpact(float gameTime);
+    void StartAttack();
+    void HandleImpact();
     void DisableDamage();
     void UpdateFireball(float deltaTime);
     float GenerateRandomAttackTime(float min, float max);
@@ -35,8 +43,7 @@ class FireballTrap : public Script
     MeshComponent* groundMesh               = nullptr;
     SphereColliderComponent* damageCollider = nullptr;
 
-    float lastAttackTime                    = -1.0f;
-    float lastHitTime                       = -1.0f;
+    float activatedTime                     = 0.0f;
     bool isDealingDamage                    = false;
 
     // fireball
@@ -48,8 +55,8 @@ class FireballTrap : public Script
     bool hasImpacted                        = false;
     float rotationSpeed                     = 1.0f;
     float fallingHeight                     = 20.0f;
-    float maxFallSpeed                      = -20.0f;
     float editableMaxFallSpeed              = 20.0f;
-    float gravity                           = -9.81f;
     float editableGravity                   = 9.81f;
+
+    ACTIVATION_STATE activationState = SLEEPING;
 };

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/FireballTrap.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/FireballTrap.h
@@ -31,20 +31,17 @@ class FireballTrap : public Script
     float GenerateRandomAttackTime(float min, float max);
 
   private:
-    bool activated                          = false;
     float activationRange                   = 10.0f;
     float minAttackCooldown                 = 0.5f;
     float maxAttackCooldown                 = 3.0f;
-    float randomAttackTime                  = -1.0f;
+    float randomAttackTime                  = 0.0f;
     int damage                              = 1;
     float damageDuration                    = 1.5f;
-    bool attacking                          = false;
 
     MeshComponent* groundMesh               = nullptr;
     SphereColliderComponent* damageCollider = nullptr;
 
     float activatedTime                     = 0.0f;
-    bool isDealingDamage                    = false;
 
     // fireball
     GameObject* fireball                    = nullptr;
@@ -52,7 +49,6 @@ class FireballTrap : public Script
     GameObject* fireballShadow              = nullptr;
     
     float verticalSpeed                     = 0.0f;
-    bool hasImpacted                        = false;
     float rotationSpeed                     = 1.0f;
     float fallingHeight                     = 20.0f;
     float editableMaxFallSpeed              = 20.0f;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/FireballTrap.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/FireballTrap.h
@@ -41,6 +41,9 @@ class FireballTrap : public Script
 
     // fireball
     GameObject* fireball                    = nullptr;
+    // fireball
+    GameObject* fireballShadow              = nullptr;
+    
     float verticalSpeed                     = 0.0f;
     bool hasImpacted                        = false;
     float rotationSpeed                     = 1.0f;


### PR DESCRIPTION
Changed the fire trap dropping behaviour and added a mockup shadow for marking where the fireball is falling.

To test:
- Create a game object with a sphere collider, a mesh plane and a script with the fireball script added
- As children, add first a cube as the projectile and then a second plane as the shadow
- Play