### PR TITLE
task/New banshee behaviour THO-720

### DIFF
--- a/Game/EngineDefaults/Shader/Fragment/gBufferMetallicFragment.glsl
+++ b/Game/EngineDefaults/Shader/Fragment/gBufferMetallicFragment.glsl
@@ -51,7 +51,7 @@ void main()
 {
     const Material mat = materials[instance_index];
     vec4 texColor = texture(sampler2D(mat.diffuseTex), uv0);
-    const float alpha = texColor.a;
+    const float alpha = texColor.a * mat.diffColor.a;
 
     if (!isWireframe && isAlpha)
     {

--- a/Game/EngineDefaults/Shader/Fragment/gBufferSpecularFragment.glsl
+++ b/Game/EngineDefaults/Shader/Fragment/gBufferSpecularFragment.glsl
@@ -52,7 +52,7 @@ void main()
     const Material mat = materials[instance_index];
 
     vec4 texColor = texture(sampler2D(mat.diffuseTex), uv0);
-    const float alpha = texColor.a;
+    const float alpha = texColor.a * mat.diffColor.a;
 
     if (!isWireframe && isAlpha)
     {

--- a/Game/EngineDefaults/Shader/Fragment/transparentShader.glsl
+++ b/Game/EngineDefaults/Shader/Fragment/transparentShader.glsl
@@ -194,7 +194,7 @@ void main()
     vec4 metallicRoughnessTexColor;
     if(mat.hasMetallic == 1) metallicRoughnessTexColor = pow(texture(sampler2D(mat.metallicTex), uv0), vec4(2.2));
     else metallicRoughnessTexColor = vec4(1);
-    const float alpha = texColor.a;
+    const float alpha = texColor.a * mat.diffColor.a;
 
     if (!isWireframe)
     {

--- a/SobrassadaEngine/ResourceManagement/Resources/ResourceMaterial.cpp
+++ b/SobrassadaEngine/ResourceManagement/Resources/ResourceMaterial.cpp
@@ -81,6 +81,7 @@ void ResourceMaterial::OnEditorUpdate()
     }
 
     updated |= ImGui::SliderFloat3("Diffuse Color", &material.diffColor.x, 0.0f, 1.0f);
+    updated |= ImGui::SliderFloat("Alpha", &material.diffColor.w, 0.0f, 1.0f);
 
     if (specularTexture.textureID != 0)
     {

--- a/SobrassadaEngine/ResourceManagement/Resources/ResourceMaterial.cpp
+++ b/SobrassadaEngine/ResourceManagement/Resources/ResourceMaterial.cpp
@@ -40,7 +40,7 @@ ResourceMaterial::~ResourceMaterial()
     FreeMaterials();
 }
 
-void ResourceMaterial::OnEditorUpdate()
+bool ResourceMaterial::OnEditorUpdate()
 {
     bool updated  = false;
 
@@ -190,6 +190,7 @@ void ResourceMaterial::OnEditorUpdate()
     }
 
     if (updated) SaveToMeta();
+    return updated;
 }
 
 void ResourceMaterial::SaveToMeta()

--- a/SobrassadaEngine/ResourceManagement/Resources/ResourceMaterial.h
+++ b/SobrassadaEngine/ResourceManagement/Resources/ResourceMaterial.h
@@ -38,7 +38,7 @@ class ResourceMaterial : public Resource
     ResourceMaterial(UID uid, const std::string& name, const rapidjson::Value& importOptions);
     ~ResourceMaterial() override;
 
-    void OnEditorUpdate();
+    bool OnEditorUpdate();
     void LoadMaterialData(Material mat);
     void FreeMaterials() const;
 

--- a/SobrassadaEngine/Scene/Components/Standalone/AIAgentComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/AIAgentComponent.cpp
@@ -11,6 +11,7 @@
 #include "Standalone/CharacterControllerComponent.h"
 
 #include "DetourCrowd.h"
+#include <random>
 
 AIAgentComponent::AIAgentComponent(UID uid, GameObject* parent) : Component(uid, parent, "AI Agent", COMPONENT_AIAGENT)
 {
@@ -300,11 +301,17 @@ void AIAgentComponent::SetRandomPositionAroundPlayer(const float3& playerPos, co
 
     dtStatus status    = navQuery->findNearestPoly(playerPos.ptr(), extents, &filter, &polyRef, nearestPoint);
     status             = navQuery->findRandomPointAroundCircle(
-        polyRef, searchPos, radius, &filter, []() { return static_cast<float>(rand()) / RAND_MAX; }, &randomRef,
-        randomPoint
+        polyRef, searchPos, radius, &filter,
+        []()
+        {
+            static std::mt19937 rng(std::random_device {}());
+            static std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+            return dist(rng);
+        },
+        &randomRef, randomPoint
     );
 
-    const float3 finalPos = {searchPos[0], searchPos[1], searchPos[2]};
+    const float3 finalPos = {randomPoint[0], randomPoint[1], randomPoint[2]};
     GLOG("TELEPORT TO: %f %f %f", finalPos[0], finalPos.y, finalPos.z);
 
     dtCrowd* crowd       = App->GetPathfinderModule()->GetCrowd();
@@ -313,6 +320,8 @@ void AIAgentComponent::SetRandomPositionAroundPlayer(const float3& playerPos, co
     editAg->npos[0]      = finalPos.x;
     editAg->npos[1]      = finalPos.y;
     editAg->npos[2]      = finalPos.z;
+
+    parent->SetLocalPosition(finalPos - parent->GetParentGlobalTransform().TranslatePart());
 }
 
 void AIAgentComponent::AddToCrowd()

--- a/SobrassadaEngine/Scene/Components/Standalone/AIAgentComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/AIAgentComponent.cpp
@@ -281,49 +281,6 @@ void AIAgentComponent::ResumeMovement()
     isPaused                   = false;
 }
 
-void AIAgentComponent::SetRandomPositionAroundPlayer(const float3& playerPos, const float radius)
-{
-    isPaused                     = false;
-
-    PathfinderModule* pathfinder = App->GetPathfinderModule();
-    dtNavMeshQuery* navQuery     = pathfinder->GetNavQuery();
-    if (!navQuery) return;
-
-    // Prepare for finding the nearest poly
-    dtQueryFilter filter;
-    float extents[3] = {2.0f, 4.0f, 2.0f}; // bounding box for the search area
-    dtPolyRef polyRef;
-    float nearestPoint[3];
-    dtPolyRef randomRef;
-    float randomPoint[3];
-
-    float searchPos[3] = {playerPos.x, playerPos.y, playerPos.z};
-
-    dtStatus status    = navQuery->findNearestPoly(playerPos.ptr(), extents, &filter, &polyRef, nearestPoint);
-    status             = navQuery->findRandomPointAroundCircle(
-        polyRef, searchPos, radius, &filter,
-        []()
-        {
-            static std::mt19937 rng(std::random_device {}());
-            static std::uniform_real_distribution<float> dist(0.0f, 1.0f);
-            return dist(rng);
-        },
-        &randomRef, randomPoint
-    );
-
-    const float3 finalPos = {randomPoint[0], randomPoint[1], randomPoint[2]};
-    GLOG("TELEPORT TO: %f %f %f", finalPos[0], finalPos.y, finalPos.z);
-
-    dtCrowd* crowd       = App->GetPathfinderModule()->GetCrowd();
-    dtCrowdAgent* editAg = crowd->getEditableAgent(agentId);
-
-    editAg->npos[0]      = finalPos.x;
-    editAg->npos[1]      = finalPos.y;
-    editAg->npos[2]      = finalPos.z;
-
-    parent->SetLocalPosition(finalPos - parent->GetParentGlobalTransform().TranslatePart());
-}
-
 void AIAgentComponent::AddToCrowd()
 {
     if (agentId != -1)
@@ -419,6 +376,32 @@ void AIAgentComponent::ResetSpeed()
     agent->params.maxAcceleration = defaultAcceleration;
 
     isPaused                      = false;
+}
+
+void AIAgentComponent::SetPosition(const float3& newPos)
+{
+    isPaused                     = false;
+
+    PathfinderModule* pathfinder = App->GetPathfinderModule();
+    dtNavMeshQuery* navQuery     = pathfinder->GetNavQuery();
+    if (!navQuery) return;
+
+    // Prepare for finding the nearest poly
+    dtQueryFilter filter;
+    float extents[3] = {2.0f, 4.0f, 2.0f}; // bounding box for the search area
+    float nearestPoint[3];
+    dtPolyRef targetRef;
+
+    dtStatus status     = navQuery->findNearestPoly(newPos.ptr(), extents, &filter, &targetRef, nearestPoint);
+
+    dtCrowdAgent* agent = App->GetPathfinderModule()->GetCrowd()->getEditableAgent(agentId);
+    agent->npos[0]      = nearestPoint[0];
+    agent->npos[1]      = nearestPoint[1];
+    agent->npos[2]      = nearestPoint[2];
+
+    parent->SetLocalPosition(
+        float3(nearestPoint[0], nearestPoint[1], nearestPoint[2]) - parent->GetParentGlobalTransform().TranslatePart()
+    );
 }
 
 void AIAgentComponent::ResetAngularSpeed()

--- a/SobrassadaEngine/Scene/Components/Standalone/AIAgentComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/AIAgentComponent.cpp
@@ -210,6 +210,7 @@ bool AIAgentComponent::SetPathNavigation(const math::float3& destination, bool m
     float extents[3] = {2.0f, 4.0f, 2.0f}; // bounding box for the search area
     float nearestPoint[3];
     dtPolyRef targetRef;
+
     dtStatus status = navQuery->findNearestPoly(destination.ptr(), extents, &filter, &targetRef, nearestPoint);
     if (dtStatusFailed(status) || targetRef == 0)
     {
@@ -277,6 +278,41 @@ void AIAgentComponent::ResumeMovement()
     currentAngularSpeed        = restoreAngular;
 
     isPaused                   = false;
+}
+
+void AIAgentComponent::SetRandomPositionAroundPlayer(const float3& playerPos, const float radius)
+{
+    isPaused                     = false;
+
+    PathfinderModule* pathfinder = App->GetPathfinderModule();
+    dtNavMeshQuery* navQuery     = pathfinder->GetNavQuery();
+    if (!navQuery) return;
+
+    // Prepare for finding the nearest poly
+    dtQueryFilter filter;
+    float extents[3] = {2.0f, 4.0f, 2.0f}; // bounding box for the search area
+    dtPolyRef polyRef;
+    float nearestPoint[3];
+    dtPolyRef randomRef;
+    float randomPoint[3];
+
+    float searchPos[3] = {playerPos.x, playerPos.y, playerPos.z};
+
+    dtStatus status    = navQuery->findNearestPoly(playerPos.ptr(), extents, &filter, &polyRef, nearestPoint);
+    status             = navQuery->findRandomPointAroundCircle(
+        polyRef, searchPos, radius, &filter, []() { return static_cast<float>(rand()) / RAND_MAX; }, &randomRef,
+        randomPoint
+    );
+
+    const float3 finalPos = {searchPos[0], searchPos[1], searchPos[2]};
+    GLOG("TELEPORT TO: %f %f %f", finalPos[0], finalPos.y, finalPos.z);
+
+    dtCrowd* crowd       = App->GetPathfinderModule()->GetCrowd();
+    dtCrowdAgent* editAg = crowd->getEditableAgent(agentId);
+
+    editAg->npos[0]      = finalPos.x;
+    editAg->npos[1]      = finalPos.y;
+    editAg->npos[2]      = finalPos.z;
 }
 
 void AIAgentComponent::AddToCrowd()

--- a/SobrassadaEngine/Scene/Components/Standalone/AIAgentComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/AIAgentComponent.cpp
@@ -11,7 +11,6 @@
 #include "Standalone/CharacterControllerComponent.h"
 
 #include "DetourCrowd.h"
-#include <random>
 
 AIAgentComponent::AIAgentComponent(UID uid, GameObject* parent) : Component(uid, parent, "AI Agent", COMPONENT_AIAGENT)
 {

--- a/SobrassadaEngine/Scene/Components/Standalone/AIAgentComponent.h
+++ b/SobrassadaEngine/Scene/Components/Standalone/AIAgentComponent.h
@@ -30,7 +30,6 @@ class SOBRASADA_API_ENGINE AIAgentComponent : public Component
     bool SetPathNavigation(const math::float3& destination, bool move = true);
     void PauseMovement();
     void ResumeMovement();
-    void SetRandomPositionAroundPlayer(const float3& playerPos, const float radius);
 
     float GetSpeed() const { return currentSpeed; }
     float GetAngularSpeed() const { return currentAngularSpeed; }
@@ -39,6 +38,7 @@ class SOBRASADA_API_ENGINE AIAgentComponent : public Component
     void SetLookForward(bool look) { lookForward = look; }
     void SetSpeed(const float newSpeed, const float acceleration);
     void SetAngularSpeed(const float newAngular);
+    void SetPosition(const float3& newPos);
     void ResetSpeed();
     void ResetAngularSpeed();
 

--- a/SobrassadaEngine/Scene/Components/Standalone/AIAgentComponent.h
+++ b/SobrassadaEngine/Scene/Components/Standalone/AIAgentComponent.h
@@ -30,6 +30,7 @@ class SOBRASADA_API_ENGINE AIAgentComponent : public Component
     bool SetPathNavigation(const math::float3& destination, bool move = true);
     void PauseMovement();
     void ResumeMovement();
+    void SetRandomPositionAroundPlayer(const float3& playerPos, const float radius);
 
     float GetSpeed() const { return currentSpeed; }
     float GetAngularSpeed() const { return currentAngularSpeed; }

--- a/SobrassadaEngine/Scene/Components/Standalone/MeshComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/MeshComponent.cpp
@@ -205,7 +205,8 @@ void MeshComponent::RenderEditorInspector()
             if (batch) BatchEditorMode();
         }
 
-        currentMaterial->OnEditorUpdate();
+        // TODO: Update batch when modifying material so it changes visually
+        //if (currentMaterial->OnEditorUpdate() && batch) BatchEditorMode();
     }
 }
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Banshee.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Banshee.cpp
@@ -8,6 +8,7 @@
 #include "Standalone/AIAgentComponent.h"
 #include "Standalone/AnimationComponent.h"
 #include "Standalone/CharacterControllerComponent.h"
+#include "Standalone/MeshComponent.h"
 #include "Standalone/Physics/CapsuleColliderComponent.h"
 #include "Standalone/Physics/SphereColliderComponent.h"
 
@@ -24,8 +25,7 @@ Banshee::Banshee(GameObject* parent)
           CharacterType::Banshee
       )
 {
-    fields.push_back({"Fleeing Distance", InspectorField::FieldType::Float, &fleeDistance, 0.0f, 10.0f});
-    fields.push_back({"Fleeing Speed", InspectorField::FieldType::Float, &fleeSpeed, 0.0f, 10.0f});
+    fields.push_back({"Invisible time range", InspectorField::FieldType::Vec2, &invisibleTimeRange, 0.0f, 10.0f});
     fields.push_back({"Attack Angular Speed", InspectorField::FieldType::Float, &attackAngularSpeed, 0.0f, 10.0f});
 }
 
@@ -63,6 +63,12 @@ bool Banshee::Init()
         else GLOG("[WARNING] Banshee: no scream visual found as child of base")
     }
 
