### PR TITLE
task/God mode player THO-664

### DIFF
--- a/SobrassadaEngine/Scene/Components/CameraComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/CameraComponent.cpp
@@ -279,11 +279,7 @@ void CameraComponent::RenderEditorInspector()
         float hfov = camera.horizontalFov * RAD_DEGREE_CONV;
         if (ImGui::DragFloat("FoV", &hfov, 0.1f, 1.0f, 179.0f, "%.2f"))
         {
-            camera.horizontalFov = hfov * DEGREE_RAD_CONV;
-            auto framebuffer     = App->GetOpenGLModule()->GetFramebuffer();
-            int width            = framebuffer->GetTextureWidth();
-            int height           = framebuffer->GetTextureHeight();
-            camera.verticalFov   = 2.0f * atanf(tanf(camera.horizontalFov * 0.5f) * ((float)height / (float)width));
+            SetFov(hfov);
         }
     }
     else if (camera.type == OrthographicFrustum)
@@ -509,4 +505,13 @@ void CameraComponent::ChangeToOrtographic()
     camera.orthographicHeight = orthographicHeight;
     camera.nearPlaneDistance  = ortographicNearPlane;
     camera.farPlaneDistance   = ortographicFarPlane;
+}
+
+void CameraComponent::SetFov(float fov)
+{
+    camera.horizontalFov = fov * DEGREE_RAD_CONV;
+    auto framebuffer     = App->GetOpenGLModule()->GetFramebuffer();
+    int width            = framebuffer->GetTextureWidth();
+    int height           = framebuffer->GetTextureHeight();
+    camera.verticalFov   = 2.0f * atanf(tanf(camera.horizontalFov * 0.5f) * ((float)height / (float)width));
 }

--- a/SobrassadaEngine/Scene/Components/CameraComponent.h
+++ b/SobrassadaEngine/Scene/Components/CameraComponent.h
@@ -54,9 +54,6 @@ class CameraComponent : public Component
     void SetFreeCamera(const bool freecamera) { freeCamera = freecamera; }
     SOBRASADA_API_ENGINE void SetFov(float fov);
 
-    float horizontalFov;
-    float verticalFov;
-
   private:
     Frustum camera;
     FrustumPlanes frustumPlanes;
@@ -71,8 +68,11 @@ class CameraComponent : public Component
 
     float orthographicWidth;
     float orthographicHeight;
-    float ortographicNearPlane      = 25.10f;
-    float ortographicFarPlane       = 50.0f;
+    float ortographicNearPlane = 25.10f;
+    float ortographicFarPlane  = 50.0f;
+
+    float horizontalFov;
+    float verticalFov;
 
     bool firstTime                  = true;
 

--- a/SobrassadaEngine/Scene/Components/CameraComponent.h
+++ b/SobrassadaEngine/Scene/Components/CameraComponent.h
@@ -52,18 +52,20 @@ class CameraComponent : public Component
     void SetCameraFront(const float3& front) { camera.front = front; }
     void SetCameraUp(const float3& up) { camera.up = up; }
     void SetFreeCamera(const bool freecamera) { freeCamera = freecamera; }
+    SOBRASADA_API_ENGINE void SetFov(float fov);
+
+    float horizontalFov;
+    float verticalFov;
 
   private:
     Frustum camera;
     FrustumPlanes frustumPlanes;
     CameraMatrices matrices;
-    unsigned int ubo  = 0;
+    unsigned int ubo           = 0;
 
-    bool drawGizmos   = true;
-    bool isMainCamera = false;
+    bool drawGizmos            = true;
+    bool isMainCamera          = false;
 
