### PR TITLE
Task/spline game object rotation tho 663

### DIFF
--- a/SobrassadaEngine/Scene/Components/Standalone/SplineComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/SplineComponent.cpp
@@ -173,7 +173,7 @@ void SplineComponent::RenderEditorInspector()
     ImGui::SeparatorText("Path Probe");
 
     ImGui::Checkbox("Show marker", &showMarker);
-    if (showMarker) ImGui::DragFloat("t  (0-1)", &markerT, 0.001f, 0.f, 1.f, "%.3f");
+    if (showMarker) ImGui::DragFloat("t  (0-1)", &markerT, 0.001f, 0.0f, 1.0f, "%.3f");
 
     ImGui::SeparatorText("Add Point");
 
@@ -327,7 +327,7 @@ float3 SplineComponent::Evaluate(float t) const
 
     if (points.size() < 2) return worldOffset;
 
-    t = std::clamp(t, 0.f, 1.f);
+    t = std::clamp(t, 0.0f, 1.0f);
 
     const int numSeg = loop ? (int)points.size() : (int)points.size() - 1;
 
@@ -348,7 +348,7 @@ Quat SplineComponent::EvaluateRotation(float t) const
     if (points.empty()) return Quat::identity;
     if (points.size() == 1) return points.front().rotation;
 
-    t = std::clamp(t, 0.f, 1.f);
+    t = std::clamp(t, 0.0f, 1.0f);
 
     const int numSeg = loop ? (int)points.size() : (int)points.size() - 1;
     const float segFloat = t * numSeg;
@@ -363,6 +363,28 @@ Quat SplineComponent::EvaluateRotation(float t) const
     const int nextIdx = loop ? (seg + 1) % points.size() : std::min(seg + 1, (int)points.size() - 1);
     
     return Quat::Slerp(points[seg].rotation, points[nextIdx].rotation, segmentT).Normalized();
+}
+
+float SplineComponent::EvaluateSpeed(float t) const
+{
+    if (points.empty()) return 1.0f;
+    if (points.size() == 1) return points.front().speed;
+
+    t = std::clamp(t, 0.0f, 1.0f);
+
+    const int numSeg = loop ? (int)points.size() : (int)points.size() - 1;
+    const float segFloat = t * numSeg;
+
+    if (segFloat >= numSeg) return loop ? points.front().speed : points.back().speed;
+
+    int seg              = (int)floorf(segFloat);
+    float segmentT       = segFloat - seg;
+
+    if (loop) seg = seg % points.size();
+
+    int next = loop ? (seg + 1) % points.size() : std::min(seg + 1, (int)points.size() - 1);
+
+    return math::Lerp(points[seg].speed, points[next].speed, segmentT);
 }
 
 void SplineComponent::EvaluateTransform(float t, float3& pos, Quat& rot) const

--- a/SobrassadaEngine/Scene/Components/Standalone/SplineComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/SplineComponent.cpp
@@ -21,7 +21,22 @@ SplineComponent::SplineComponent(const rapidjson::Value& initialState, GameObjec
     {
         const auto& arrayPoints = initialState["Points"].GetArray();
         for (auto& p : arrayPoints)
-            points.emplace_back(p[0].GetFloat(), p[1].GetFloat(), p[2].GetFloat());
+        {
+            if (p.IsObject() && p.HasMember("Pos") && p.HasMember("Rot"))
+            {
+                const auto& pos = p["Pos"].GetArray();
+                const auto& rot = p["Rot"].GetArray();
+
+                float3 position(pos[0].GetFloat(), pos[1].GetFloat(), pos[2].GetFloat());
+                Quat rotation(rot[0].GetFloat(), rot[1].GetFloat(), rot[2].GetFloat(), rot[3].GetFloat()); // w,x,y,z
+
+                points.emplace_back(position, rotation);
+            }
+            else if (p.IsArray() && p.Size() == 3) //Old format (array x,y,z)
+            {
+                points.emplace_back(float3(p[0].GetFloat(), p[1].GetFloat(), p[2].GetFloat()), Quat::identity);
+            }
+        }
     }
 }
 