+    mesh = parent->GetComponentChild<MeshComponent*>(AppEngine);
+    if (!mesh) GLOG("No mesh found for Banshee");
+
+    rng  = std::mt19937(std::random_device {}());
+    dist = std::uniform_int_distribution<std::mt19937::result_type>(invisibleTimeRange[0], invisibleTimeRange[1]);
+
     return true;
 }
 
@@ -99,11 +105,7 @@ void Banshee::HandleState(float deltaTime)
         ChasePlayer();
         break;
 
-    case BansheeStates::Flee:
-        Flee();
-        break;
-
-    case BansheeStates::Scream:
+    case BansheeStates::Attack:
         if (attackCdTimer <= 0) Attack(deltaTime);
         break;
     }
@@ -114,32 +116,8 @@ void Banshee::ChasePlayer()
     if (!character) return;
 
     if (animComponent) animComponent->UseTrigger("Chase");
-    if (CheckDistanceWithPlayer() <= PlayerDistances::Close) currentState = BansheeStates::Scream;
+    if (CheckDistanceWithPlayer() <= PlayerDistances::Close) currentState = BansheeStates::Attack;
     else if (!agentAI->SetPathNavigation(character->GetLastPosition())) currentState = BansheeStates::Idle;
-}
-
-void Banshee::Flee()
-{
-    if (!isFleeing)
-    {
-        if (animComponent) animComponent->UseTrigger("Chase");
-        isFleeing = true;
-        agentAI->SetSpeed(fleeSpeed, 100.0f);
-    }
-
-    const float3 newPos =
-        (parent->GetGlobalTransform().TranslatePart() - character->GetGlobalTransform().TranslatePart()).Normalized() +
-        parent->GetGlobalTransform().TranslatePart();
-
-    agentAI->SetPathNavigation(newPos);
-
-    const float distance = character->GetLastPosition().Distance(parent->GetPosition());
-    if (attackCdTimer <= 0 && distance > fleeDistance)
-    {
-        isFleeing = false;
-        agentAI->ResetSpeed();
-        ChangeState();
-    }
 }
 
 void Banshee::Attack(float deltaTime)