-    float horizontalFov;
-    float verticalFov;
     float perspectiveNearPlane = 0.1f;
     float perspectiveFarPlane  = 50.0f;
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Character.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Character.cpp
@@ -110,7 +110,6 @@ void Character::OnCollision(GameObject* otherObject, const float3& collisionNorm
     // GLOG("COLLISION %s with %s", parent->GetName().c_str(), otherObject->GetName().c_str())
 
     // ---- Damage Collisions ----
-    if (isInvulnerable) return;
 
     // Melee check
     CapsuleColliderComponent* otherWeapon = otherObject->GetComponent<CapsuleColliderComponent*>();
@@ -199,6 +198,8 @@ void Character::UpdateTimers(float deltaTime)
 
 void Character::TakeDamage(int amount)
 {
+    if (isInvulnerable) return;
+
     currentHealth        -= amount;
 
     isInvulnerable        = true;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Character.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Character.h
@@ -39,7 +39,7 @@ class Character : public Script
     virtual void Update(float deltaTime) override;
     void OnCollision(GameObject* otherObject, const float3& collisionNormal) override;
 
-    void TakeDamage(int amount);
+    virtual void TakeDamage(int amount);
     void Restart();
 
   protected:

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -40,6 +40,7 @@ CuChulainn::CuChulainn(GameObject* parent)
     fields.push_back({"Ultimate hitbox delay", InspectorField::FieldType::Float, &ultimateHitboxDelay, 0.0f, 5.0f});
     fields.push_back({"Ultimate hitbox duration", InspectorField::FieldType::Float, &ultimateHitboxDuration, 0.0f, 5.0f}
     );
+    fields.push_back({"God Mode", InspectorField::FieldType::Bool, &godMode});
 }
 
 bool CuChulainn::Init()
@@ -67,7 +68,7 @@ bool CuChulainn::Init()
 
     };
 
-    character                  = parent->GetComponent<CharacterControllerComponent*>();
+    character = parent->GetComponent<CharacterControllerComponent*>();
     if (!character) GLOG("CharacterController component not found for CuChulainn")
     else speed = character->GetSpeed();
 
@@ -247,20 +248,26 @@ void CuChulainn::GetInputs()
     {
         if (state == CharacterStates::AIM) ThrowSpear();
     }
-    if (keyboard[SDL_SCANCODE_F] || controller[SDL_CONTROLLER_BUTTON_B] == KEY_DOWN)
+    if (keyboard[SDL_SCANCODE_F] == KEY_DOWN || controller[SDL_CONTROLLER_BUTTON_B] == KEY_DOWN)
     {
         desiredUltimate     = true;
         ultimateBufferTimer = inputBuffer;
     }
-    if (keyboard[SDL_SCANCODE_F5])
+    if (keyboard[SDL_SCANCODE_F5] == KEY_DOWN)
     {
-        // TODO: This should be SetSpawnPos, Respawn is here to test
+        // TODO: This should be SetPosition, Respawn is here to test
         // SetPosition(spawnPos);
         Respawn();
     }
-    if (keyboard[SDL_SCANCODE_F6])
+    if (keyboard[SDL_SCANCODE_F6] == KEY_DOWN)
     {
         spawnPos = parent->GetGlobalTransform().TranslatePart();
+    }
+    if (keyboard[SDL_SCANCODE_F7] == KEY_DOWN)
+    {
+        godMode = !godMode;
+        if (godMode) GLOG("God Mode enabled")
+        else GLOG("God Mode disabled")
     }
 }
 
@@ -351,7 +358,7 @@ void CuChulainn::UpdateTimers(float deltaTime)
     }
 
     if (state == CharacterStates::ULTIMATE) ultimateTimer += deltaTime;
-    
+
     // When stop dashing this gets automatically disabled in the timers check
     if (state == CharacterStates::DASH) isInvulnerable = true;
 }
@@ -560,6 +567,12 @@ void CuChulainn::Respawn()
     SetPosition(spawnPos);
     if (animComponent) animComponent->UseTrigger("Respawn");
     character->EnableMovement(false);
+}
+
+void CuChulainn::TakeDamage(int amount)
+{
+    if (godMode) return;
+    Character::TakeDamage(amount);
 }
 
 void CuChulainn::UpdateHealthBarUI()

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
@@ -10,7 +10,6 @@ class Projectile;
 class AudioSourceComponent;
 class ImageComponent;
 
