### PR TITLE
task/Prefabs usability upgrade THO-638

### DIFF
--- a/SobrassadaEngine/FileSystem/PrefabManager.cpp
+++ b/SobrassadaEngine/FileSystem/PrefabManager.cpp
@@ -16,7 +16,7 @@
 
 namespace PrefabManager
 {
-    UID SavePrefab(const GameObject* gameObject, bool override)
+    UID SavePrefab(const GameObject* gameObject, bool override, const UID versionUID)
     {
         // Create doc JSON
         rapidjson::Document doc;
@@ -36,6 +36,7 @@ namespace PrefabManager
 
         // Create structure
         prefab.AddMember("UID", finalPrefabUID, allocator);
+        prefab.AddMember("VersionUID", versionUID, allocator);
         prefab.AddMember("Name", rapidjson::Value(name.c_str(), allocator), allocator);
 
         // Serialize GameObjects
@@ -133,7 +134,11 @@ namespace PrefabManager
         rapidjson::Value& prefab = doc["Prefab"];
 
         UID uid                  = prefab["UID"].GetUint64();
-        std::string name         = prefab["Name"].GetString();
+
+        UID versionUid           = INVALID_UID;
+        if (prefab.HasMember("VersionUID")) versionUid = prefab["VersionUID"].GetUint64();
+
+        std::string name = prefab["Name"].GetString();
 
         std::vector<GameObject*> loadedGameObjects;
         std::vector<int> parentIndices;
@@ -157,7 +162,7 @@ namespace PrefabManager
                 loadedGameObjects.push_back(newObject);
             }
         }
-        ResourcePrefab* resourcePrefab = new ResourcePrefab(uid, name);
+        ResourcePrefab* resourcePrefab = new ResourcePrefab(uid, versionUid, name);
         resourcePrefab->LoadData(loadedGameObjects, parentIndices);
         return resourcePrefab;
     }