@@ -150,19 +128,34 @@ void Banshee::Attack(float deltaTime)
     {
         GLOG("Banshee attack");
         agentAI->SetLookForward(false);
-        if (animComponent) animComponent->UseTrigger("Scream");
 
         Character::Attack(deltaTime);
         agentAI->SetSpeed(0.0f, 0.0f);
         agentAI->SetAngularSpeed(attackAngularSpeed);
+
+        currentInvisibleTime = dist(rng);
+        isInvisible          = true;
+        mesh->SetEnabled(false);
     }
     else
     {
-        // Slowly rotate towards player while charging the attack
-        if (attackTimer < attackHitboxDelay) agentAI->LookAtMovement(character->GetLastPosition(), deltaTime);
+        if (attackTimer < currentInvisibleTime) return;
 
-        if (!damageArea->GetEnabled() && attackTimer >= attackHitboxDelay &&
-            attackTimer <= attackHitboxDelay + attackHitboxDuration)
+        if (isInvisible)
+        {
+            // Tp to player and enable
+            GetAttackPosition();
+            mesh->SetEnabled(true);
+            isInvisible = false;
+            if (animComponent) animComponent->UseTrigger("Scream");
+        }
+
+        // Slowly rotate towards player while charging the attack
+        if (attackTimer < currentInvisibleTime + attackHitboxDelay)
+            agentAI->LookAtMovement(character->GetLastPosition(), deltaTime);
+
+        if (!damageArea->GetEnabled() && attackTimer >= currentInvisibleTime + attackHitboxDelay &&
+            attackTimer <= currentInvisibleTime + attackHitboxDelay + attackHitboxDuration)
         {
             GLOG("Banshee enable hitbox");
             if (areaVisual) areaVisual->SetEnabled(true);
@@ -170,7 +163,8 @@ void Banshee::Attack(float deltaTime)
             damageArea->SetEnabled(true);
             if (weaponCollider) weaponCollider->SetEnabled(true);
         }
-        else if (damageArea->GetEnabled() && attackTimer >= attackHitboxDelay + attackHitboxDuration)
+        else if (damageArea->GetEnabled() &&
+                 attackTimer >= currentInvisibleTime + attackHitboxDelay + attackHitboxDuration)
         {
             GLOG("Banshee disable hitbox");
             damageArea->SetEnabled(false);
@@ -179,7 +173,7 @@ void Banshee::Attack(float deltaTime)
             if (screamVisual) screamVisual->SetEnabled(false);
         }
 
-        if (attackTimer >= attackDuration)
+        if (attackTimer >= currentInvisibleTime + attackDuration)
         {
             isAttacking   = false;
             attackCdTimer = attackCooldown;
@@ -194,8 +188,12 @@ void Banshee::Attack(float deltaTime)
 void Banshee::ChangeState()
 {
     const float distance = character->GetLastPosition().Distance(parent->GetPosition());
-    if (distance <= fleeDistance) currentState = BansheeStates::Flee;
-    else if (distance <= rangeAIAttack) currentState = BansheeStates::Scream;
+    if (distance <= rangeAIAttack) currentState = BansheeStates::Attack;
     else if (distance <= rangeAIChase) currentState = BansheeStates::Chase;
     else currentState = BansheeStates::Idle;
+}
+
+void Banshee::GetAttackPosition()
+{
+    agentAI->SetRandomPositionAroundPlayer(character->GetLastPosition(), 2.0f);
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Banshee.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Banshee.cpp
@@ -66,8 +66,9 @@ bool Banshee::Init()
     mesh = parent->GetComponentChild<MeshComponent*>(AppEngine);
     if (!mesh) GLOG("No mesh found for Banshee");
 
-    rng  = std::mt19937(std::random_device {}());
-    dist = std::uniform_int_distribution<std::mt19937::result_type>(invisibleTimeRange[0], invisibleTimeRange[1]);
+    rng            = std::mt19937(std::random_device {}());
+    normalizedDist = std::uniform_real_distribution<float>(0.0f, 1.0f);
+    invisibleDist  = std::uniform_real_distribution<float>(invisibleTimeRange[0], invisibleTimeRange[1]);
 
     return true;
 }
@@ -109,6 +110,11 @@ void Banshee::HandleState(float deltaTime)
         if (attackCdTimer <= 0) Attack(deltaTime);
         break;
     }
+
+    if (animComponent && animComponent->IsFinished())
+    {
+        animComponent->UseTrigger("Idle");
+    }
 }
 
 void Banshee::ChasePlayer()
