### PR TITLE
Task/navmesh config save THO-661

### DIFF
--- a/SobrassadaEngine/Modules/PathfinderModule.cpp
+++ b/SobrassadaEngine/Modules/PathfinderModule.cpp
@@ -57,7 +57,9 @@ update_status PathfinderModule::Update(float deltaTime)
 }
 
 // All ai agent components will call this to add themselves to crowd
-int PathfinderModule::CreateAgent(const float3& position, const float radius, const float height, const float speed, const float acceleration)
+int PathfinderModule::CreateAgent(
+    const float3& position, const float radius, const float height, const float speed, const float acceleration
+)
 {
 
     dtCrowdAgentParams params;
@@ -218,6 +220,7 @@ void PathfinderModule::LoadNavMesh(const std::string& name)
         return;
     }
 
+    navconf.LoadFromMeta(navmeshUID);
     navmesh = loadedNavmesh;
 
     InitQuerySystem();

--- a/SobrassadaEngine/Utils/Globals.h
+++ b/SobrassadaEngine/Utils/Globals.h
@@ -172,6 +172,8 @@ constexpr UID UID_PREFIX_DIVISOR                         = 100000000000000;
 constexpr UID FALLBACK_TEXTURE_UID                       = 1200000000000000;
 constexpr UID DEFAULT_MATERIAL_UID                       = 1300000000000000;
 
+constexpr const char* NAVMESH_META_PREFIX                = "16_";
+
 constexpr const char* CONSTANT_MESH_SELECT_DIALOG_ID     = "mesh-select";
 constexpr const char* CONSTANT_MATERIAL_SELECT_DIALOG_ID = "material-select";
 constexpr const char* CONSTANT_TEXTURE_SELECT_DIALOG_ID  = "texture-select";

--- a/SobrassadaEngine/Utils/Globals.h
+++ b/SobrassadaEngine/Utils/Globals.h
@@ -172,7 +172,7 @@ constexpr UID UID_PREFIX_DIVISOR                         = 100000000000000;
 constexpr UID FALLBACK_TEXTURE_UID                       = 1200000000000000;
 constexpr UID DEFAULT_MATERIAL_UID                       = 1300000000000000;
 
-constexpr const char* NAVMESH_META_PREFIX                = "16_";
+constexpr const char* NAVMESH_META_PREFIX                = "20_";
 
 constexpr const char* CONSTANT_MESH_SELECT_DIALOG_ID     = "mesh-select";
 constexpr const char* CONSTANT_MATERIAL_SELECT_DIALOG_ID = "material-select";

--- a/SobrassadaEngine/Utils/NavMeshConfig.cpp
+++ b/SobrassadaEngine/Utils/NavMeshConfig.cpp
@@ -44,7 +44,7 @@ bool NavMeshConfig::LoadFromMeta(UID navmeshUID)
     rapidjson::Document doc;
     bool loaded = FileSystem::LoadJSON(navmeshMetaPath.c_str(), doc);
 
-    if (!doc.HasMember("NavMeshConfig") || !doc["NavMeshConfig"].IsObject()) return false;
+    if (!doc.HasMember("NavMeshConfig")) return false;
 
     const auto& cfg                 = doc["NavMeshConfig"];
 

--- a/SobrassadaEngine/Utils/NavMeshConfig.cpp
+++ b/SobrassadaEngine/Utils/NavMeshConfig.cpp
@@ -1,4 +1,8 @@
 #include "NavMeshConfig.h"
+#include "Application.h"
+#include "FileSystem.h"
+#include "LibraryModule.h"
+#include "ProjectModule.h"
 #include "Recast.h" // Only here!
 #include "imgui.h"
 
@@ -12,27 +16,57 @@ NavMeshConfig::~NavMeshConfig()
 {
 }
 