--- a/SobrassadaEngine/FileSystem/PrefabManager.h
+++ b/SobrassadaEngine/FileSystem/PrefabManager.h
@@ -9,7 +9,7 @@ class GameObject;
 
 namespace PrefabManager
 {
-    UID SavePrefab(const GameObject* gameObject, bool override);
+    UID SavePrefab(const GameObject* gameObject, bool override, const UID versionUID);
     void CopyPrefab(
         const std::string& filePath, const std::string& targetFilePath, const std::string& name, const UID sourceUID
     );

--- a/SobrassadaEngine/ResourceManagement/Resources/ResourcePrefab.cpp
+++ b/SobrassadaEngine/ResourceManagement/Resources/ResourcePrefab.cpp
@@ -17,6 +17,14 @@ ResourcePrefab::~ResourcePrefab()
 
 void ResourcePrefab::LoadData(const std::vector<GameObject*>& objects, const std::vector<int>& indices)
 {
-    gameObjects = objects;
+    gameObjects   = objects;
     parentIndices = indices;
+}
+
+void ResourcePrefab::GetGameObjectsMap(std::unordered_map<UID, GameObject*>& mapToFill)
+{
+    for (GameObject* object : gameObjects)
+    {
+        mapToFill.insert({object->GetPrefabChildUID(), object});
+    }
 }

--- a/SobrassadaEngine/ResourceManagement/Resources/ResourcePrefab.cpp
+++ b/SobrassadaEngine/ResourceManagement/Resources/ResourcePrefab.cpp
@@ -1,7 +1,7 @@
 #include "ResourcePrefab.h"
 #include "GameObject.h"
 
-ResourcePrefab::ResourcePrefab(UID uid, const std::string& name) : Resource(uid, name, ResourceType::Prefab)
+ResourcePrefab::ResourcePrefab(UID uid, UID versionUid, const std::string& name) : versionUID(versionUid), Resource(uid, name, ResourceType::Prefab)
 {
 }
 

--- a/SobrassadaEngine/ResourceManagement/Resources/ResourcePrefab.h
+++ b/SobrassadaEngine/ResourceManagement/Resources/ResourcePrefab.h
@@ -2,6 +2,7 @@
 
 #include "Resource.h"
 
+#include <unordered_map>
 #include <vector>
 
 class GameObject;
@@ -15,6 +16,7 @@ class ResourcePrefab : public Resource
     void LoadData(const std::vector<GameObject*>& objects, const std::vector<int>& indices);
 
     GameObject* GetRootObject() const { return gameObjects[0]; }
+    void GetGameObjectsMap(std::unordered_map<UID, GameObject*>& mapToFill);
     const std::vector<GameObject*>& GetGameObjectsVector() const { return gameObjects; }
     const std::vector<int>& GetParentIndices() const { return parentIndices; }
 

--- a/SobrassadaEngine/ResourceManagement/Resources/ResourcePrefab.h
+++ b/SobrassadaEngine/ResourceManagement/Resources/ResourcePrefab.h
@@ -10,7 +10,7 @@ class GameObject;
 class ResourcePrefab : public Resource
 {
   public:
-    ResourcePrefab(UID uid, const std::string& name);
+    ResourcePrefab(UID uid, UID versionUid, const std::string& name);
     ~ResourcePrefab() override;
 
     void LoadData(const std::vector<GameObject*>& objects, const std::vector<int>& indices);
@@ -19,8 +19,10 @@ class ResourcePrefab : public Resource
     void GetGameObjectsMap(std::unordered_map<UID, GameObject*>& mapToFill);
     const std::vector<GameObject*>& GetGameObjectsVector() const { return gameObjects; }
     const std::vector<int>& GetParentIndices() const { return parentIndices; }
+    const UID GetVersionUID() const { return versionUID; }
 
   private:
+    UID versionUID = INVALID_UID;
     std::vector<GameObject*> gameObjects;
     std::vector<int> parentIndices;
 };

--- a/SobrassadaEngine/Scene/Components/ScriptComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/ScriptComponent.cpp
@@ -88,6 +88,7 @@ void ScriptComponent::Clone(const Component* other)
         const ScriptComponent* otherScript = static_cast<const ScriptComponent*>(other);
         enabled                            = otherScript->enabled;
         wasEnabled                         = otherScript->wasEnabled;
+        DeleteAllScripts();
 
         for (size_t i = 0; i < otherScript->scriptNames.size(); ++i)
         {

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
@@ -15,6 +15,7 @@
 #include "Standalone/Audio/AudioSourceComponent.h"
 #include "Standalone/BillboardComponent.h"
 #include "Standalone/CharacterControllerComponent.h"
+#include "Standalone/DecalComponent.h"
 #include "Standalone/Lights/DirectionalLightComponent.h"
 #include "Standalone/Lights/PointLightComponent.h"
 #include "Standalone/Lights/SpotLightComponent.h"
@@ -30,7 +31,6 @@
 #include "Standalone/UI/ImageComponent.h"
 #include "Standalone/UI/Transform2DComponent.h"
 #include "Standalone/UI/UILabelComponent.h"
-#include "Standalone/DecalComponent.h"
 
 #include "imgui.h"
 #include <queue>
@@ -238,6 +238,7 @@ GameObject::GameObject(UID parentUID, GameObject* refObject)
     rotation         = refObject->rotation;
     scale            = refObject->scale;
     prefabUID        = refObject->prefabUID;
+    prefabChildUID   = refObject->prefabChildUID;
     navMeshValid     = refObject->navMeshValid;
     enabled          = refObject->enabled;
     wasEnabled       = refObject->wasEnabled;
@@ -278,6 +279,7 @@ void GameObject::LoadData(const rapidjson::Value& initialState)
     if (initialState.HasMember("SelectParent")) selectParent = initialState["SelectParent"].GetBool();
 
     if (initialState.HasMember("PrefabUID")) prefabUID = initialState["PrefabUID"].GetUint64();
+    if (initialState.HasMember("PrefabChildUID")) prefabChildUID = initialState["PrefabChildUID"].GetUint64();
     if (initialState.HasMember("NavmeshValid")) navMeshValid = initialState["NavmeshValid"].GetBool();
 
     if (initialState.HasMember("LocalTransform") && initialState["LocalTransform"].IsArray() &&
@@ -390,7 +392,8 @@ void GameObject::Save(rapidjson::Value& targetState, rapidjson::Document::Alloca
     targetState.AddMember("NavmeshValid", navMeshValid, allocator);
 
     if (prefabUID != INVALID_UID) targetState.AddMember("PrefabUID", prefabUID, allocator);
-    
+    if (prefabChildUID != INVALID_UID) targetState.AddMember("PrefabChildUID", prefabChildUID, allocator);
+
     rapidjson::Value valLocalTransform(rapidjson::kArrayType);
     valLocalTransform.PushBack(localTransform.ptr()[0], allocator)
         .PushBack(localTransform.ptr()[1], allocator)
@@ -1170,7 +1173,28 @@ bool GameObject::RemoveComponent(ComponentType componentType)
 void GameObject::CreatePrefab()
 {
     bool override = this->prefabUID != INVALID_UID;
-    prefabUID     = PrefabManager::SavePrefab(this, override);
+
+    std::queue<UID> childrenUIDs;
+
+    for (UID child : children)
+    {
+        childrenUIDs.push(child);
+    }
+
+    // Set the prefabChildUID to all children of the prefab in case they don't already have
+    while (!childrenUIDs.empty())
+    {
+        GameObject* currentChild = App->GetSceneModule()->GetScene()->GetGameObjectByUID(childrenUIDs.front());
+        if (currentChild->prefabChildUID == INVALID_UID) currentChild->prefabChildUID = GenerateUID();
+
+        childrenUIDs.pop();
+        for (UID child : currentChild->children)
+        {
+            childrenUIDs.push(child);
+        }
+    }
+
+    prefabUID = PrefabManager::SavePrefab(this, override);
 
     if (override)
     {

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
@@ -1212,11 +1212,7 @@ void GameObject::CreatePrefab()
     bool override = this->prefabUID != INVALID_UID;
 
     std::queue<UID> childrenUIDs;
-
-    for (UID child : children)
-    {
-        childrenUIDs.push(child);
-    }
+    childrenUIDs.push(uid);
 
     // Set the prefabChildUID to all children of the prefab in case they don't already have
     while (!childrenUIDs.empty())
@@ -1224,7 +1220,7 @@ void GameObject::CreatePrefab()
         GameObject* currentChild = App->GetSceneModule()->GetScene()->GetGameObjectByUID(childrenUIDs.front());
         if (currentChild->prefabChildUID == INVALID_UID)
         {
-            GLOG("New prefab child UID");
+            //GLOG("New prefab child UID");
             currentChild->prefabChildUID = GenerateUID();
         }
         childrenUIDs.pop();

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
@@ -1218,8 +1218,11 @@ void GameObject::CreatePrefab()
     while (!childrenUIDs.empty())
     {
         GameObject* currentChild = App->GetSceneModule()->GetScene()->GetGameObjectByUID(childrenUIDs.front());
-        if (currentChild->prefabChildUID == INVALID_UID) currentChild->prefabChildUID = GenerateUID();
-
+        if (currentChild->prefabChildUID == INVALID_UID)
+        {
+            GLOG("New prefab child UID");
+            currentChild->prefabChildUID = GenerateUID();
+        }
         childrenUIDs.pop();
         for (UID child : currentChild->children)
         {

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
@@ -238,6 +238,7 @@ GameObject::GameObject(UID parentUID, GameObject* refObject)
     rotation         = refObject->rotation;
     scale            = refObject->scale;
     prefabUID        = refObject->prefabUID;
+    prefabVersionUID = refObject->prefabVersionUID;
     prefabChildUID   = refObject->prefabChildUID;
     navMeshValid     = refObject->navMeshValid;
     enabled          = refObject->enabled;
@@ -279,6 +280,7 @@ void GameObject::LoadData(const rapidjson::Value& initialState)
     if (initialState.HasMember("SelectParent")) selectParent = initialState["SelectParent"].GetBool();
 
     if (initialState.HasMember("PrefabUID")) prefabUID = initialState["PrefabUID"].GetUint64();
+    if (initialState.HasMember("PrefabVersionUID")) prefabVersionUID = initialState["PrefabVersionUID"].GetUint64();
     if (initialState.HasMember("PrefabChildUID")) prefabChildUID = initialState["PrefabChildUID"].GetUint64();
     if (initialState.HasMember("NavmeshValid")) navMeshValid = initialState["NavmeshValid"].GetBool();
 
@@ -392,6 +394,7 @@ void GameObject::Save(rapidjson::Value& targetState, rapidjson::Document::Alloca
     targetState.AddMember("NavmeshValid", navMeshValid, allocator);
 
     if (prefabUID != INVALID_UID) targetState.AddMember("PrefabUID", prefabUID, allocator);
+    if (prefabVersionUID != INVALID_UID) targetState.AddMember("PrefabVersionUID", prefabVersionUID, allocator);
     if (prefabChildUID != INVALID_UID) targetState.AddMember("PrefabChildUID", prefabChildUID, allocator);
 
     rapidjson::Value valLocalTransform(rapidjson::kArrayType);
@@ -853,7 +856,7 @@ void GameObject::RenderContextMenu()
         const char* label = prefabUID == INVALID_UID ? "Create Prefab" : "Update Prefab";
         if (ImGui::MenuItem(label)) CreatePrefab();
 
-        if (prefabUID != INVALID_UID && ImGui::MenuItem("Unlink prefab")) prefabUID = INVALID_UID;
+        if (prefabUID != INVALID_UID && ImGui::MenuItem("Unlink prefab")) RemovePrefabStatus();
 
         if (uid != App->GetSceneModule()->GetScene()->GetGameObjectRootUID() && ImGui::MenuItem("Delete"))
         {
@@ -1058,6 +1061,7 @@ void GameObject::UpdateFromReference(GameObject* reference)
     rotation         = reference->rotation;
     scale            = reference->scale;
     prefabUID        = reference->prefabUID;
+    prefabVersionUID = reference->prefabVersionUID;
     prefabChildUID   = reference->prefabChildUID;
     navMeshValid     = reference->navMeshValid;
     enabled          = reference->enabled;
@@ -1230,12 +1234,38 @@ void GameObject::CreatePrefab()
         }
     }
 
-    prefabUID = PrefabManager::SavePrefab(this, override);
+    prefabVersionUID = GenerateUID();
+    prefabUID        = PrefabManager::SavePrefab(this, override, prefabVersionUID);
 
     if (override)
     {
         // Update all prefabs
         App->GetSceneModule()->GetScene()->OverridePrefabs(prefabUID);
+    }
+}
+
+void GameObject::RemovePrefabStatus()
+{
+    // Clear prefab flags of all the gameObject hierarchy
+    prefabUID        = INVALID_UID;
+    prefabVersionUID = INVALID_UID;
+
+    std::stack<UID> childrenUIDs;
+    for (UID child : children)
+    {
+        childrenUIDs.push(child);
+    }
+
+    while (!childrenUIDs.empty())
+    {
+        GameObject* currentObject = App->GetSceneModule()->GetScene()->GetGameObjectByUID(childrenUIDs.top());
+        childrenUIDs.pop();
+
+        currentObject->prefabChildUID = INVALID_UID;
+        for (UID child : currentObject->children)
+        {
+            childrenUIDs.push(child);
+        }
     }
 }
 

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
@@ -1049,6 +1049,39 @@ void GameObject::SetJustLocalTransform(const float4x4& newTransform)
     scale          = localTransform.GetScale();
 }
 
+void GameObject::UpdateFromReference(GameObject* reference)
+{
+    selectParent     = reference->selectParent;
+    mobilitySettings = reference->mobilitySettings;
+
+    position         = reference->position;
+    rotation         = reference->rotation;
+    scale            = reference->scale;
+    prefabUID        = reference->prefabUID;
+    prefabChildUID   = reference->prefabChildUID;
+    navMeshValid     = reference->navMeshValid;
+    enabled          = reference->enabled;
+    wasEnabled       = reference->wasEnabled;
+
+    for (int i = 0; i < std::tuple_size<decltype(compTuple)>::value; ++i)
+    {
+        // Add missing components and remove the ones that are no longer in the reference
+        if (reference->IsComponentCreated(i) && !IsComponentCreated(i))
+        {
+            CreateComponent(ComponentType(i + 1));
+        }
+        else if (IsComponentCreated(i) && !reference->IsComponentCreated(i))
+        {
+            RemoveComponent(ComponentType(i + 1));
+        }
+    }
+
+    // Update components values
+    DuplicateComponents(compTuple, reference->GetComponentsTupleRef());
+
+    OnAABBUpdated();
+}
+
 void GameObject::DrawNodes() const
 {
     DebugDrawModule* debug = App->GetDebugDrawModule();

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
@@ -1220,7 +1220,7 @@ void GameObject::CreatePrefab()
         GameObject* currentChild = App->GetSceneModule()->GetScene()->GetGameObjectByUID(childrenUIDs.front());
         if (currentChild->prefabChildUID == INVALID_UID)
         {
-            //GLOG("New prefab child UID");
+            // GLOG("New prefab child UID");
             currentChild->prefabChildUID = GenerateUID();
         }
         childrenUIDs.pop();
@@ -1247,10 +1247,7 @@ void GameObject::RemovePrefabStatus()
     prefabVersionUID = INVALID_UID;
 
     std::stack<UID> childrenUIDs;
-    for (UID child : children)
-    {
-        childrenUIDs.push(child);
-    }
+    childrenUIDs.push(uid);
 
     while (!childrenUIDs.empty())
     {

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.h
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.h
@@ -142,6 +142,7 @@ class SOBRASADA_API_ENGINE GameObject
     void SetEnabledRecursive(bool value);
 
     UID GetPrefabUID() const { return prefabUID; }
+    UID GetPrefabChildUID() const { return prefabChildUID; }
     void SetPrefabUID(const UID uid) { prefabUID = uid; }
     void SetPrefabChildUID(const UID uid) { prefabChildUID = uid; }
 
@@ -161,6 +162,8 @@ class SOBRASADA_API_ENGINE GameObject
     void SetOpenHierarchyNode(bool newOpen) { openHierarchyNode = newOpen; }
 
     void SetJustLocalTransform(const float4x4& newTransform);
+
+    void UpdateFromReference(GameObject* reference);
 
   private:
     void DrawNodes() const;

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.h
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.h
@@ -140,8 +140,11 @@ class SOBRASADA_API_ENGINE GameObject
     void CreatePrefab();
     bool IsGloballyEnabled() const;
     void SetEnabledRecursive(bool value);
+
     UID GetPrefabUID() const { return prefabUID; }
     void SetPrefabUID(const UID uid) { prefabUID = uid; }
+    void SetPrefabChildUID(const UID uid) { prefabChildUID = uid; }
+
     void ParentUpdatedComponents();
     void OnTransformUpdated();
     void SetPosition(float3& newPosition) { position = newPosition; };
@@ -158,6 +161,7 @@ class SOBRASADA_API_ENGINE GameObject
     void SetOpenHierarchyNode(bool newOpen) { openHierarchyNode = newOpen; }
 
     void SetJustLocalTransform(const float4x4& newTransform);
+
   private:
     void DrawNodes() const;
     void OnDrawConnectionsToggle();
@@ -182,6 +186,7 @@ class SOBRASADA_API_ENGINE GameObject
     char renameBuffer[128];
 
     UID prefabUID                        = INVALID_UID;
+    UID prefabChildUID                   = INVALID_UID;
     bool drawNodes                       = false;
 
     float3 position                      = float3::zero;

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.h
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.h
@@ -141,7 +141,9 @@ class SOBRASADA_API_ENGINE GameObject
     bool IsGloballyEnabled() const;
     void SetEnabledRecursive(bool value);
 
+    void RemovePrefabStatus();
     UID GetPrefabUID() const { return prefabUID; }
+    UID GetPrefabVersionUID() const { return prefabVersionUID; }
     UID GetPrefabChildUID() const { return prefabChildUID; }
     void SetPrefabUID(const UID uid) { prefabUID = uid; }
     void SetPrefabChildUID(const UID uid) { prefabChildUID = uid; }
@@ -189,7 +191,9 @@ class SOBRASADA_API_ENGINE GameObject
     char renameBuffer[128];
 
     UID prefabUID                        = INVALID_UID;
+    UID prefabVersionUID                 = INVALID_UID;
     UID prefabChildUID                   = INVALID_UID;
+
     bool drawNodes                       = false;
 
     float3 position                      = float3::zero;

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -1845,7 +1845,7 @@ void Scene::OverridePrefabs(const UID prefabUID)
         return;
     }
 
-    // CHeck that the prefab and target objects have the field prefabChildUID. If not, override like in the old times
+    // Check that the prefab and target objects have the field prefabChildUID. If not, override like in the old times
     bool newPrefab                                = true;
 
     const std::vector<GameObject*>& prefabObjects = prefab->GetGameObjectsVector();
@@ -1858,163 +1858,189 @@ void Scene::OverridePrefabs(const UID prefabUID)
         }
     }
 
-    if (newPrefab)
+    std::vector<GameObject*> newPrefabInstances;
+    std::vector<GameObject*> oldPrefabInstances;
+    for (const auto& gameObject : gameObjectsContainer)
     {
-        for (const auto& gameObject : gameObjectsContainer)
+        if (gameObject.second != nullptr && gameObject.second->GetPrefabUID() == prefabUID)
         {
-            if (gameObject.second != nullptr && gameObject.second->GetPrefabUID() == prefabUID)
+            bool newObject = true;
+            std::queue<UID> childUIDs;
+            for (UID child : gameObject.second->GetChildren())
             {
-                std::queue<UID> childUIDs;
-                for (UID child : gameObject.second->GetChildren())
+                childUIDs.push(child);
+            }
+
+            while (!childUIDs.empty())
+            {
+                GameObject* currentObject = GetGameObjectByUID(childUIDs.front());
+                if (currentObject->GetPrefabChildUID() == INVALID_UID)
+                {
+                    newObject = false;
+                    break;
+                }
+                childUIDs.pop();
+
+                for (UID child : currentObject->GetChildren())
                 {
                     childUIDs.push(child);
                 }
-
-                while (!childUIDs.empty())
-                {
-                    GameObject* currentObject = GetGameObjectByUID(childUIDs.front());
-                    if (currentObject->GetPrefabChildUID() == INVALID_UID)
-                    {
-                        newPrefab = false;
-                        break;
-                    }
-                    childUIDs.pop();
-
-                    for (UID child : currentObject->GetChildren())
-                    {
-                        childUIDs.push(child);
-                    }
-                }
             }
+
+            if (newPrefab && newObject) newPrefabInstances.push_back(gameObject.second);
+            else oldPrefabInstances.push_back(gameObject.second);
         }
     }
 
-    if (!newPrefab)
+    // Keep this method of overriding for old prefabs, to avoid issues. Eventually all prefabs will get updated and
+    // this won't be used anymore
+    std::vector<UID> updatedObjects;
+    std::vector<float4x4> transforms;
+    std::vector<bool> isEnabled;
+    std::vector<std::vector<bool>> componentsEnabledStates;
+
+    for (GameObject* gameObject : oldPrefabInstances)
     {
-        GLOG("Update old prefab");
-        // Store uids and transforms. We need transforms so when we override the prefab, the objects
-        // stay in place. UIDs to delete the duplicates
-        std::vector<UID> updatedObjects;
-        std::vector<float4x4> transforms;
-        std::vector<bool> isEnabled;
-        std::vector<std::vector<bool>> componentsEnabledStates;
+        GLOG("Update OLD prefab");
 
-        for (const auto& gameObject : gameObjectsContainer)
-        {
-            if (gameObject.second != nullptr && gameObject.second->GetPrefabUID() == prefabUID)
+        updatedObjects.push_back(gameObject->GetUID());
+        transforms.emplace_back(gameObject->GetLocalTransform());
+        isEnabled.push_back(gameObject->IsEnabled());
+
+        std::vector<bool> componentStates;
+        auto& tuple = gameObject->GetComponentsTupleRef();
+
+        ForEachInTuple(
+            tuple,
+            [&](auto* component)
             {
-                updatedObjects.push_back(gameObject.first);
-                transforms.emplace_back(gameObject.second->GetLocalTransform());
-                isEnabled.push_back(gameObject.second->IsEnabled());
+                if (component != nullptr)
+                {
+                    componentStates.push_back(component->GetWasEnabled());
+                }
+            }
+        );
 
-                std::vector<bool> componentStates;
-                auto& tuple = gameObject.second->GetComponentsTupleRef();
+        componentsEnabledStates.push_back(componentStates);
+    }
 
-                ForEachInTuple(
-                    tuple,
-                    [&](auto* component)
-                    {
-                        if (component != nullptr)
-                        {
-                            componentStates.push_back(component->GetWasEnabled());
-                        }
-                    }
-                );
+    for (const UID object : updatedObjects)
+    {
+        RemoveGameObjectHierarchy(object);
+    }
 
-                componentsEnabledStates.push_back(componentStates);
+    for (int i = 0; i < transforms.size(); ++i)
+    {
+        LoadPrefab(prefabUID, prefab, transforms[i], isEnabled[i], componentsEnabledStates[i]);
+    }
+
+    // This new method only works if the gameObjects inside the prefab have the field prefabChildUIDS, so it can't
+    // be used with older prefabs Update all gameObjects that have the same prefabUID
+    for (GameObject* gameObject : newPrefabInstances)
+    {
+        GLOG("Update NEW prefab");
+
+        const std::vector<GameObject*>& referenceObjectsVector = prefab->GetGameObjectsVector();
+        std::unordered_map<UID, GameObject*> referenceObjectsMap;
+        prefab->GetGameObjectsMap(referenceObjectsMap);
+
+        // Check for children
+        const std::vector<UID>& rootObjectChildrenUIDs = gameObject->GetChildren();
+        const std::vector<UID>& rootPrefabChildrenUIDs = referenceObjectsVector[0]->GetChildren();
+        if (rootObjectChildrenUIDs.size() < rootPrefabChildrenUIDs.size())
+        {
+            // Fill a vector with the prefab children gameObects
+            std::vector<GameObject*> prefabChildren;
+            for (const UID childUID : rootPrefabChildrenUIDs)
+            {
+                for (GameObject* object : referenceObjectsVector)
+                {
+                    if (object->GetUID() == childUID) prefabChildren.push_back(object);
+                }
+            }
+
+            // Fill a map with the current object children for faster lookup
+            std::map<UID, GameObject*> objectChildren;
+            for (const UID childUID : rootObjectChildrenUIDs)
+            {
+                GameObject* objectToAdd = GetGameObjectByUID(childUID);
+                objectChildren.insert({objectToAdd->GetPrefabChildUID(), objectToAdd});
+            }
+
+            for (GameObject* prefabChild : prefabChildren)
+            {
+                // If prefab child does not exist in current gameObject, create it here
+                if (objectChildren.find(prefabChild->GetPrefabChildUID()) == objectChildren.end())
+                {
+                    GameObject* newObject = new GameObject(gameObject->GetUID(), prefabChild);
+                    gameObject->AddGameObject(newObject->GetUID());
+                    AddGameObject(newObject->GetUID(), newObject);
+                }
             }
         }
 
-        for (const UID object : updatedObjects)
+        std::queue<UID> childUIDs;
+        for (UID child : gameObject->GetChildren())
         {
-            RemoveGameObjectHierarchy(object);
+            childUIDs.push(child);
         }
 
-        for (int i = 0; i < transforms.size(); ++i)
+        while (!childUIDs.empty())
         {
-            LoadPrefab(prefabUID, prefab, transforms[i], isEnabled[i], componentsEnabledStates[i]);
-        }
-    }
-    else
-    {
-        GLOG("Update new prefab");
-        // This new method only works if the gameObjects inside the prefab have the field prefabChildUIDS, so it can't
-        // be used with older prefabs Update all gameObjects that have the same prefabUID
-        for (const auto& gameObject : gameObjectsContainer)
-        {
-            if (gameObject.second != nullptr && gameObject.second->GetPrefabUID() == prefabUID)
+            GameObject* currentObject = GetGameObjectByUID(childUIDs.front());
+            childUIDs.pop();
+
+            GameObject* refObject = nullptr;
+            if (referenceObjectsMap.find(currentObject->GetPrefabChildUID()) == referenceObjectsMap.end())
             {
-                std::unordered_map<UID, GameObject*> referenceObjects;
-                prefab->GetGameObjectsMap(referenceObjects);
+                // If not found in prefab, delete the gameObject because it was deleted in the prefab
+                RemoveGameObjectHierarchy(currentObject->GetUID());
+                continue;
+            }
 
-                std::queue<UID> childUIDs;
-                for (UID child : gameObject.second->GetChildren())
+            refObject = referenceObjectsMap.at(currentObject->GetPrefabChildUID());
+
+            // Update gameObject
+            currentObject->UpdateFromReference(refObject);
+
+            // Add children to queue
+            for (UID child : currentObject->GetChildren())
+            {
+                childUIDs.push(child);
+            }
+
+            // Check for children
+            const std::vector<UID>& objectChildrenUIDs = currentObject->GetChildren();
+            const std::vector<UID>& prefabChildrenUIDs = refObject->GetChildren();
+
+            if (objectChildrenUIDs.size() < prefabChildrenUIDs.size())
+            {
+                // Fill a vector with the prefab children gameObects
+                std::vector<GameObject*> prefabChildren;
+                for (const UID childUID : prefabChildrenUIDs)
                 {
-                    childUIDs.push(child);
+                    for (const auto& object : referenceObjectsMap)
+                    {
+                        if (object.second->GetUID() == childUID) prefabChildren.push_back(object.second);
+                    }
                 }
 
-                while (!childUIDs.empty())
+                // Fill a map with the current object children for faster lookup
+                std::map<UID, GameObject*> objectChildren;
+                for (const UID childUID : objectChildrenUIDs)
                 {
-                    GameObject* currentObject = GetGameObjectByUID(childUIDs.front());
-                    childUIDs.pop();
+                    GameObject* objectToAdd = GetGameObjectByUID(childUID);
+                    objectChildren.insert({objectToAdd->GetPrefabChildUID(), objectToAdd});
+                }
 
-                    GameObject* refObject = nullptr;
-                    if (referenceObjects.find(currentObject->GetPrefabChildUID()) == referenceObjects.end())
+                for (GameObject* prefabChild : prefabChildren)
+                {
+                    // If prefab child does not exist in current gameObject, create it here
+                    if (objectChildren.find(prefabChild->GetPrefabChildUID()) == objectChildren.end())
                     {
-                        // If not found in prefab, delete the gameObject because it was deleted in the prefab
-                        RemoveGameObjectHierarchy(currentObject->GetUID());
-                        continue;
-                    }
-
-                    refObject = referenceObjects.at(currentObject->GetPrefabChildUID());
-
-                    // Update gameObject
-                    currentObject->UpdateFromReference(refObject);
-
-                    // Add children to queue
-                    for (UID child : currentObject->GetChildren())
-                    {
-                        childUIDs.push(child);
-                    }
-
-                    // Check for children
-                    const std::vector<UID>& objectChildrenUIDs = currentObject->GetChildren();
-                    const std::vector<UID>& prefabChildrenUIDs = refObject->GetChildren();
-
-                    if (objectChildrenUIDs.size() < prefabChildrenUIDs.size())
-                    {
-                        // GLOG("Object: %s", currentObject->GetName());
-                        // GLOG("Object child size: %d", objectChildrenUIDs.size());
-                        // GLOG("Prefab child size: %d", prefabChildrenUIDs.size());
-
-                        // Fill a vector with the prefab children gameObects
-                        std::vector<GameObject*> prefabChildren;
-                        for (const UID childUID : prefabChildrenUIDs)
-                        {
-                            for (const auto& object : referenceObjects)
-                            {
-                                if (object.second->GetUID() == childUID) prefabChildren.push_back(object.second);
-                            }
-                        }
-
-                        // Fill a map with the current object children for faster lookup
-                        std::map<UID, GameObject*> objectChildren;
-                        for (const UID childUID : objectChildrenUIDs)
-                        {
-                            GameObject* objectToAdd = GetGameObjectByUID(childUID);
-                            objectChildren.insert({objectToAdd->GetPrefabChildUID(), objectToAdd});
-                        }
-
-                        for (GameObject* prefabChild : prefabChildren)
-                        {
-                            // If prefab child does not exist in current gameObject, create it here
-                            if (objectChildren.find(prefabChild->GetPrefabChildUID()) == objectChildren.end())
-                            {
-                                GameObject* newObject = new GameObject(currentObject->GetUID(), prefabChild);
-                                currentObject->AddGameObject(newObject->GetUID());
-                                AddGameObject(newObject->GetUID(), newObject);
-                            }
-                        }
+                        GameObject* newObject = new GameObject(currentObject->GetUID(), prefabChild);
+                        currentObject->AddGameObject(newObject->GetUID());
+                        AddGameObject(newObject->GetUID(), newObject);
                     }
                 }
             }

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -1840,7 +1840,7 @@ void Scene::OverridePrefabs(const UID prefabUID)
         for (const auto& gameObject : gameObjectsContainer)
         {
             if (gameObject.second != nullptr && gameObject.second->GetPrefabUID() == prefabUID)
-                gameObject.second->SetPrefabUID(INVALID_UID);
+                gameObject.second->RemovePrefabStatus();
         }
         return;
     }
@@ -1860,10 +1860,16 @@ void Scene::OverridePrefabs(const UID prefabUID)
 
     std::vector<GameObject*> newPrefabInstances;
     std::vector<GameObject*> oldPrefabInstances;
+    int instancesToOverride = 0;
     for (const auto& gameObject : gameObjectsContainer)
     {
         if (gameObject.second != nullptr && gameObject.second->GetPrefabUID() == prefabUID)
         {
+            if (prefab->GetVersionUID() != INVALID_UID &&
+                gameObject.second->GetPrefabVersionUID() == prefab->GetVersionUID())
+                continue;
+
+            ++instancesToOverride;
             bool newObject = true;
             std::queue<UID> childUIDs;
             for (UID child : gameObject.second->GetChildren())
@@ -1891,7 +1897,12 @@ void Scene::OverridePrefabs(const UID prefabUID)
             else oldPrefabInstances.push_back(gameObject.second);
         }
     }
-
+    GLOG("Instances to override: %d", instancesToOverride);
+    if (instancesToOverride == 0)
+    {
+        App->GetResourcesModule()->ReleaseResource(prefab);
+        return;
+    }
     // Keep this method of overriding for old prefabs, to avoid issues. Eventually all prefabs will get updated and
     // this won't be used anymore
     std::vector<UID> updatedObjects;
@@ -1944,7 +1955,10 @@ void Scene::OverridePrefabs(const UID prefabUID)
         std::unordered_map<UID, GameObject*> referenceObjectsMap;
         prefab->GetGameObjectsMap(referenceObjectsMap);
 
-        // Check for children
+        // Update root
+        gameObject->UpdateFromReference(referenceObjectsVector[0]);
+
+        // Check for root children
         const std::vector<UID>& rootObjectChildrenUIDs = gameObject->GetChildren();
         const std::vector<UID>& rootPrefabChildrenUIDs = referenceObjectsVector[0]->GetChildren();
         if (rootObjectChildrenUIDs.size() < rootPrefabChildrenUIDs.size())
@@ -1979,6 +1993,7 @@ void Scene::OverridePrefabs(const UID prefabUID)
             }
         }
 
+        // Do the same for all the hierarchy
         std::queue<UID> childUIDs;
         for (UID child : gameObject->GetChildren())
         {

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -1832,7 +1832,7 @@ void Scene::LoadPrefab(
 
 void Scene::OverridePrefabs(const UID prefabUID)
 {
-    const ResourcePrefab* prefab = (const ResourcePrefab*)App->GetResourcesModule()->RequestResource(prefabUID);
+    ResourcePrefab* prefab = (ResourcePrefab*)App->GetResourcesModule()->RequestResource(prefabUID);
 
     // If prefab is null, it no longer exists, then remove the prefab UID from all objects that may have it
     if (prefab == nullptr)
@@ -1896,26 +1896,72 @@ void Scene::OverridePrefabs(const UID prefabUID)
     {
         if (gameObject.second != nullptr && gameObject.second->GetPrefabUID() == prefabUID)
         {
-            const std::vector<GameObject*>& referenceObjects = prefab->GetGameObjectsVector();
-            // gameObject.second Copy components from root prefab
+            std::unordered_map<UID, GameObject*> referenceObjects;
+            prefab->GetGameObjectsMap(referenceObjects);
 
             std::queue<UID> childUIDs;
-            for (UID child : referenceObjects[0]->GetChildren())
+            for (UID child : gameObject.second->GetChildren())
             {
                 childUIDs.push(child);
             }
 
             while (!childUIDs.empty())
             {
-                GameObject* currentObject = App->GetSceneModule()->GetScene()->GetGameObjectByUID(childUIDs.front());
-                // Pillar equivalent en el prefab i copies components
-
+                GameObject* currentObject = GetGameObjectByUID(childUIDs.front());
                 childUIDs.pop();
 
-                // Despres de copiar els gameObjects o borrar els que ja no existeixen, s'han d'afegir si se n'han creat nous. Puc pillar aqui el numero de fills del pare d'aquest i del pare del del prefab.
-                // Si el del prefab es mes gran, miro quins no s'han copiat i els creo. Aixo tambe s'haura de fer al principi per al root
-            }
+                GameObject* refObject = nullptr;
+                if (referenceObjects.find(currentObject->GetPrefabChildUID()) == referenceObjects.end())
+                {
+                    // If not found in prefab, delete the gameObject because it was deleted in the prefab
+                    RemoveGameObjectHierarchy(currentObject->GetUID());
+                    continue;
+                }
 
+                refObject = referenceObjects.at(currentObject->GetPrefabChildUID());
+
+                // Update gameObject
+
+                // Add children to queue
+                for (UID child : currentObject->GetChildren())
+                {
+                    childUIDs.push(child);
+                }
+
+                // Check for children
+                const std::vector<UID>& objectChildrenUIDs = currentObject->GetChildren();
+                const std::vector<UID>& prefabChildrenUIDs = refObject->GetChildren();
+                if (objectChildrenUIDs.size() < prefabChildrenUIDs.size())
+                {
+                    // Fill a vector with the prefab children gameObects
+                    std::vector<GameObject*> prefabChildren;
+                    for (const UID childUID : prefabChildrenUIDs)
+                    {
+                        for (const auto& object : referenceObjects)
+                        {
+                            if (object.second->GetUID() == childUID) prefabChildren.push_back(object.second);
+                        }
+                    }
+
+                    // Fill a map with the current object children for faster lookup
+                    std::map<UID, GameObject*> objectChildren;
+                    for (const UID childUID : objectChildrenUIDs)
+                    {
+                        objectChildren.insert({childUID, GetGameObjectByUID(childUID)});
+                    }
+
+                    for (GameObject* prefabChild : prefabChildren)
+                    {
+                        // If prefab child does not exist in current gameObject, create it here
+                        if (objectChildren.find(prefabChild->GetPrefabChildUID()) == objectChildren.end())
+                        {
+                            GameObject* newObject = new GameObject(currentObject->GetUID(), prefabChild);
+                            currentObject->AddGameObject(newObject->GetUID());
+                            AddGameObject(newObject->GetUID(), newObject);
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -2020,7 +2020,7 @@ void Scene::OverridePrefabs(const UID prefabUID)
             }
         }
     }
-
+    if (lightsConfig != nullptr) lightsConfig->GetAllSceneLights();
     App->GetResourcesModule()->ReleaseResource(prefab);
 }
 

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -206,11 +206,11 @@ void Scene::Init()
     multiSelectParent = new GameObject(GenerateUID(), "MULTISELECT_DUMMY");
     gameObjectsContainer.insert({multiSelectParent->GetUID(), multiSelectParent});
 
-    constexpr float cubeVertices[]       = {-0.5f, -0.5f, 0.5f,  -0.5f, 0.5f, 0.5f,  0.5f, 0.5f, 0.5f,  0.5f, -0.5f, 0.5f,
-                                        -0.5f, -0.5f, -0.5f, -0.5f, 0.5f, -0.5f, 0.5f, 0.5f, -0.5f, 0.5f, -0.5f, -0.5f};
+    constexpr float cubeVertices[] = {-0.5f, -0.5f, 0.5f,  -0.5f, 0.5f, 0.5f,  0.5f, 0.5f, 0.5f,  0.5f, -0.5f, 0.5f,
+                                      -0.5f, -0.5f, -0.5f, -0.5f, 0.5f, -0.5f, 0.5f, 0.5f, -0.5f, 0.5f, -0.5f, -0.5f};
 
     constexpr unsigned int cubeIndices[] = {0, 1, 2, 2, 3, 0, 7, 6, 5, 5, 4, 7, 4, 5, 1, 1, 0, 4,
-                                        3, 2, 6, 6, 7, 3, 1, 5, 6, 6, 2, 1, 4, 0, 3, 3, 7, 4};
+                                            3, 2, 6, 6, 7, 3, 1, 5, 6, 6, 2, 1, 4, 0, 3, 3, 7, 4};
 
     glGenVertexArrays(1, &decalVAO);
     glGenBuffers(1, &decalVBO);
@@ -1847,48 +1847,76 @@ void Scene::OverridePrefabs(const UID prefabUID)
 
     // Store uids and transforms. We need transforms so when we override the prefab, the objects
     // stay in place. UIDs to delete the duplicates
-    std::vector<UID> updatedObjects;
-    std::vector<float4x4> transforms;
-    std::vector<bool> isEnabled;
-    std::vector<std::vector<bool>> componentsEnabledStates;
+    // std::vector<UID> updatedObjects;
+    // std::vector<float4x4> transforms;
+    // std::vector<bool> isEnabled;
+    // std::vector<std::vector<bool>> componentsEnabledStates;
+    //
+    // for (const auto& gameObject : gameObjectsContainer)
+    //{
+    //    if (gameObject.second != nullptr)
+    //    {
+    //        if (gameObject.second->GetPrefabUID() == prefabUID)
+    //        {
+    //            updatedObjects.push_back(gameObject.first);
+    //            transforms.emplace_back(gameObject.second->GetLocalTransform());
+    //            isEnabled.push_back(gameObject.second->IsEnabled());
+    //
+    //            std::vector<bool> componentStates;
+    //            auto& tuple = gameObject.second->GetComponentsTupleRef();
+    //
+    //            ForEachInTuple(
+    //                tuple,
+    //                [&](auto* component)
+    //                {
+    //                    if (component != nullptr)
+    //                    {
+    //                        componentStates.push_back(component->GetWasEnabled());
+    //                    }
+    //                }
+    //            );
+    //
+    //            componentsEnabledStates.push_back(componentStates);
+    //        }
+    //    }
+    //}
+    //
+    // for (const UID object : updatedObjects)
+    //{
+    //    RemoveGameObjectHierarchy(object);
+    //}
+    //
+    // for (int i = 0; i < transforms.size(); ++i)
+    //{
+    //    LoadPrefab(prefabUID, prefab, transforms[i], isEnabled[i], componentsEnabledStates[i]);
+    //}
 
+    // Update all gameObjects that have the same prefabUID
     for (const auto& gameObject : gameObjectsContainer)
     {
-        if (gameObject.second != nullptr)
+        if (gameObject.second != nullptr && gameObject.second->GetPrefabUID() == prefabUID)
         {
-            if (gameObject.second->GetPrefabUID() == prefabUID)
+            const std::vector<GameObject*>& referenceObjects = prefab->GetGameObjectsVector();
+            // gameObject.second Copy components from root prefab
+
+            std::queue<UID> childUIDs;
+            for (UID child : referenceObjects[0]->GetChildren())
             {
-                updatedObjects.push_back(gameObject.first);
-                transforms.emplace_back(gameObject.second->GetLocalTransform());
-                isEnabled.push_back(gameObject.second->IsEnabled());
-
-                std::vector<bool> componentStates;
-                auto& tuple = gameObject.second->GetComponentsTupleRef();
-
-                ForEachInTuple(
-                    tuple,
-                    [&](auto* component)
-                    {
-                        if (component != nullptr)
-                        {
-                            componentStates.push_back(component->GetWasEnabled());
-                        }
-                    }
-                );
-
-                componentsEnabledStates.push_back(componentStates);
+                childUIDs.push(child);
             }
+
+            while (!childUIDs.empty())
+            {
+                GameObject* currentObject = App->GetSceneModule()->GetScene()->GetGameObjectByUID(childUIDs.front());
+                // Pillar equivalent en el prefab i copies components
+
+                childUIDs.pop();
+
+                // Despres de copiar els gameObjects o borrar els que ja no existeixen, s'han d'afegir si se n'han creat nous. Puc pillar aqui el numero de fills del pare d'aquest i del pare del del prefab.
+                // Si el del prefab es mes gran, miro quins no s'han copiat i els creo. Aixo tambe s'haura de fer al principi per al root
+            }
+
         }
-    }
-
-    for (const UID object : updatedObjects)
-    {
-        RemoveGameObjectHierarchy(object);
-    }
-
-    for (int i = 0; i < transforms.size(); ++i)
-    {
-        LoadPrefab(prefabUID, prefab, transforms[i], isEnabled[i], componentsEnabledStates[i]);
     }
 
     App->GetResourcesModule()->ReleaseResource(prefab);

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -1845,119 +1845,175 @@ void Scene::OverridePrefabs(const UID prefabUID)
         return;
     }
 
-    // Store uids and transforms. We need transforms so when we override the prefab, the objects
-    // stay in place. UIDs to delete the duplicates
-    // std::vector<UID> updatedObjects;
-    // std::vector<float4x4> transforms;
-    // std::vector<bool> isEnabled;
-    // std::vector<std::vector<bool>> componentsEnabledStates;
-    //
-    // for (const auto& gameObject : gameObjectsContainer)
-    //{
-    //    if (gameObject.second != nullptr)
-    //    {
-    //        if (gameObject.second->GetPrefabUID() == prefabUID)
-    //        {
-    //            updatedObjects.push_back(gameObject.first);
-    //            transforms.emplace_back(gameObject.second->GetLocalTransform());
-    //            isEnabled.push_back(gameObject.second->IsEnabled());
-    //
-    //            std::vector<bool> componentStates;
-    //            auto& tuple = gameObject.second->GetComponentsTupleRef();
-    //
-    //            ForEachInTuple(
-    //                tuple,
-    //                [&](auto* component)
-    //                {
-    //                    if (component != nullptr)
-    //                    {
-    //                        componentStates.push_back(component->GetWasEnabled());
-    //                    }
-    //                }
-    //            );
-    //
-    //            componentsEnabledStates.push_back(componentStates);
-    //        }
-    //    }
-    //}
-    //
-    // for (const UID object : updatedObjects)
-    //{
-    //    RemoveGameObjectHierarchy(object);
-    //}
-    //
-    // for (int i = 0; i < transforms.size(); ++i)
-    //{
-    //    LoadPrefab(prefabUID, prefab, transforms[i], isEnabled[i], componentsEnabledStates[i]);
-    //}
+    // CHeck that the prefab and target objects have the field prefabChildUID. If not, override like in the old times
+    bool newPrefab                                = true;
 
-    // Update all gameObjects that have the same prefabUID
-    for (const auto& gameObject : gameObjectsContainer)
+    const std::vector<GameObject*>& prefabObjects = prefab->GetGameObjectsVector();
+    for (int i = 1; i < prefabObjects.size(); ++i)
     {
-        if (gameObject.second != nullptr && gameObject.second->GetPrefabUID() == prefabUID)
+        if (prefabObjects[i]->GetPrefabChildUID() == INVALID_UID)
         {
-            std::unordered_map<UID, GameObject*> referenceObjects;
-            prefab->GetGameObjectsMap(referenceObjects);
+            newPrefab = false;
+            break;
+        }
+    }
 
-            std::queue<UID> childUIDs;
-            for (UID child : gameObject.second->GetChildren())
+    if (newPrefab)
+    {
+        for (const auto& gameObject : gameObjectsContainer)
+        {
+            if (gameObject.second != nullptr && gameObject.second->GetPrefabUID() == prefabUID)
             {
-                childUIDs.push(child);
-            }
-
-            while (!childUIDs.empty())
-            {
-                GameObject* currentObject = GetGameObjectByUID(childUIDs.front());
-                childUIDs.pop();
-
-                GameObject* refObject = nullptr;
-                if (referenceObjects.find(currentObject->GetPrefabChildUID()) == referenceObjects.end())
-                {
-                    // If not found in prefab, delete the gameObject because it was deleted in the prefab
-                    RemoveGameObjectHierarchy(currentObject->GetUID());
-                    continue;
-                }
-
-                refObject = referenceObjects.at(currentObject->GetPrefabChildUID());
-
-                // Update gameObject
-
-                // Add children to queue
-                for (UID child : currentObject->GetChildren())
+                std::queue<UID> childUIDs;
+                for (UID child : gameObject.second->GetChildren())
                 {
                     childUIDs.push(child);
                 }
 
-                // Check for children
-                const std::vector<UID>& objectChildrenUIDs = currentObject->GetChildren();
-                const std::vector<UID>& prefabChildrenUIDs = refObject->GetChildren();
-                if (objectChildrenUIDs.size() < prefabChildrenUIDs.size())
+                while (!childUIDs.empty())
                 {
-                    // Fill a vector with the prefab children gameObects
-                    std::vector<GameObject*> prefabChildren;
-                    for (const UID childUID : prefabChildrenUIDs)
+                    GameObject* currentObject = GetGameObjectByUID(childUIDs.front());
+                    if (currentObject->GetPrefabChildUID() == INVALID_UID)
                     {
-                        for (const auto& object : referenceObjects)
+                        newPrefab = false;
+                        break;
+                    }
+                    childUIDs.pop();
+
+                    for (UID child : currentObject->GetChildren())
+                    {
+                        childUIDs.push(child);
+                    }
+                }
+            }
+        }
+    }
+
+    if (!newPrefab)
+    {
+        GLOG("Update old prefab");
+        // Store uids and transforms. We need transforms so when we override the prefab, the objects
+        // stay in place. UIDs to delete the duplicates
+        std::vector<UID> updatedObjects;
+        std::vector<float4x4> transforms;
+        std::vector<bool> isEnabled;
+        std::vector<std::vector<bool>> componentsEnabledStates;
+
+        for (const auto& gameObject : gameObjectsContainer)
+        {
+            if (gameObject.second != nullptr && gameObject.second->GetPrefabUID() == prefabUID)
+            {
+                updatedObjects.push_back(gameObject.first);
+                transforms.emplace_back(gameObject.second->GetLocalTransform());
+                isEnabled.push_back(gameObject.second->IsEnabled());
+
+                std::vector<bool> componentStates;
+                auto& tuple = gameObject.second->GetComponentsTupleRef();
+
+                ForEachInTuple(
+                    tuple,
+                    [&](auto* component)
+                    {
+                        if (component != nullptr)
                         {
-                            if (object.second->GetUID() == childUID) prefabChildren.push_back(object.second);
+                            componentStates.push_back(component->GetWasEnabled());
                         }
                     }
+                );
 
-                    // Fill a map with the current object children for faster lookup
-                    std::map<UID, GameObject*> objectChildren;
-                    for (const UID childUID : objectChildrenUIDs)
+                componentsEnabledStates.push_back(componentStates);
+            }
+        }
+
+        for (const UID object : updatedObjects)
+        {
+            RemoveGameObjectHierarchy(object);
+        }
+
+        for (int i = 0; i < transforms.size(); ++i)
+        {
+            LoadPrefab(prefabUID, prefab, transforms[i], isEnabled[i], componentsEnabledStates[i]);
+        }
+    }
+    else
+    {
+        GLOG("Update new prefab");
+        // This new method only works if the gameObjects inside the prefab have the field prefabChildUIDS, so it can't
+        // be used with older prefabs Update all gameObjects that have the same prefabUID
+        for (const auto& gameObject : gameObjectsContainer)
+        {
+            if (gameObject.second != nullptr && gameObject.second->GetPrefabUID() == prefabUID)
+            {
+                std::unordered_map<UID, GameObject*> referenceObjects;
+                prefab->GetGameObjectsMap(referenceObjects);
+
+                std::queue<UID> childUIDs;
+                for (UID child : gameObject.second->GetChildren())
+                {
+                    childUIDs.push(child);
+                }
+
+                while (!childUIDs.empty())
+                {
+                    GameObject* currentObject = GetGameObjectByUID(childUIDs.front());
+                    childUIDs.pop();
+
+                    GameObject* refObject = nullptr;
+                    if (referenceObjects.find(currentObject->GetPrefabChildUID()) == referenceObjects.end())
                     {
-                        objectChildren.insert({childUID, GetGameObjectByUID(childUID)});
+                        // If not found in prefab, delete the gameObject because it was deleted in the prefab
+                        RemoveGameObjectHierarchy(currentObject->GetUID());
+                        continue;
                     }
 
-                    for (GameObject* prefabChild : prefabChildren)
+                    refObject = referenceObjects.at(currentObject->GetPrefabChildUID());
+
+                    // Update gameObject
+                    currentObject->UpdateFromReference(refObject);
+
+                    // Add children to queue
+                    for (UID child : currentObject->GetChildren())
                     {
-                        // If prefab child does not exist in current gameObject, create it here
-                        if (objectChildren.find(prefabChild->GetPrefabChildUID()) == objectChildren.end())
+                        childUIDs.push(child);
+                    }
+
+                    // Check for children
+                    const std::vector<UID>& objectChildrenUIDs = currentObject->GetChildren();
+                    const std::vector<UID>& prefabChildrenUIDs = refObject->GetChildren();
+
+                    if (objectChildrenUIDs.size() < prefabChildrenUIDs.size())
+                    {
+                        // GLOG("Object: %s", currentObject->GetName());
+                        // GLOG("Object child size: %d", objectChildrenUIDs.size());
+                        // GLOG("Prefab child size: %d", prefabChildrenUIDs.size());
+
+                        // Fill a vector with the prefab children gameObects
+                        std::vector<GameObject*> prefabChildren;
+                        for (const UID childUID : prefabChildrenUIDs)
                         {
-                            GameObject* newObject = new GameObject(currentObject->GetUID(), prefabChild);
-                            currentObject->AddGameObject(newObject->GetUID());
-                            AddGameObject(newObject->GetUID(), newObject);
+                            for (const auto& object : referenceObjects)
+                            {
+                                if (object.second->GetUID() == childUID) prefabChildren.push_back(object.second);
+                            }
+                        }
+
+                        // Fill a map with the current object children for faster lookup
+                        std::map<UID, GameObject*> objectChildren;
+                        for (const UID childUID : objectChildrenUIDs)
+                        {
+                            GameObject* objectToAdd = GetGameObjectByUID(childUID);
+                            objectChildren.insert({objectToAdd->GetPrefabChildUID(), objectToAdd});
+                        }
+
+                        for (GameObject* prefabChild : prefabChildren)
+                        {
+                            // If prefab child does not exist in current gameObject, create it here
+                            if (objectChildren.find(prefabChild->GetPrefabChildUID()) == objectChildren.end())
+                            {
+                                GameObject* newObject = new GameObject(currentObject->GetUID(), prefabChild);
+                                currentObject->AddGameObject(newObject->GetUID());
+                                AddGameObject(newObject->GetUID(), newObject);
+                            }
                         }
                     }
                 }

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -1870,6 +1870,13 @@ void Scene::OverridePrefabs(const UID prefabUID)
                 continue;
 
             ++instancesToOverride;
+
+            if (!newPrefab)
+            {
+                oldPrefabInstances.push_back(gameObject.second);
+                continue;
+            }
+
             bool newObject = true;
             std::queue<UID> childUIDs;
             for (UID child : gameObject.second->GetChildren())
@@ -1893,7 +1900,7 @@ void Scene::OverridePrefabs(const UID prefabUID)
                 }
             }
 
-            if (newPrefab && newObject) newPrefabInstances.push_back(gameObject.second);
+            if (newObject) newPrefabInstances.push_back(gameObject.second);
             else oldPrefabInstances.push_back(gameObject.second);
         }
     }
@@ -1955,50 +1962,9 @@ void Scene::OverridePrefabs(const UID prefabUID)
         std::unordered_map<UID, GameObject*> referenceObjectsMap;
         prefab->GetGameObjectsMap(referenceObjectsMap);
 
-        // Update root
-        gameObject->UpdateFromReference(referenceObjectsVector[0]);
-
-        // Check for root children
-        const std::vector<UID>& rootObjectChildrenUIDs = gameObject->GetChildren();
-        const std::vector<UID>& rootPrefabChildrenUIDs = referenceObjectsVector[0]->GetChildren();
-        if (rootObjectChildrenUIDs.size() < rootPrefabChildrenUIDs.size())
-        {
-            // Fill a vector with the prefab children gameObects
-            std::vector<GameObject*> prefabChildren;
-            for (const UID childUID : rootPrefabChildrenUIDs)
-            {
-                for (GameObject* object : referenceObjectsVector)
-                {
-                    if (object->GetUID() == childUID) prefabChildren.push_back(object);
-                }
-            }
-
-            // Fill a map with the current object children for faster lookup
-            std::map<UID, GameObject*> objectChildren;
-            for (const UID childUID : rootObjectChildrenUIDs)
-            {
-                GameObject* objectToAdd = GetGameObjectByUID(childUID);
-                objectChildren.insert({objectToAdd->GetPrefabChildUID(), objectToAdd});
-            }
-
-            for (GameObject* prefabChild : prefabChildren)
-            {
-                // If prefab child does not exist in current gameObject, create it here
-                if (objectChildren.find(prefabChild->GetPrefabChildUID()) == objectChildren.end())
-                {
-                    GameObject* newObject = new GameObject(gameObject->GetUID(), prefabChild);
-                    gameObject->AddGameObject(newObject->GetUID());
-                    AddGameObject(newObject->GetUID(), newObject);
-                }
-            }
-        }
-
-        // Do the same for all the hierarchy
+       // Update all the hierarchy
         std::queue<UID> childUIDs;
-        for (UID child : gameObject->GetChildren())
-        {
-            childUIDs.push(child);
-        }
+        childUIDs.push(gameObject->GetUID());
 
         while (!childUIDs.empty())
         {

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SpawnUI.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SpawnUI.cpp
@@ -39,6 +39,6 @@ void SpawnUI::Update(float deltaTime)
 void SpawnUI::OnCollision(GameObject* otherObject, const float3& collisionNormal)
 {
     // triggers only collision with Player
-    imageUI->SetEnabled(true);
+    if (imageUI) imageUI->SetEnabled(true);
     onCollision = true;
 }


### PR DESCRIPTION
The main change of this PR is how prefabs are overriden. Now prefabs are no longer deleted and created again, but simply updated, so the gameObjects and components UIDs remain the same. This allows some features like the gameObject field in scripting be useful again. Also, because they are not deleted they can be children of other gameObjects. I'm pretty sure this change also fixes some other problems there could be with batching and other things, but I have not checked.

However, this only works with new prefabs, because a new field has been added to the prefab files. Old prefabs are still overriden the old way, but once they are overriden, they should be updated and start overriding in the new way. Eventually all prefabs that already exist in the game will probably get updated wihtout needing to recreate them.

I also added a new field prefabVersionUID, which keeps track of the prefab version. This way, prefabs are only overriden if they have changed, so when loading a new scene no prefabs will be overrriden except if they have been updated in another scene. This also works only with new prefabs.

TO TEST: go in the game repo, modify prefabs and load scenes to check if everything works fine. There are some logs that say how many prefabs have been overriden, if in the old or new way, etc., to help see if it's correct.

This task had another part of saving individually modified prefabs when saving the scene, but I have not done it here. I don't even know if that's needed. If you want to save a modified prefab, you can unlink it before saving the scene and it will be properly saved.