@@ -132,8 +138,9 @@ void Banshee::Attack(float deltaTime)
         Character::Attack(deltaTime);
         agentAI->SetSpeed(0.0f, 0.0f);
 
-        currentInvisibleTime = dist(rng);
-        isInvisible          = true;
+        currentInvisibleTime = invisibleDist(rng);
+        GLOG("Current inivivible time: %f", currentInvisibleTime);
+        isInvisible = true;
         mesh->SetEnabled(false);
     }
     else
@@ -195,6 +202,16 @@ void Banshee::ChangeState()
 
 void Banshee::GetAttackPosition()
 {
-    agentAI->SetRandomPositionAroundPlayer(character->GetLastPosition(), 0.001f);
-    agentAI->LookAtMovement(character->GetLastPosition(), 1000.0f);
+    const float3 playerPos = character->GetLastPosition();
+    const float maxRadius  = 2.5f;
+    const float minRadius  = 1.5f;
+
+    float angle            = normalizedDist(rng) * 2.0f * PI;
+    float r = sqrtf(normalizedDist(rng) * (maxRadius * maxRadius - minRadius * minRadius) + minRadius * minRadius);
+
+    float3 position(cosf(angle) * r + playerPos.x, playerPos.y, sinf(angle) * r + playerPos.z);
+
+    agentAI->SetPosition(position);
+
+    agentAI->LookAtMovement(character->GetLastPosition(), 1.0f);
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Banshee.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Banshee.cpp
@@ -131,7 +131,6 @@ void Banshee::Attack(float deltaTime)
 
         Character::Attack(deltaTime);
         agentAI->SetSpeed(0.0f, 0.0f);
-        agentAI->SetAngularSpeed(attackAngularSpeed);
 
         currentInvisibleTime = dist(rng);
         isInvisible          = true;
@@ -147,6 +146,7 @@ void Banshee::Attack(float deltaTime)
             GetAttackPosition();
             mesh->SetEnabled(true);
             isInvisible = false;
+            agentAI->SetAngularSpeed(attackAngularSpeed);
             if (animComponent) animComponent->UseTrigger("Scream");
         }
 