-void NavMeshConfig::ApplyTo(void* out) const {
+void NavMeshConfig::ApplyTo(void* out) const
+{
     rcConfig& outCfg = *reinterpret_cast<rcConfig*>(out);
     memset(&outCfg, 0, sizeof(rcConfig));
 
-    outCfg.cs = settings.cellSize;
-    outCfg.ch = settings.cellHeight;
-    outCfg.walkableSlopeAngle = settings.walkableSlopeAngle;
-    outCfg.walkableClimb = settings.walkableClimb;
-    outCfg.walkableHeight = settings.walkableHeight;
-    outCfg.walkableRadius = settings.walkableRadius;
-    outCfg.maxEdgeLen = settings.maxEdgeLen;
+    outCfg.cs                     = settings.cellSize;
+    outCfg.ch                     = settings.cellHeight;
+    outCfg.walkableSlopeAngle     = settings.walkableSlopeAngle;
+    outCfg.walkableClimb          = settings.walkableClimb;
+    outCfg.walkableHeight         = settings.walkableHeight;
+    outCfg.walkableRadius         = settings.walkableRadius;
+    outCfg.maxEdgeLen             = settings.maxEdgeLen;
     outCfg.maxSimplificationError = settings.maxSimplificationError;
-    outCfg.minRegionArea = settings.minRegionArea;
-    outCfg.mergeRegionArea = settings.mergeRegionArea;
-    outCfg.maxVertsPerPoly = settings.maxVertsPerPoly;
-    outCfg.detailSampleDist = settings.detailSampleDist;
-    outCfg.detailSampleMaxError = settings.detailSampleMaxError;
-
+    outCfg.minRegionArea          = settings.minRegionArea;
+    outCfg.mergeRegionArea        = settings.mergeRegionArea;
+    outCfg.maxVertsPerPoly        = settings.maxVertsPerPoly;
+    outCfg.detailSampleDist       = settings.detailSampleDist;
+    outCfg.detailSampleMaxError   = settings.detailSampleMaxError;
 }
 
-void NavMeshConfig::RenderEditorUI() {
+bool NavMeshConfig::LoadFromMeta(UID navmeshUID)
+{
+    const std::string navmeshName     = App->GetLibraryModule()->GetResourceName(navmeshUID);
+    const std::string navmeshMetaPath = App->GetProjectModule()->GetLoadedProjectPath() + METADATA_PATH +
+                                        NAVMESH_META_PREFIX + navmeshName + META_EXTENSION;
+    rapidjson::Document doc;
+    bool loaded = FileSystem::LoadJSON(navmeshMetaPath.c_str(), doc);
+
+    if (!doc.HasMember("NavMeshConfig") || !doc["NavMeshConfig"].IsObject()) return false;
+
+    const auto& cfg                 = doc["NavMeshConfig"];
+
+    settings.cellSize               = cfg["cellSize"].GetFloat();
+    settings.cellHeight             = cfg["cellHeight"].GetFloat();
+    settings.walkableSlopeAngle     = cfg["walkableSlopeAngle"].GetFloat();
+    settings.walkableClimb          = cfg["walkableClimb"].GetInt();
+    settings.walkableHeight         = cfg["walkableHeight"].GetInt();
+    settings.walkableRadius         = cfg["walkableRadius"].GetInt();
+    settings.maxEdgeLen             = cfg["maxEdgeLen"].GetInt();
+    settings.maxSimplificationError = cfg["maxSimplificationError"].GetFloat();
+    settings.minRegionArea          = cfg["minRegionArea"].GetInt();
+    settings.mergeRegionArea        = cfg["mergeRegionArea"].GetInt();
+    settings.maxVertsPerPoly        = cfg["maxVertsPerPoly"].GetInt();
+    settings.detailSampleDist       = cfg["detailSampleDist"].GetFloat();
+    settings.detailSampleMaxError   = cfg["detailSampleMaxError"].GetFloat();
+
+    return true;
+}
+
+void NavMeshConfig::RenderEditorUI()
+{
     ImGui::Text("Recast Config");
 
     ImGui::SliderFloat("Cell Size", &settings.cellSize, 0.05f, 1.0f);
@@ -50,13 +84,12 @@ void NavMeshConfig::RenderEditorUI() {
     ImGui::SliderInt("Max Verts Per Poly", &settings.maxVertsPerPoly, 3, 12);
 
     const char* partitionLabels[] = {
-     "SAMPLE_PARTITION_WATERSHED",
-     "SAMPLE_PARTITION_MONOTONE",
-     "SAMPLE_PARTITION_LAYERS"
+        "SAMPLE_PARTITION_WATERSHED", "SAMPLE_PARTITION_MONOTONE", "SAMPLE_PARTITION_LAYERS"
     };
 
     int currentIndex = static_cast<int>(settings.partitionType);
-    if (ImGui::Combo("Partition Type", &currentIndex, partitionLabels, IM_ARRAYSIZE(partitionLabels))) {
+    if (ImGui::Combo("Partition Type", &currentIndex, partitionLabels, IM_ARRAYSIZE(partitionLabels)))
+    {
         settings.partitionType = static_cast<SamplePartitionType>(currentIndex);
     }
 

--- a/SobrassadaEngine/Utils/NavMeshConfig.h
+++ b/SobrassadaEngine/Utils/NavMeshConfig.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Globals.h"
+
 enum class SamplePartitionType
 {
     SAMPLE_PARTITION_WATERSHED = 0,
@@ -21,7 +23,7 @@ struct NavMeshSettings {
     int maxVertsPerPoly = 6;
     float detailSampleDist = 6.0f;
     float detailSampleMaxError = 1.0f;
-    SamplePartitionType partitionType = SamplePartitionType::SAMPLE_PARTITION_MONOTONE;
+    SamplePartitionType partitionType = SamplePartitionType::SAMPLE_PARTITION_WATERSHED;
     // Your custom params
     bool filterLowHangingObstacles = true;
     bool filterLedgeSpans = true;
@@ -38,6 +40,7 @@ public:
     ~NavMeshConfig();
 
     void ApplyTo(void* outRecastRcConfig) const; // opaque interface
+    bool LoadFromMeta(UID navmeshUID);
     void RenderEditorUI();
     const NavMeshSettings& GetSettings() const { return settings; }
 

--- a/SobrassadaEngine/Utils/NavMeshConfig.h
+++ b/SobrassadaEngine/Utils/NavMeshConfig.h
@@ -13,7 +13,7 @@ struct NavMeshSettings {
     float cellSize = 0.3f;
     float cellHeight = 0.2f;
     float walkableSlopeAngle = 45.0f;
-    int walkableClimb = 4;
+    int walkableClimb = 1;
     int walkableHeight = 2;
     int walkableRadius = 2;
     int maxEdgeLen = 12;
@@ -26,7 +26,7 @@ struct NavMeshSettings {
     SamplePartitionType partitionType = SamplePartitionType::SAMPLE_PARTITION_WATERSHED;
     // Your custom params
     bool filterLowHangingObstacles = true;
-    bool filterLedgeSpans = true;
+    bool filterLedgeSpans = false;
     bool filterWalkableLowHeightSpans = true;
 
     float agentHeight = 2.0f;


### PR DESCRIPTION
To test: Load any scene with a navmesh, and open the navmesh metafile, check that the values in the editor are the same.

only rcConfig values, the values that are not stored in the metafile aren't kept. The UI default values have been fixed to always use the best ones, which should be kept across all navmeshes. These are the WATERSHED instead of MONOTONE partition type, and the agent parameters which dont do anything right now.