### PR TITLE
task/Enemy behaviour update THO-737

### DIFF
--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Archer.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Archer.cpp
@@ -15,7 +15,7 @@
 #include "Standalone/CharacterControllerComponent.h"
 #include "Standalone/Physics/CapsuleColliderComponent.h"
 
-Archer::Archer(GameObject* parent) : Character(parent, 3, 1, 0.5f, 1.0f, 1.0f, 2.0f, 10.0f, CharacterType::Archer)
+Archer::Archer(GameObject* parent) : Character(parent, 3, 1, 0.5f, 1.0f, 1.0f, 2.0f, 10.0f, 15.0f, CharacterType::Archer)
 {
     fields.push_back({"AI Patrol Point", InspectorField::FieldType::Vec3, &patrolPoint, -1000.0f, 1000.0f});
     fields.push_back({"Arrow Projectile Name", InspectorField::FieldType::InputText, &arrowName});

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Archer.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Archer.cpp
@@ -112,8 +112,11 @@ void Archer::PatrolAI()
 {
     animComponent->UseTrigger("run");
 
-    if (CheckDistanceWithPlayer() == PlayerDistances::Medium) currentState = ArcherStates::CHASE;
-    else if (CheckDistanceWithPlayer() == PlayerDistances::Close) currentState = ArcherStates::BASIC_ATTACK;
+    if (!playerScript->IsDead())
+    {
+        if (CheckDistanceWithPlayer() == PlayerDistances::Medium) currentState = ArcherStates::CHASE;
+        else if (CheckDistanceWithPlayer() == PlayerDistances::Close) currentState = ArcherStates::BASIC_ATTACK;
+    }
 
     bool valid = false;
     if (reachedPatrolPoint)
@@ -206,6 +209,12 @@ void Archer::Attack(float deltaTime)
 
 void Archer::ChangeState()
 {
+    if (playerScript->IsDead())
+    {
+        currentState = ArcherStates::PATROL;
+        return;
+    }
+
     const float distance = GetDistanceFromPlayer();
     if (distance <= rangeAIAttack) currentState = ArcherStates::BASIC_ATTACK;
     else if (distance <= rangeAIChase) currentState = ArcherStates::CHASE;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Archer.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Archer.cpp
@@ -15,7 +15,8 @@
 #include "Standalone/CharacterControllerComponent.h"
 #include "Standalone/Physics/CapsuleColliderComponent.h"
 
-Archer::Archer(GameObject* parent) : Character(parent, 3, 1, 0.5f, 1.0f, 1.0f, 2.0f, 10.0f, 15.0f, CharacterType::Archer)
+Archer::Archer(GameObject* parent)
+    : Character(parent, 3, 1, 0.5f, 1.0f, 1.0f, 2.0f, 10.0f, 15.0f, CharacterType::Archer)
 {
     fields.push_back({"AI Patrol Point", InspectorField::FieldType::Vec3, &patrolPoint, -1000.0f, 1000.0f});
     fields.push_back({"Arrow Projectile Name", InspectorField::FieldType::InputText, &arrowName});
@@ -81,16 +82,17 @@ void Archer::HandleState(float deltaTime)
 
     switch (currentState)
     {
+    case ArcherStates::SEARCH:
+        SearchForPlayer();
+        break;
     case ArcherStates::PATROL:
-        // GLOG("Soldier Patrolling");
+        // TODO: Patrol animation
         PatrolAI();
         break;
     case ArcherStates::CHASE:
-        // GLOG("Soldier Chasing");
         ChaseAI();
         break;
     case ArcherStates::BASIC_ATTACK:
-        // GLOG("Soldier Basic Attack");
         if (attackCdTimer <= 0) Attack(deltaTime);
         break;
     default:
@@ -136,6 +138,32 @@ void Archer::ChaseAI()
         else if (!agentAI->SetPathNavigation(character->GetLastPosition())) currentState = ArcherStates::PATROL;
     }
     else currentState = ArcherStates::PATROL;
+}
+
+void Archer::SearchForPlayer()
+{
+    // Stands still for a few seconds, if player gets close again chases, if not returns to patrol
+    if (!isSearching)
+    {
+        // TODO: Would be nice to be a "search" animation instead of idle
+        animComponent->UseTrigger("idle");
+        isSearching = true;
+        searchTimer = searchDuration;
+        agentAI->SetSpeed(0.0f, 0.0f);
+    }
+
+    if (GetDistanceFromPlayer() < maxDetectionRange - 0.5f)
+    {
+        isSearching = false;
+        agentAI->ResetSpeed();
+        currentState = ArcherStates::CHASE;
+    }
+    else if (searchTimer <= 0.0f)
+    {
+        isSearching  = false;
+        currentState = ArcherStates::PATROL;
+        agentAI->ResetSpeed();
+    }
 }
 
 void Archer::Attack(float deltaTime)

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Archer.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Archer.cpp
@@ -134,8 +134,8 @@ void Archer::ChaseAI()
 
     if (character != nullptr)
     {
-        if (CheckDistanceWithPlayer() == PlayerDistances::Medium) currentState = ArcherStates::BASIC_ATTACK;
-        else if (!agentAI->SetPathNavigation(character->GetLastPosition())) currentState = ArcherStates::PATROL;
+        agentAI->SetPathNavigation(character->GetLastPosition());
+        ChangeState();
     }
     else currentState = ArcherStates::PATROL;
 }
@@ -199,7 +199,15 @@ void Archer::Attack(float deltaTime)
             agentAI->ResetSpeed();
             agentAI->SetLookForward(true);
 
-            if (CheckDistanceWithPlayer() != PlayerDistances::Medium) currentState = ArcherStates::CHASE;
+            ChangeState();
         }
     }