@@ -195,5 +195,6 @@ void Banshee::ChangeState()
 
 void Banshee::GetAttackPosition()
 {
-    agentAI->SetRandomPositionAroundPlayer(character->GetLastPosition(), 2.0f);
+    agentAI->SetRandomPositionAroundPlayer(character->GetLastPosition(), 0.001f);
+    agentAI->LookAtMovement(character->GetLastPosition(), 1000.0f);
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Banshee.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Banshee.cpp
@@ -140,7 +140,7 @@ void Banshee::Attack(float deltaTime)
 
         currentInvisibleTime = invisibleDist(rng);
         GLOG("Current inivivible time: %f", currentInvisibleTime);
-        isInvisible = true;
+        isInvisible    = true;
         mesh->SetEnabled(false);
     }
     else
@@ -152,7 +152,7 @@ void Banshee::Attack(float deltaTime)
             // Tp to player and enable
             GetAttackPosition();
             mesh->SetEnabled(true);
-            isInvisible = false;
+            isInvisible    = false;
             agentAI->SetAngularSpeed(attackAngularSpeed);
             if (animComponent) animComponent->UseTrigger("Scream");
         }
@@ -214,4 +214,11 @@ void Banshee::GetAttackPosition()
     agentAI->SetPosition(position);
 
     agentAI->LookAtMovement(character->GetLastPosition(), 1.0f);