-
 enum class CharacterStates
 {
     NONE,
@@ -51,6 +50,7 @@ class CuChulainn : public Character
     void OnHealed(int amount) override;
     void PerformAttack() override;
     void HandleState(float deltaTime) override;
+    void TakeDamage(int amount) override;
 
     bool CanDash() const;
     bool CanAttack() const;
@@ -124,6 +124,7 @@ class CuChulainn : public Character
     std::vector<UID> healthBarTextures;
     ImageComponent* healthImageComponent = nullptr;
 
+    bool godMode                         = false;
 };
 
 extern CharacterControllerComponent* character;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/GodMode.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/GodMode.cpp
@@ -13,7 +13,7 @@
 GodMode::GodMode(GameObject* parent) : Script(parent)
 {
     fields.push_back({"Camera Name", InspectorField::FieldType::InputText, &cameraName});
-    fields.push_back({"Free camera FOV", InspectorField::FieldType::Float, &freeCameraFov});
+    fields.push_back({"Free camera FOV", InspectorField::FieldType::Float, &freeCameraFov, 0.0f, 180.0f});
 }
 
 bool GodMode::Init()

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/GodMode.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/GodMode.cpp
@@ -3,6 +3,7 @@
 #include "Application.h"
 #include "CameraComponent.h"
 #include "Components/Standalone/CharacterControllerComponent.h"
+#include "CuChulainn.h"
 #include "GameObject.h"
 #include "GodMode.h"
 #include "InputModule.h"
@@ -12,14 +13,11 @@
 GodMode::GodMode(GameObject* parent) : Script(parent)
 {
     fields.push_back({"Camera Name", InspectorField::FieldType::InputText, &cameraName});
+    fields.push_back({"Free camera FOV", InspectorField::FieldType::Float, &freeCameraFov});
 }
 
 bool GodMode::Init()
 {
-    characterController = parent->GetComponent<CharacterControllerComponent*>();
-    if (!characterController)
-        GLOG("[WARNING] GodMode character controller component not found for %s", parent->GetName().c_str());
-
     GameObject* cameraGameObject = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(cameraName);
     if (cameraGameObject)
     {
@@ -33,7 +31,7 @@ bool GodMode::Init()
 
 void GodMode::Update(float deltaTime)
 {
-    if (!characterController || !godCamera) return;
+    if (!godCamera) return;
 
     const KeyState* keyboard = AppEngine->GetInputModule()->GetKeyboard();
 
@@ -67,13 +65,23 @@ void GodMode::Update(float deltaTime)
         {
             freeCamera = false;
             godCamera->SetFreeCamera(false);
-            characterController->SetInputDown(true);
+            character->SetInputDown(true);
+            godCamera->SetFov(35.0f);
+        }
+
+        if (keyboard[SDL_SCANCODE_I] == KEY_DOWN)
+        {
+            const float3& newPlayerPos = godCamera->GetCameraPosition();
+            character->GetParent()->SetLocalPosition(
+                newPlayerPos - character->GetParent()->GetParentGlobalTransform().TranslatePart()
+            );
         }
     }
     if (keyboard[SDL_SCANCODE_P] == KEY_DOWN)
     {
-        characterController->SetInputDown(false);
+        character->SetInputDown(false);
         godCamera->SetFreeCamera(true);
         freeCamera = true;
+        godCamera->SetFov(freeCameraFov);
     }
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/GodMode.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/GodMode.h
@@ -16,9 +16,9 @@ class GodMode : public Script
     void Update(float deltaTime) override;
 
   private:
-    CharacterControllerComponent* characterController = nullptr;
-    std::string cameraName                            = "";
-    CameraComponent* godCamera                        = nullptr;
-    bool freeCamera                                   = false;
-    float4x4 originalTransform;
+    std::string cameraName     = "";
+    CameraComponent* godCamera = nullptr;
+    bool freeCamera            = false;
+    float4x4 originalTransform = float4x4::identity;
+    float freeCameraFov        = 90.0f;
 };


### PR DESCRIPTION
Now, when you are in the god camera while playing, you can press the key 'I' to teleport the player to the camera position (The god camera was enabled with 'P' and disabled with 'O'). You can also change the fov for the god camera.

Also, now the player script has a GodMode checkbox, which if enabled the player can not take damage, to avoid dying while something else is being tested. This can also be enabled and disabled with the F7 key, so it can be used in the game build as well.