+}
+
+void Archer::ChangeState()
+{
+    const float distance = GetDistanceFromPlayer();
+    if (distance <= rangeAIAttack) currentState = ArcherStates::BASIC_ATTACK;
+    else if (distance <= rangeAIChase) currentState = ArcherStates::CHASE;
+    else if (distance > maxDetectionRange) currentState = ArcherStates::SEARCH;
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Archer.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Archer.h
@@ -9,6 +9,7 @@ class Projectile;
 enum class ArcherStates
 {
     NONE,
+    SEARCH,
     PATROL,
     CHASE,
     BASIC_ATTACK
@@ -29,9 +30,10 @@ class Archer : public Character
     void PerformAttack() override;
     void HandleState(float deltaTime) override;
     void Attack(float deltaTime) override;
-
+ 
     void PatrolAI();
     void ChaseAI();
+    void SearchForPlayer();
 
   private:
     AIAgentComponent* agentAI = nullptr;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Archer.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Archer.h
@@ -30,7 +30,8 @@ class Archer : public Character
     void PerformAttack() override;
     void HandleState(float deltaTime) override;
     void Attack(float deltaTime) override;
- 
+
+    void ChangeState();
     void PatrolAI();
     void ChaseAI();
     void SearchForPlayer();

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Banshee.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Banshee.cpp
@@ -192,7 +192,8 @@ void Banshee::Attack(float deltaTime)
             agentAI->ResetSpeed();
             agentAI->ResetAngularSpeed();
             agentAI->SetLookForward(true);
-            ChangeState();
+            if (GetDistanceFromPlayer() > maxDetectionRange) currentState = BansheeStates::Search;
+            else ChangeState();
         }
     }
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Banshee.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Banshee.cpp
@@ -200,6 +200,12 @@ void Banshee::Attack(float deltaTime)
 
 void Banshee::ChangeState()
 {
+    if (playerScript->IsDead())
+    {
+        currentState = BansheeStates::Idle;
+        return;
+    }
+
     const float distance = GetDistanceFromPlayer();
     if (distance <= fleeDistance) currentState = BansheeStates::Flee;
     else if (distance <= rangeAIAttack) currentState = BansheeStates::Scream;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Banshee.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Banshee.cpp
@@ -14,13 +14,14 @@
 Banshee::Banshee(GameObject* parent)
     : Character(
           parent,
-          2, // Max Health
-          2, // Damage
-          2, // Attack Duration
-          4, // Attack Cooldown
-          5, // Attack Range
-          5, // AI Aggro Range
-          5, // AI Chase Range
+          2,    // Max Health
+          2,    // Damage
+          2.0f, // Attack Duration
+          4.0f, // Attack Cooldown
+          5.0f, // Attack Range
+          5.0f, // AI Aggro Range
+          5.0f, // AI Chase Range
+          10.0f, // Max detection range
           CharacterType::Banshee
       )
 {

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Banshee.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Banshee.cpp
@@ -14,13 +14,13 @@
 Banshee::Banshee(GameObject* parent)
     : Character(
           parent,
-          2,    // Max Health
-          2,    // Damage
-          2.0f, // Attack Duration
-          4.0f, // Attack Cooldown
-          5.0f, // Attack Range
-          5.0f, // AI Aggro Range
-          5.0f, // AI Chase Range
+          2,     // Max Health
+          2,     // Damage
+          2.0f,  // Attack Duration
+          4.0f,  // Attack Cooldown
+          5.0f,  // Attack Range
+          5.0f,  // AI Aggro Range
+          5.0f,  // AI Chase Range
           10.0f, // Max detection range
           CharacterType::Banshee
       )
@@ -96,6 +96,10 @@ void Banshee::HandleState(float deltaTime)
         ChangeState();
         break;
 
+    case BansheeStates::Search:
+        SearchForPlayer();
+        break;
+
     case BansheeStates::Chase:
         ChasePlayer();
         break;
@@ -116,7 +120,8 @@ void Banshee::ChasePlayer()
 
     if (animComponent) animComponent->UseTrigger("Chase");
     if (CheckDistanceWithPlayer() <= PlayerDistances::Close) currentState = BansheeStates::Scream;
-    else if (!agentAI->SetPathNavigation(character->GetLastPosition())) currentState = BansheeStates::Idle;
+    else if (!agentAI->SetPathNavigation(character->GetLastPosition()) || GetDistanceFromPlayer() > maxDetectionRange)
+        currentState = BansheeStates::Search;
 }
 
 void Banshee::Flee()
@@ -194,9 +199,37 @@ void Banshee::Attack(float deltaTime)
 
 void Banshee::ChangeState()
 {
-    const float distance = character->GetLastPosition().Distance(parent->GetPosition());
+    const float distance = GetDistanceFromPlayer();
     if (distance <= fleeDistance) currentState = BansheeStates::Flee;
     else if (distance <= rangeAIAttack) currentState = BansheeStates::Scream;
     else if (distance <= rangeAIChase) currentState = BansheeStates::Chase;
     else currentState = BansheeStates::Idle;
+}
+
+void Banshee::SearchForPlayer()
+{
+    // Stands still for a few seconds, if player gets close again chases, if not returns to patrol
+    if (!isSearching)
+    {
+        // TODO: Would be nice to be a "search" animation instead of idle
+        animComponent->UseTrigger("Idle");
+        isSearching = true;
+        searchTimer = searchDuration;
+        agentAI->SetSpeed(0.0f, 0.0f);
+    }
+
+    if (GetDistanceFromPlayer() < maxDetectionRange - 0.5f)
+    {
+        isSearching = false;
+        agentAI->ResetSpeed();
+        currentState = BansheeStates::Chase;
+    }
+    else if (searchTimer <= 0.0f)
+    {
+        // TODO: When merge with new banshee behaviour, teleport to start pos
+        isSearching  = false;
+        currentState = BansheeStates::Idle;
+        agentAI->ResetSpeed();
+        agentAI->SetPathNavigation(startPos);
+    }
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Banshee.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Banshee.h
@@ -9,6 +9,7 @@ class SphereColliderComponent;
 enum class BansheeStates
 {
     Idle,
+    Search,
     Chase,
     Flee,
     Scream
@@ -33,6 +34,7 @@ class Banshee : public Character
     void Flee();
     void Attack(float deltaTime) override;
     void ChangeState();
+    void SearchForPlayer();
 
   private:
     AIAgentComponent* agentAI           = nullptr;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Character.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Character.cpp
@@ -23,11 +23,11 @@
 
 Character::Character(
     GameObject* parent, int newMaxHealth, int newDamage, float newAttackDuration, float newAttackCooldown,
-    float newRange, float newRangeAIAttack, float newRangeAIChase, CharacterType newType
+    float newRange, float newRangeAIAttack, float newRangeAIChase, float newDetectionRange, CharacterType newType
 )
     : Script(parent), maxHealth(newMaxHealth), attackDamage(newDamage), attackDuration(newAttackDuration),
       attackCooldown(newAttackCooldown), range(newRange), rangeAIAttack(newRangeAIAttack),
-      rangeAIChase(newRangeAIChase), type(newType)
+      rangeAIChase(newRangeAIChase), maxDetectionRange(newDetectionRange), type(newType)
 {
     currentHealth = maxHealth;
 
@@ -48,6 +48,7 @@ Character::Character(
     {
         fields.push_back({"AI Chase Range", InspectorField::FieldType::Float, &rangeAIChase, 0.0f, 20.0f});
         fields.push_back({"AI Attack Range", InspectorField::FieldType::Float, &rangeAIAttack, 0.0f, 15.0f});
+        fields.push_back({"AI Max Detection Range", InspectorField::FieldType::Float, &maxDetectionRange, 0.0f, 15.0f});
     }
 }
 
@@ -232,6 +233,11 @@ void Character::Heal(int amount)
     if (currentHealth > maxHealth) currentHealth = maxHealth;
 
     OnHealed(amount);
+}
+
+float Character::GetDistanceFromPlayer() const
+{
+    return character->GetLastPosition().Distance(parent->GetGlobalTransform().TranslatePart());
 }
 
 PlayerDistances Character::CheckDistanceWithPlayer() const

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Character.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Character.cpp
@@ -49,6 +49,7 @@ Character::Character(
         fields.push_back({"AI Chase Range", InspectorField::FieldType::Float, &rangeAIChase, 0.0f, 20.0f});
         fields.push_back({"AI Attack Range", InspectorField::FieldType::Float, &rangeAIAttack, 0.0f, 15.0f});
         fields.push_back({"AI Max Detection Range", InspectorField::FieldType::Float, &maxDetectionRange, 0.0f, 15.0f});
+        fields.push_back({"Player search duration", InspectorField::FieldType::Float, &searchDuration, 0.0f, 10.0f});
     }
 }
 
@@ -196,6 +197,9 @@ void Character::UpdateTimers(float deltaTime)
         desiredHeal = false;
         healCdTimer = 0.0f;
     }
+
+    searchTimer -= deltaTime;
+    if (searchTimer < 0.0f) searchTimer = 0.0f;
 }
 
 void Character::TakeDamage(int amount)

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Character.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Character.h
@@ -31,7 +31,7 @@ class Character : public Script
   public:
     Character(
         GameObject* parent, int maxHealth, int damage, float attackDuration, float cooldown, float range,
-        float rangeAIAttack, float rangeAIChase, CharacterType type
+        float rangeAIAttack, float rangeAIChase, float maxDetectionRange, CharacterType type
     );
     virtual ~Character() noexcept override { parent = nullptr; };
 