+}
+
+void Banshee::OnCollision(GameObject* otherObject, const float3& collisionNormal)
+{
+    if (isInvisible) return;
+
+    Character::OnCollision(otherObject, collisionNormal);
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Banshee.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Banshee.cpp
@@ -132,15 +132,14 @@ void Banshee::Attack(float deltaTime)
 
     if (!isAttacking)
     {
-        GLOG("Banshee attack");
+        // GLOG("Banshee attack");
         agentAI->SetLookForward(false);
 
         Character::Attack(deltaTime);
         agentAI->SetSpeed(0.0f, 0.0f);
 
         currentInvisibleTime = invisibleDist(rng);
-        GLOG("Current inivivible time: %f", currentInvisibleTime);
-        isInvisible    = true;
+        isInvisible          = true;
         mesh->SetEnabled(false);
     }
     else
@@ -150,9 +149,9 @@ void Banshee::Attack(float deltaTime)
         if (isInvisible)
         {
             // Tp to player and enable
-            GetAttackPosition();
+            GoToAttackPosition();
             mesh->SetEnabled(true);
-            isInvisible    = false;
+            isInvisible = false;
             agentAI->SetAngularSpeed(attackAngularSpeed);
             if (animComponent) animComponent->UseTrigger("Scream");
         }
@@ -164,7 +163,7 @@ void Banshee::Attack(float deltaTime)
         if (!damageArea->GetEnabled() && attackTimer >= currentInvisibleTime + attackHitboxDelay &&
             attackTimer <= currentInvisibleTime + attackHitboxDelay + attackHitboxDuration)
         {
-            GLOG("Banshee enable hitbox");
+            // GLOG("Banshee enable hitbox");
             if (areaVisual) areaVisual->SetEnabled(true);
             if (screamVisual) screamVisual->SetEnabled(true);
             damageArea->SetEnabled(true);
@@ -173,7 +172,7 @@ void Banshee::Attack(float deltaTime)
         else if (damageArea->GetEnabled() &&
                  attackTimer >= currentInvisibleTime + attackHitboxDelay + attackHitboxDuration)
         {
-            GLOG("Banshee disable hitbox");
+            // GLOG("Banshee disable hitbox");
             damageArea->SetEnabled(false);
             if (weaponCollider) weaponCollider->SetEnabled(false);
             if (areaVisual) areaVisual->SetEnabled(false);
@@ -200,19 +199,20 @@ void Banshee::ChangeState()
     else currentState = BansheeStates::Idle;
 }
 
-void Banshee::GetAttackPosition()
+void Banshee::GoToAttackPosition()
 {
     const float3 playerPos = character->GetLastPosition();
     const float maxRadius  = 2.5f;
     const float minRadius  = 1.5f;
 
-    float angle            = normalizedDist(rng) * 2.0f * PI;
-    float r = sqrtf(normalizedDist(rng) * (maxRadius * maxRadius - minRadius * minRadius) + minRadius * minRadius);
+    // Get a random position within a circle smaller than maxRadius and bigger than minRadius
+    const float angle      = normalizedDist(rng) * 2.0f * PI;
+    const float r =
+        sqrtf(normalizedDist(rng) * (maxRadius * maxRadius - minRadius * minRadius) + minRadius * minRadius);
 
-    float3 position(cosf(angle) * r + playerPos.x, playerPos.y, sinf(angle) * r + playerPos.z);
+    const float3 position(cosf(angle) * r + playerPos.x, playerPos.y, sinf(angle) * r + playerPos.z);
 
     agentAI->SetPosition(position);
-
     agentAI->LookAtMovement(character->GetLastPosition(), 1.0f);
 }
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Banshee.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Banshee.h
@@ -37,6 +37,8 @@ class Banshee : public Character
     void ChangeState();
     void GetAttackPosition();
 
+    void OnCollision(GameObject* otherObject, const float3& collisionNormal) override;
+
   private:
     AIAgentComponent* agentAI           = nullptr;
     BansheeStates currentState          = BansheeStates::Idle;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Banshee.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Banshee.h
@@ -51,5 +51,6 @@ class Banshee : public Character
     bool isInvisible                    = false;
 
     std::mt19937 rng;
-    std::uniform_int_distribution<std::mt19937::result_type> dist;
+    std::uniform_real_distribution<float> normalizedDist;
+    std::uniform_real_distribution<float> invisibleDist;
 };

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Banshee.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Banshee.h
@@ -2,7 +2,11 @@
 
 #include "Character.h"
 
+#include "Math/float2.h"
+#include <random>
+
 class GameObject;
+class MeshComponent;
 class AIAgentComponent;
 class SphereColliderComponent;
 
@@ -10,8 +14,7 @@ enum class BansheeStates
 {
     Idle,
     Chase,
-    Flee,
-    Scream
+    Attack
 };
 
 class Banshee : public Character
@@ -30,9 +33,9 @@ class Banshee : public Character
     void HandleState(float deltaTime) override;
 
     void ChasePlayer();
-    void Flee();
     void Attack(float deltaTime) override;
     void ChangeState();
+    void GetAttackPosition();
 
   private:
     AIAgentComponent* agentAI           = nullptr;
@@ -40,10 +43,13 @@ class Banshee : public Character
     SphereColliderComponent* damageArea = nullptr;
     GameObject* areaVisual              = nullptr;
     GameObject* screamVisual            = nullptr;
+    MeshComponent* mesh                 = nullptr;
 
-    float fleeDistance                  = 0.0f;
-    float fleeSpeed                     = 10.0f;
-    bool isFleeing                      = false;
-
+    float2 invisibleTimeRange           = float2::zero;
+    float currentInvisibleTime          = 0.0f;
     float attackAngularSpeed            = 0.0f;
+    bool isInvisible                    = false;
+
+    std::mt19937 rng;
+    std::uniform_int_distribution<std::mt19937::result_type> dist;
 };

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Banshee.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Banshee.h
@@ -35,7 +35,7 @@ class Banshee : public Character
     void ChasePlayer();
     void Attack(float deltaTime) override;
     void ChangeState();
-    void GetAttackPosition();
+    void GoToAttackPosition();
 
     void OnCollision(GameObject* otherObject, const float3& collisionNormal) override;
 


### PR DESCRIPTION
Implemented the new banshee behaviour as it was discussed. Now the banshee no longer flees. When the player is detected, it chases it until a set distance, then disappears and after a random amount of time appears next to the player, attacks, disappears again, attacks, etc. If the player gets far it is chased again or even stops chasing it.

The changes on shaders and materials do nothing for now, I tried some things with Andreu to make the banshee disappear smoothly tweaking the alpha, but there were more problems than we expected, so for now it directly disables and enables the mesh. That will be done in a future task.

To test you can go to the level 2 of the game repo and see if it works fine. Raise chase range and the attack range of the banshee, so it disappears further away from the player.