@@ -69,11 +84,11 @@ void SplineComponent::RenderDebug(float deltaTime)
                 prev = p;
             }
         }
-        else drawLine(points[seg], points[seg + 1]);
+        else drawLine(points[seg].position, points[seg + 1].position);
     }
 
-    for (const float3& p : points)
-        dbg->DrawSphere(p + worldOffset, pointColor, 0.08f);
+    for (const SplinePoint& p : points)
+        dbg->DrawSphere(p.position + worldOffset, pointColor, 0.08f);
 
     if (showMarker && points.size() >= 2)
     {
@@ -116,7 +131,7 @@ void SplineComponent::RenderEditorInspector()
 
     if (validSel)
     {
-        float3 tempPoint = points[selectedIdx];
+        float3 tempPoint = points[selectedIdx].position;
         if (ImGui::InputFloat3("Selected Pos", &tempPoint[0]))
         {
             points[selectedIdx] = tempPoint;
@@ -177,9 +192,20 @@ void SplineComponent::Save(rapidjson::Value& targetState, rapidjson::Document::A
 
     for (const auto& p : points)
     {
-        rapidjson::Value pArr(rapidjson::kArrayType);
-        pArr.PushBack(p.x, allocator).PushBack(p.y, allocator).PushBack(p.z, allocator);
-        arr.PushBack(pArr, allocator);
+        rapidjson::Value pObj(rapidjson::kObjectType);
+        //position
+        rapidjson::Value posArr(rapidjson::kArrayType);
+        posArr.PushBack(p.position.x, allocator).PushBack(p.position.y, allocator).PushBack(p.position.z, allocator);
+        pObj.AddMember("Pos", posArr, allocator);
+        //rotation
+        rapidjson::Value rotArr(rapidjson::kArrayType);
+        rotArr.PushBack(p.rotation.x, allocator)
+            .PushBack(p.rotation.y, allocator)
+            .PushBack(p.rotation.z, allocator)
+            .PushBack(p.rotation.w, allocator);
+        pObj.AddMember("Rot", rotArr, allocator);
+
+        arr.PushBack(pObj, allocator);
     }
 
     targetState.AddMember("Points", arr, allocator);
@@ -271,7 +297,8 @@ float3 SplineComponent::EvaluateSegment(const size_t seg, float segmentT) const
     };
 
     return CatmullRom(
-        points[idx((int)seg - 1)], points[idx((int)seg)], points[idx((int)seg + 1)], points[idx((int)seg + 2)], segmentT
+        points[idx((int)seg - 1)].position, points[idx((int)seg)].position, points[idx((int)seg + 1)].position,
+        points[idx((int)seg + 2)].position, segmentT
     );
 }
 
@@ -286,7 +313,7 @@ float3 SplineComponent::Evaluate(float t) const
     const int numSeg = loop ? (int)points.size() : (int)points.size() - 1;
 
     const float segFloat   = t * numSeg;
-    if (segFloat >= numSeg) return worldOffset + (loop ? points.front() : points.back());
+    if (segFloat >= numSeg) return worldOffset + (loop ? points.front().position : points.back().position);
 
     int seg = (int)floorf(segFloat);
     const float segmentT = segFloat - seg;
@@ -301,7 +328,7 @@ bool SplineComponent::PointGizmo(size_t idx)
 {
     if (selectedIdx >= 0 && selectedIdx < (int)points.size())
     {
-        float4x4 localMatrix  = float4x4::FromTRS(points[idx], float4x4::identity, float3::one);
+        float4x4 localMatrix  = float4x4::FromTRS(points[idx].position, float4x4::identity, float3::one);
         
         //In order to ignore Rotation and Scale from parent and set it to 1
         const float3 translate        = parent->GetGlobalTransform().TranslatePart();
@@ -325,7 +352,7 @@ float3 SplineComponent::GetPointWorld(size_t idx) const
 {
     if (idx >= points.size()) return float3::zero;
 
-    return points[idx] + parent->GetGlobalTransform().TranslatePart();
+    return points[idx].position + parent->GetGlobalTransform().TranslatePart();
 }
 
 float3 SplineComponent::GetWorldPositionInSpine(float posT) const

--- a/SobrassadaEngine/Scene/Components/Standalone/SplineComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/SplineComponent.cpp
@@ -132,10 +132,13 @@ void SplineComponent::RenderEditorInspector()
     if (validSel)
     {
         float3 tempPoint = points[selectedIdx].position;
-        if (ImGui::InputFloat3("Selected Pos", &tempPoint[0]))
-        {
-            points[selectedIdx] = tempPoint;
-        }
+        if (ImGui::InputFloat3("Selected Pos", &tempPoint[0])) points[selectedIdx] = tempPoint;
+
+        float3 eulerDeg = points[selectedIdx].rotation.ToEulerXYZ() * RAD_DEGREE_CONV;
+        if (ImGui::InputFloat3("Selected Rot (deg)", &eulerDeg[0]))
+            points[selectedIdx].rotation = Quat::FromEulerXYZ(
+                eulerDeg.x * DEGREE_RAD_CONV, eulerDeg.y * DEGREE_RAD_CONV, eulerDeg.z * DEGREE_RAD_CONV
+            );
     }
 
     ImGui::BeginDisabled(!validSel);

--- a/SobrassadaEngine/Scene/Components/Standalone/SplineComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/SplineComponent.cpp
@@ -92,8 +92,19 @@ void SplineComponent::RenderDebug(float deltaTime)
 
     if (showMarker && points.size() >= 2)
     {
-        const float3 wPos = GetWorldPositionInSpine(markerT);
-        dbg->DrawSphere(wPos, float3(1, 1, 0), 0.10f);
+        float3 wPos;
+        Quat wRot;
+
+        EvaluateTransform(markerT, wPos, wRot);
+        
+        auto coneDir = [&](const Quat& rot, float height)
+        {
+            return rot * float3(0, 0, 1) * height;
+        };
+
+        const float h = 0.22f;
+        const float r = 0.08f;
+        dbg->DrawCone(wPos, coneDir(wRot, h), r, 0.f);
     }
 }
 

--- a/SobrassadaEngine/Scene/Components/Standalone/SplineComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/SplineComponent.cpp
@@ -152,7 +152,7 @@ void SplineComponent::RenderEditorInspector()
             points[selectedIdx].rotation = Quat::FromEulerXYZ(
                 eulerDeg.x * DEGREE_RAD_CONV, eulerDeg.y * DEGREE_RAD_CONV, eulerDeg.z * DEGREE_RAD_CONV
             );
-        ImGui::DragFloat("Selected Speed", &points[selectedIdx].speed, 0.1f, 0.0f, 100.0f);
+        ImGui::DragFloat("Selected Speed", &points[selectedIdx].speed, 0.001f, 0.0f, 1.0f);
     }
 
     ImGui::BeginDisabled(!validSel);

--- a/SobrassadaEngine/Scene/Components/Standalone/SplineComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/SplineComponent.cpp
@@ -68,6 +68,12 @@ void SplineComponent::RenderDebug(float deltaTime)
 
     const float3 worldOffset = inWorld ? parent->GetGlobalTransform().TranslatePart() : float3(0, 0, 0);
 
+    auto coneDir             = [&](const Quat& rot, float height) { return rot * float3(0, 0, 1) * height; };
+
+    const float coneH            = 0.22f;
+    const float coneR           = 0.08f;
+    const float apexR            = 0.0f;
+
     auto drawLine = [&](const float3& a, const float3& b) { dbg->DrawLineSegment(LineSegment(a, b), curveColor); };
 
     for (size_t seg = 0; seg < endSeg; ++seg)
@@ -88,7 +94,9 @@ void SplineComponent::RenderDebug(float deltaTime)
     }
 
     for (const SplinePoint& p : points)
-        dbg->DrawSphere(p.position + worldOffset, pointColor, 0.08f);
+    {
+        dbg->DrawCone(p.position + worldOffset, coneDir(p.rotation, coneH), coneR, apexR); 
+    }
 
     if (showMarker && points.size() >= 2)
     {
@@ -97,14 +105,7 @@ void SplineComponent::RenderDebug(float deltaTime)
 
         EvaluateTransform(markerT, wPos, wRot);
         
-        auto coneDir = [&](const Quat& rot, float height)
-        {
-            return rot * float3(0, 0, 1) * height;
-        };
-
-        const float h = 0.22f;
-        const float r = 0.08f;
-        dbg->DrawCone(wPos, coneDir(wRot, h), r, 0.f);
+        dbg->DrawCone(wPos, coneDir(wRot, coneH), coneR, apexR);
     }
 }
 