@@ -46,6 +46,7 @@ class Character : public Script
     virtual void Attack(float deltaTime);
     virtual void UpdateTimers(float deltaTime);
     void Heal(int amount);
+    float GetDistanceFromPlayer() const;
     PlayerDistances CheckDistanceWithPlayer() const;
     bool CheckDistanceWithPoint(const float3& point) const;
     void RenderDebug();
@@ -94,6 +95,7 @@ class Character : public Script
     // AI
     float rangeAIChase      = 0.0f;
     float rangeAIAttack     = 0.0f;
+    float maxDetectionRange = 0.0f;
     bool reachedPatrolPoint = false;
     float3 startPos         = float3::zero;
 };

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Character.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Character.h
@@ -41,6 +41,7 @@ class Character : public Script
 
     void TakeDamage(int amount);
     void Restart();
+    bool IsDead() const { return isDead; };
 
   protected:
     virtual void Attack(float deltaTime);
@@ -98,4 +99,8 @@ class Character : public Script
     float maxDetectionRange = 0.0f;
     bool reachedPatrolPoint = false;
     float3 startPos         = float3::zero;
+
+    float searchTimer       = 0.0f;
+    float searchDuration    = 5.0f;
+    bool isSearching        = false;
 };

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -25,7 +25,7 @@
 CharacterControllerComponent* character = nullptr;
 
 CuChulainn::CuChulainn(GameObject* parent)
-    : Character(parent, 5, 1, 0.5f, 1.0f, 1.0f, 0.0f, 0.0f, CharacterType::CuChulainn)
+    : Character(parent, 5, 1, 0.5f, 1.0f, 1.0f, 0.0f, 0.0f, 0.0f, CharacterType::CuChulainn)
 {
     currentHealth = 3; // mainChar starts low hp
 
@@ -67,7 +67,7 @@ bool CuChulainn::Init()
 
     };
 
-    character                  = parent->GetComponent<CharacterControllerComponent*>();
+    character = parent->GetComponent<CharacterControllerComponent*>();
     if (!character) GLOG("CharacterController component not found for CuChulainn")
     else speed = character->GetSpeed();
 
@@ -351,7 +351,7 @@ void CuChulainn::UpdateTimers(float deltaTime)
     }
 
     if (state == CharacterStates::ULTIMATE) ultimateTimer += deltaTime;
-    
+
     // When stop dashing this gets automatically disabled in the timers check
     if (state == CharacterStates::DASH) isInvulnerable = true;
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -23,6 +23,7 @@
 #include "Wwise_IDs.h"
 
 CharacterControllerComponent* character = nullptr;
+CuChulainn* playerScript                = nullptr;
 
 CuChulainn::CuChulainn(GameObject* parent)
     : Character(parent, 5, 1, 0.5f, 1.0f, 1.0f, 0.0f, 0.0f, 0.0f, CharacterType::CuChulainn)