@@ -372,7 +373,7 @@ bool SplineComponent::PointGizmo(size_t idx)
 {
     if (selectedIdx >= 0 && selectedIdx < (int)points.size())
     {
-        float4x4 localMatrix  = float4x4::FromTRS(points[idx].position, float4x4::identity, float3::one);
+        float4x4 localMatrix = float4x4::FromTRS(points[idx].position, points[idx].rotation.ToFloat4x4(), float3::one);
         
         //In order to ignore Rotation and Scale from parent and set it to 1
         const float3 translate        = parent->GetGlobalTransform().TranslatePart();
@@ -380,13 +381,16 @@ bool SplineComponent::PointGizmo(size_t idx)
 
         float4x4 globalMatrix         = parentT * localMatrix;
 
-        float3 newPos, _unusedRot, _unusedScale;
+        float3 newPos, newRot, _unusedScale;
 
-        bool moved = App->GetEditorUIModule()->RenderImGuizmo(
-            localMatrix, globalMatrix, parentT, newPos, _unusedRot, _unusedScale
+        bool moved = App->GetEditorUIModule()->RenderImGuizmo(localMatrix, globalMatrix, parentT, newPos, newRot, _unusedScale
         );
 
-        if (moved) points[idx] = localMatrix.TranslatePart();
+        if (moved)
+        {
+            points[idx].position = localMatrix.TranslatePart();
+            points[idx].rotation = Quat(localMatrix).Normalized();
+        }
         return true;
     }
     return false;

--- a/SobrassadaEngine/Scene/Components/Standalone/SplineComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/SplineComponent.cpp
@@ -26,11 +26,12 @@ SplineComponent::SplineComponent(const rapidjson::Value& initialState, GameObjec
             {
                 const auto& pos = p["Pos"].GetArray();
                 const auto& rot = p["Rot"].GetArray();
+                float sp         = p.HasMember("Speed") ? p["Speed"].GetFloat() : 1.0f;
 
                 float3 position(pos[0].GetFloat(), pos[1].GetFloat(), pos[2].GetFloat());
                 Quat rotation(rot[0].GetFloat(), rot[1].GetFloat(), rot[2].GetFloat(), rot[3].GetFloat()); // w,x,y,z
 
-                points.emplace_back(position, rotation);
+                points.emplace_back(position, rotation, sp);
             }
             else if (p.IsArray() && p.Size() == 3) //Old format (array x,y,z)
             {
@@ -151,6 +152,7 @@ void SplineComponent::RenderEditorInspector()
             points[selectedIdx].rotation = Quat::FromEulerXYZ(
                 eulerDeg.x * DEGREE_RAD_CONV, eulerDeg.y * DEGREE_RAD_CONV, eulerDeg.z * DEGREE_RAD_CONV
             );
+        ImGui::DragFloat("Selected Speed", &points[selectedIdx].speed, 0.1f, 0.0f, 100.0f);
     }
 
     ImGui::BeginDisabled(!validSel);
@@ -219,6 +221,8 @@ void SplineComponent::Save(rapidjson::Value& targetState, rapidjson::Document::A
             .PushBack(p.rotation.z, allocator)
             .PushBack(p.rotation.w, allocator);
         pObj.AddMember("Rot", rotArr, allocator);
+        //speed
+        pObj.AddMember("Speed", p.speed, allocator);
 
         arr.PushBack(pObj, allocator);
     }

--- a/SobrassadaEngine/Scene/Components/Standalone/SplineComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/SplineComponent.cpp
@@ -324,6 +324,36 @@ float3 SplineComponent::Evaluate(float t) const
     return worldOffset + local;
 }
 
+Quat SplineComponent::EvaluateRotation(float t) const
+{
+    if (points.empty()) return Quat::identity;
+    if (points.size() == 1) return points.front().rotation;
+
+    t = std::clamp(t, 0.f, 1.f);
+
+    const int numSeg = loop ? (int)points.size() : (int)points.size() - 1;
+    const float segFloat = t * numSeg;
+
+    if (segFloat >= numSeg) return loop ? points.front().rotation : points.back().rotation;
+
+    int seg = (int)floorf(segFloat);
+    float segmentT = segFloat - seg;
+
+    if (loop) seg = seg % points.size();
+
+    const int nextIdx = loop ? (seg + 1) % points.size() : std::min(seg + 1, (int)points.size() - 1);
+    
+    return Quat::Slerp(points[seg].rotation, points[nextIdx].rotation, segmentT).Normalized();
+}
+
+void SplineComponent::EvaluateTransform(float t, float3& pos, Quat& rot) const
+{
+    pos = Evaluate(t);
+    rot = EvaluateRotation(t);
+}
+
+
+
 bool SplineComponent::PointGizmo(size_t idx)
 {
     if (selectedIdx >= 0 && selectedIdx < (int)points.size())

--- a/SobrassadaEngine/Scene/Components/Standalone/SplineComponent.h
+++ b/SobrassadaEngine/Scene/Components/Standalone/SplineComponent.h
@@ -9,10 +9,12 @@ struct SplinePoint
 {
     float3 position;
     Quat rotation;
+    float speed = 1.0f;
 
-    SplinePoint() : position(float3::zero), rotation(Quat::identity){}
-    SplinePoint(const float3& p) : position(p), rotation(Quat::identity) {}
-    SplinePoint(const float3& p, Quat r) : position(p), rotation(r){}
+    SplinePoint() : position(float3::zero), rotation(Quat::identity), speed(1.0f){}
+    SplinePoint(const float3& p) : position(p), rotation(Quat::identity), speed(1.0f) {}
+    SplinePoint(const float3& p, Quat r) : position(p), rotation(r), speed(1.0f){}
+    SplinePoint(const float3& p, Quat r, float s) : position(p), rotation(r), speed(s){}
 };
 
 class SOBRASADA_API_ENGINE SplineComponent : public Component

--- a/SobrassadaEngine/Scene/Components/Standalone/SplineComponent.h
+++ b/SobrassadaEngine/Scene/Components/Standalone/SplineComponent.h
@@ -2,7 +2,18 @@
 #include "Component.h"
 
 #include "Math/float3.h"
+#include "Math/Quat.h"
 #include <vector>
+
+struct SplinePoint
+{
+    float3 position;
+    Quat rotation;
+
+    SplinePoint() : position(float3::zero), rotation(Quat::identity){}
+    SplinePoint(const float3& p) : position(p), rotation(Quat::identity) {}
+    SplinePoint(const float3& p, Quat r) : position(p), rotation(r){}
+};
 
 class SOBRASADA_API_ENGINE SplineComponent : public Component
 {
@@ -31,7 +42,7 @@ class SOBRASADA_API_ENGINE SplineComponent : public Component
     bool PointGizmo(size_t idx);
 
     size_t GetNumPoints() const { return points.size(); }
-    const float3 GetPointLocal(size_t idx) const { return points[idx]; }
+    const float3 GetPointLocal(size_t idx) const { return points[idx].position; }
     float3 GetPointWorld(size_t idx) const;
     float3 GetWorldPositionInSpine(float posT) const;
     bool IsLoop() const { return loop; }
@@ -40,7 +51,7 @@ class SOBRASADA_API_ENGINE SplineComponent : public Component
     void SetInWorld(bool isInWorld) { inWorld = isInWorld; }
 
   private:
-    std::vector<float3> points;
+    std::vector<SplinePoint> points;
     float3 pendingPoint  = float3::zero;
 
     float alpha          = 0.5f;

--- a/SobrassadaEngine/Scene/Components/Standalone/SplineComponent.h
+++ b/SobrassadaEngine/Scene/Components/Standalone/SplineComponent.h
@@ -39,6 +39,8 @@ class SOBRASADA_API_ENGINE SplineComponent : public Component
     size_t Wrap(int i) const;
     float3 EvaluateSegment(const size_t seg, float segmentT) const;
     float3 Evaluate(float t) const;
+    Quat EvaluateRotation(float t) const;
+    void EvaluateTransform(float t, float3& pos, Quat& rot) const;
     bool PointGizmo(size_t idx);
 
     size_t GetNumPoints() const { return points.size(); }

--- a/SobrassadaEngine/Scene/Components/Standalone/SplineComponent.h
+++ b/SobrassadaEngine/Scene/Components/Standalone/SplineComponent.h
@@ -42,6 +42,7 @@ class SOBRASADA_API_ENGINE SplineComponent : public Component
     float3 EvaluateSegment(const size_t seg, float segmentT) const;
     float3 Evaluate(float t) const;
     Quat EvaluateRotation(float t) const;
+    float EvaluateSpeed(float t) const;
     void EvaluateTransform(float t, float3& pos, Quat& rot) const;
     bool PointGizmo(size_t idx);
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MoveGOInSpline.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MoveGOInSpline.cpp
@@ -9,7 +9,7 @@
 
 MoveGOInSpline::MoveGOInSpline(GameObject* parent) : Script(parent)
 {
-    fields.push_back({"Speed (0-1/s)", InspectorField::FieldType::Float, &speed, 0.0f, 10.0f});
+    fields.push_back({"Speed Factor", InspectorField::FieldType::Float, &speed, 0.0f, 10.0f});
     fields.push_back({"PingPong effect", InspectorField::FieldType::Bool, &pingPong});
 }
 
@@ -31,22 +31,39 @@ void MoveGOInSpline::Update(float deltaTime)
     }
     if (speed <= 0.0f) return;
 
-    const float deltaT  = speed * deltaTime;
-    
+    float segSpeed = spline->EvaluateSpeed(t) * speed;
 
-    isLoop  = spline->IsLoop();
+    const int ptCount  = spline->GetNumPoints();
+    const bool isLoop  = spline->IsLoop();
+    const int segCount = isLoop ? ptCount : ptCount - 1;
+
+    float segFloat     = t * segCount;
+    int idxStart           = static_cast<int>(floorf(segFloat));
+    
+    if (isLoop) idxStart %= ptCount;
+
+    int idxEnd    = isLoop ? (idxStart + 1) % ptCount : (std::min)(idxStart + 1, ptCount - 1);
+    
+    float3 pStart = spline->GetPointWorld(idxStart);
+    float3 pEnd   = spline->GetPointWorld(idxEnd);
+    float segLen  = (pEnd - pStart).Length();
+
+    if (segLen < 0.0001f) segLen = 0.0001f;
+    
+    float deltaT = (segSpeed * deltaTime) / (segLen * segCount);
+
     if (pingPong && !isLoop)
     {
         t += goingForward ? deltaT : -deltaT;
 
         if (t > 1.f)
         {
-            t            = 1.f;
+            t            = 2.0 - t;
             goingForward = false;
         }
         else if (t < 0)
         {
-            t            = 0.f;
+            t            = -t;
             goingForward = true;
         }
     }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MoveGOInSpline.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MoveGOInSpline.cpp
@@ -31,43 +31,48 @@ void MoveGOInSpline::Update(float deltaTime)
     }
     if (speed <= 0.0f) return;
 
-    float delta  = speed * deltaTime * (goingForward ? 1.0f : -1.0f);
-    t += delta;
+    const float deltaT  = speed * deltaTime;
+    
 
-    loop  = spline->IsLoop();
-    if (loop)  //Closed spline
+    isLoop  = spline->IsLoop();
+    if (pingPong && !isLoop)
     {
+        t += goingForward ? deltaT : -deltaT;
+
+        if (t > 1.f)
+        {
+            t            = 1.f;
+            goingForward = false;
+        }
+        else if (t < 0)
+        {
+            t            = 0.f;
+            goingForward = true;
+        }
+    }
+    else
+    {
+        t += deltaT;
         if (t > 1.f) t -= 1.f;
         else if (t < 0.f) t += 1.f;
     }
-    else    //Open Spline
-    {
-        if (pingPong)
-        {
-            if (t > 1.f)
-            {
-                t            = 1.f;
-                goingForward = false;
-            }
-            else if (t < 0)
-            {
-                t            = 0.f;
-                goingForward = true;
-            }
-        }
-        else
-        {
-            if (t > 1.f) t -= 1.f;
-            else if (t < 0.f) t += 1.f;
-        }
-    }
 
-    float3 worldPos = spline->GetWorldPositionInSpine(t);
+    float3 localPos;
+    Quat localRot;
+    spline->EvaluateTransform(t, localPos, localRot);
 
-    float4x4 local  = parent->GetLocalTransform();
-    local.SetTranslatePart(parent->GetParentGlobalTransform().Inverted().TransformPos(worldPos));
+    GameObject* splineGO = spline->GetParent();
+    const float4x4& splineGlob = splineGO->GetGlobalTransform();
 
-    parent->SetLocalTransform(local);
+    float3 worldPos            = splineGlob.TransformPos(localPos);
+    Quat worldRot              = Quat(splineGlob) * localRot;
+    
+    const float4x4& parentGlob = parent->GetParentGlobalTransform();
+
+    float4x4 worldM            = float4x4::FromTRS(worldPos, worldRot.ToFloat4x4(), float3::one);
+    
+    float4x4 localM            = parentGlob.Inverted() * worldM;
+    parent->SetLocalTransform(localM);
 
 }
 
@@ -89,7 +94,7 @@ SplineComponent* MoveGOInSpline::FindSpline()
 
         if (spline)
         {
-            splineGO = childUID;
+            splineIdGO = childUID;
             return spline;
         }
     }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MoveGOInSpline.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MoveGOInSpline.h