@@ -67,7 +68,9 @@ bool CuChulainn::Init()
 
     };
 
-    character = parent->GetComponent<CharacterControllerComponent*>();
+    playerScript = this;
+
+    character    = parent->GetComponent<CharacterControllerComponent*>();
     if (!character) GLOG("CharacterController component not found for CuChulainn")
     else speed = character->GetSpeed();
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
@@ -57,7 +57,7 @@ class CuChulainn : public Character
     bool CanUltimate() const;
     bool CanAim() const;
     void GetInputs();
-    void UpdateTimers(float deltaTime);
+    void UpdateTimers(float deltaTime) override;
     void LookAtMouse();
     void LookAtRightStick();
     void LookAtLeftStick();

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
@@ -127,3 +127,4 @@ class CuChulainn : public Character
 };
 
 extern CharacterControllerComponent* character;
+extern CuChulainn* playerScript;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.cpp
@@ -13,9 +13,11 @@
 #include "Standalone/CharacterControllerComponent.h"
 #include "Standalone/Physics/CapsuleColliderComponent.h"
 
-Soldier::Soldier(GameObject* parent) : Character(parent, 3, 1, 0.5f, 1.0f, 1.0f, 2.0f, 10.0f, 15.0f, CharacterType::Soldier)
+Soldier::Soldier(GameObject* parent)
+    : Character(parent, 3, 1, 0.5f, 1.0f, 1.0f, 2.0f, 10.0f, 15.0f, CharacterType::Soldier)
 {
     fields.push_back({"AI Patrol Point", InspectorField::FieldType::Vec3, &patrolPoint, -1000.0f, 1000.0f});
+    fields.push_back({"Player search duration", InspectorField::FieldType::Vec3, &searchDuration, 0.0f, 10.0f});
 }
 
 bool Soldier::Init()
@@ -71,18 +73,19 @@ void Soldier::HandleState(float deltaTime)
 
     switch (currentState)
     {
+    case SoldierStates::SEARCH:
+        SearchForPlayer();
+        break;
     case SoldierStates::PATROL:
-        // GLOG("Soldier Patrolling");
         PatrolAI();
+        // TODO: patrol animation
         animComponent->UseTrigger("run");
         break;
     case SoldierStates::CHASE:
-        // GLOG("Soldier Chasing");
         animComponent->UseTrigger("run");
         ChaseAI();
         break;
     case SoldierStates::BASIC_ATTACK:
-        // GLOG("Soldier Basic Attack");
         if (attackCdTimer <= 0) Attack(deltaTime);
         break;
     default:
@@ -120,9 +123,39 @@ void Soldier::ChaseAI()
     if (character != nullptr)
     {
         if (CheckDistanceWithPlayer() == PlayerDistances::Close) currentState = SoldierStates::BASIC_ATTACK;
+        else if (GetDistanceFromPlayer() > maxDetectionRange + 0.5f)
+        {
+            currentState = SoldierStates::SEARCH;
+        }
         else if (!agentAI->SetPathNavigation(character->GetLastPosition())) currentState = SoldierStates::PATROL;
     }
     else currentState = SoldierStates::PATROL;
+}
+
+void Soldier::SearchForPlayer()
+{
+    // Stands still for a few seconds, if player gets close again chases, if not returns to patrol
+    if (!isSearching)
+    {
+        // TODO: Would be nice to be a "search" animation instead of idle
+        animComponent->UseTrigger("idle");
+        isSearching = true;
+        searchTimer = searchDuration;
+        agentAI->SetSpeed(0.0f, 10.0f);
+    }
+
+    if (GetDistanceFromPlayer() < maxDetectionRange - 0.5f)
+    {
+        isSearching = false;
+        agentAI->ResetSpeed();
+        currentState = SoldierStates::CHASE;
+    }
+    else if (searchTimer <= 0.0f)
+    {
+        isSearching  = false;
+        currentState = SoldierStates::PATROL;
+        agentAI->ResetSpeed();
+    }
 }
 
 void Soldier::Attack(float deltaTime)
@@ -159,4 +192,12 @@ void Soldier::Attack(float deltaTime)
             if (CheckDistanceWithPlayer() != PlayerDistances::Close) currentState = SoldierStates::CHASE;
         }
     }
+}
+
+void Soldier::UpdateTimers(float deltaTime)
+{
+    Character::UpdateTimers(deltaTime);
+
+    searchTimer -= deltaTime;
+    if (searchTimer < 0.0f) searchTimer = 0.0f;
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.cpp
@@ -13,7 +13,7 @@
 #include "Standalone/CharacterControllerComponent.h"
 #include "Standalone/Physics/CapsuleColliderComponent.h"
 
-Soldier::Soldier(GameObject* parent) : Character(parent, 3, 1, 0.5f, 1.0f, 1.0f, 2.0f, 10.0f, CharacterType::Soldier)
+Soldier::Soldier(GameObject* parent) : Character(parent, 3, 1, 0.5f, 1.0f, 1.0f, 2.0f, 10.0f, 15.0f, CharacterType::Soldier)
 {
     fields.push_back({"AI Patrol Point", InspectorField::FieldType::Vec3, &patrolPoint, -1000.0f, 1000.0f});
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.cpp
@@ -17,7 +17,6 @@ Soldier::Soldier(GameObject* parent)
     : Character(parent, 3, 1, 0.5f, 1.0f, 1.0f, 2.0f, 10.0f, 15.0f, CharacterType::Soldier)
 {
     fields.push_back({"AI Patrol Point", InspectorField::FieldType::Vec3, &patrolPoint, -1000.0f, 1000.0f});
-    fields.push_back({"Player search duration", InspectorField::FieldType::Vec3, &searchDuration, 0.0f, 10.0f});
 }
 
 bool Soldier::Init()
@@ -123,10 +122,7 @@ void Soldier::ChaseAI()
     if (character != nullptr)
     {
         if (CheckDistanceWithPlayer() == PlayerDistances::Close) currentState = SoldierStates::BASIC_ATTACK;
-        else if (GetDistanceFromPlayer() > maxDetectionRange + 0.5f)
-        {
-            currentState = SoldierStates::SEARCH;
-        }
+        else if (GetDistanceFromPlayer() > maxDetectionRange + 0.5f) currentState = SoldierStates::SEARCH;
         else if (!agentAI->SetPathNavigation(character->GetLastPosition())) currentState = SoldierStates::PATROL;
     }
     else currentState = SoldierStates::PATROL;
@@ -192,12 +188,4 @@ void Soldier::Attack(float deltaTime)
             if (CheckDistanceWithPlayer() != PlayerDistances::Close) currentState = SoldierStates::CHASE;
         }
     }
-}
-
-void Soldier::UpdateTimers(float deltaTime)
-{
-    Character::UpdateTimers(deltaTime);
-
-    searchTimer -= deltaTime;
-    if (searchTimer < 0.0f) searchTimer = 0.0f;
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.cpp
@@ -121,9 +121,8 @@ void Soldier::ChaseAI()
 {
     if (character != nullptr)
     {
-        if (CheckDistanceWithPlayer() == PlayerDistances::Close) currentState = SoldierStates::BASIC_ATTACK;
-        else if (GetDistanceFromPlayer() > maxDetectionRange + 0.5f) currentState = SoldierStates::SEARCH;
-        else if (!agentAI->SetPathNavigation(character->GetLastPosition())) currentState = SoldierStates::PATROL;
+        agentAI->SetPathNavigation(character->GetLastPosition());
+        ChangeState();
     }
     else currentState = SoldierStates::PATROL;
 }
@@ -185,7 +184,15 @@ void Soldier::Attack(float deltaTime)
             isAttacking   = false;
             attackCdTimer = attackCooldown;
             agentAI->ResumeMovement();
-            if (CheckDistanceWithPlayer() != PlayerDistances::Close) currentState = SoldierStates::CHASE;
+            ChangeState();
         }
     }