@@ -18,7 +18,7 @@ private:
 
 private:
     UID splineIdGO = INVALID_UID;
-    float speed  = 0.1f;
+    float speed  = 1.0f;
     bool isLoop    = false;
     
     SplineComponent* spline = nullptr;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MoveGOInSpline.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MoveGOInSpline.h
@@ -17,9 +17,9 @@ private:
     SplineComponent* FindSpline();
 
 private:
-    UID splineGO = INVALID_UID;
+    UID splineIdGO = INVALID_UID;
     float speed  = 0.1f;
-    bool loop    = false;
+    bool isLoop    = false;
     
     SplineComponent* spline = nullptr;
     float t                 = 0.0f;


### PR DESCRIPTION
The Spline now incorporates rotation of the splinePoints and speed variable that indicates at which velocity the GameObject shound arrive at that point. 

The spline points have been changed for cones, in order to show the rotation in which the gameObject should have.

In order to test it:
- There is a scene created in dev-testing called "SplineTestV2". You can use that or create a spline from zero. (Take into account that if you decide to create it from zero, the GO that contain the spline has to be a sibling of the GO that would contain the script to move through the spline).
- Go to the spline and tweak the position and rotation values (scale is ignored), You can use gizmos to modify it easily.
- Set a speed value in each point. This speed variable is interpolated. In order to change the speed of the GameObject, that is modified in the script MoveGOInSpline inspector.
- Go to play mode and tweak also the parameters mention above to see how it reacts.
- Try it with a loop and non-loop spline.
- Tweak the pingpong parameter (only for non-loop splines). Is located in the script component for MoveGOInSpline script.

(NOTE: there are three functions that almost have the same code but with different parameters according to the values requested (Evaluate, EvaluateRotation & EvaluateSpeed). I'm thinking of a way to adapt them to not repeat code. I'm making the pull request now to test the functionality that works correctly and then modify that part to make it more "clean").