+}
+
+void Soldier::ChangeState()
+{
+    const float distance = GetDistanceFromPlayer();
+    if (distance <= rangeAIAttack) currentState = SoldierStates::BASIC_ATTACK;
+    else if (distance <= rangeAIChase) currentState = SoldierStates::CHASE;
+    else if (distance > maxDetectionRange) currentState = SoldierStates::SEARCH;
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.cpp
@@ -101,8 +101,11 @@ void Soldier::HandleState(float deltaTime)
 
 void Soldier::PatrolAI()
 {
-    if (CheckDistanceWithPlayer() == PlayerDistances::Medium) currentState = SoldierStates::CHASE;
-    else if (CheckDistanceWithPlayer() == PlayerDistances::Close) currentState = SoldierStates::BASIC_ATTACK;
+    if (!playerScript->IsDead())
+    {
+        if (CheckDistanceWithPlayer() == PlayerDistances::Medium) currentState = SoldierStates::CHASE;
+        else if (CheckDistanceWithPlayer() == PlayerDistances::Close) currentState = SoldierStates::BASIC_ATTACK;
+    }
 
     bool valid = false;
     if (reachedPatrolPoint)
@@ -191,6 +194,12 @@ void Soldier::Attack(float deltaTime)
 
 void Soldier::ChangeState()
 {
+    if (playerScript->IsDead())
+    {
+        currentState = SoldierStates::PATROL;
+        return;
+    }
+
     const float distance = GetDistanceFromPlayer();
     if (distance <= rangeAIAttack) currentState = SoldierStates::BASIC_ATTACK;
     else if (distance <= rangeAIChase) currentState = SoldierStates::CHASE;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.h
@@ -30,6 +30,7 @@ class Soldier : public Character
     void HandleState(float deltaTime) override;
     void Attack(float deltaTime) override;
 
+    void ChangeState();
     void PatrolAI();
     void ChaseAI();
     void SearchForPlayer();

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.h
@@ -8,6 +8,8 @@ class AIAgentComponent;
 enum class SoldierStates
 {
     NONE,
+    SEARCH,
+
     PATROL,
     CHASE,
     BASIC_ATTACK
@@ -28,13 +30,19 @@ class Soldier : public Character
     void PerformAttack() override;
     void HandleState(float deltaTime) override;
     void Attack(float deltaTime) override;
+    void UpdateTimers(float deltaTime) override;
 
     void PatrolAI();
     void ChaseAI();
+    void SearchForPlayer();
 
   private:
     AIAgentComponent* agentAI  = nullptr;
     SoldierStates currentState = SoldierStates::NONE;
 
     float3 patrolPoint         = float3::zero;
+
+    float searchTimer          = 0.0f;
+    float searchDuration       = 5.0f;
+    bool isSearching           = false;
 };

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.h
@@ -9,7 +9,6 @@ enum class SoldierStates
 {
     NONE,
     SEARCH,
-
     PATROL,
     CHASE,
     BASIC_ATTACK
@@ -30,7 +29,6 @@ class Soldier : public Character
     void PerformAttack() override;
     void HandleState(float deltaTime) override;
     void Attack(float deltaTime) override;
-    void UpdateTimers(float deltaTime) override;
 
     void PatrolAI();
     void ChaseAI();
@@ -41,8 +39,4 @@ class Soldier : public Character
     SoldierStates currentState = SoldierStates::NONE;
 
     float3 patrolPoint         = float3::zero;
-
-    float searchTimer          = 0.0f;
-    float searchDuration       = 5.0f;
-    bool isSearching           = false;
 };


### PR DESCRIPTION
Now enemies have a new field called maxDetectionRange. If the player is further than this, the enemy will stop chasing. It will stand still searching for the player (right now is the idle animation, would be nice to be an animaion where it looks around), and after the duration delcared in the new field searchDuration the enemy goes back to patrol (the banshee just goes to the start position, it will teleport when merged with the banshee PR).
Also, if the player is dead enemies go back to patroling.

TO TEST: Just play in some levels and test if the differend types of enemies behave as expected, stopping to chase if the player is too far or dead.
