### PR TITLE
Task/camera shake THO-748

### DIFF
--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CameraMovement.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CameraMovement.cpp
@@ -55,11 +55,12 @@ void CameraMovement::SetPosition(const float3& newPos)
     parent->SetLocalPosition(newPos);
 }
 
-void CameraMovement::StartShake(float duration, float intensity)
+void CameraMovement::StartShake(float duration, float intensity, float smoothness)
 {
     shakeDuration    = duration;
     shakeTimer       = duration;
     shakeIntensity   = intensity;
+    shakeSmoothness  = smoothness;
     defaultCameraPos = camera->GetPosition();
     currentOffset    = float3::zero;
 }
@@ -125,7 +126,7 @@ void CameraMovement::CameraShake(float deltaTime)
     const float y        = dist(rng) * shakeIntensity * fade;
 
     float3 targetOffset  = float3(x, y, 0.0f);
-    currentOffset        = Lerp(currentOffset, targetOffset, deltaTime * 10.0f);
+    currentOffset        = shakeSmoothness > 0 ? Lerp(currentOffset, targetOffset, shakeSmoothness) : targetOffset;
 
     camera->SetLocalPosition(defaultCameraPos + currentOffset);
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CameraMovement.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CameraMovement.cpp
@@ -36,12 +36,32 @@ bool CameraMovement::Init()
         controller = target->GetComponent<CharacterControllerComponent*>();
     }
 
+    camera = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByUID(parent->GetChildren()[0]);
+
+    rng    = std::mt19937(std::random_device {}());
+    dist   = std::uniform_real_distribution<float>(-1.0f, 1.0f);
+
     return true;
 }
 
 void CameraMovement::Update(float deltaTime)
 {
     FollowTarget(deltaTime);
+    if (shakeTimer > 0.0f) CameraShake(deltaTime);
+}
+
+void CameraMovement::SetPosition(const float3& newPos)
+{
+    parent->SetLocalPosition(newPos);
+}
+
+void CameraMovement::StartShake(float duration, float intensity)
+{
+    shakeDuration    = duration;
+    shakeTimer       = duration;
+    shakeIntensity   = intensity;
+    defaultCameraPos = camera->GetPosition();
+    currentOffset    = float3::zero;
 }
 
 void CameraMovement::FollowTarget(float deltaTime)
@@ -92,7 +112,27 @@ void CameraMovement::FollowTarget(float deltaTime)
     parent->SetLocalPosition(finalPosition - parent->GetParentGlobalTransform().TranslatePart());
 }
 
-void CameraMovement::SetPosition(const float3& newPos)
+void CameraMovement::CameraShake(float deltaTime)
 {
-    parent->SetLocalPosition(newPos);
+    const float progress = (shakeDuration - shakeTimer) / shakeDuration;
+
+    float fadeIn         = SmoothStep(0.0f, 0.25f, progress);
+    float fadeOut        = 1.0f - SmoothStep(0.75f, 1.0f, progress);
+    float fade           = fadeIn < fadeOut ? fadeIn : fadeOut;
+    fade                 = fade * fade * (3.0f - 2.0f * fade);
+
+    const float x        = dist(rng) * shakeIntensity * fade;
+    const float y        = dist(rng) * shakeIntensity * fade;
+
+    float3 targetOffset  = float3(x, y, 0.0f);
+    currentOffset        = Lerp(currentOffset, targetOffset, deltaTime * 10.0f);
+
+    camera->SetLocalPosition(defaultCameraPos + currentOffset);
+
+    shakeTimer -= deltaTime;
+
+    if (shakeTimer <= 0.0f)
+    {
+        camera->SetLocalPosition(defaultCameraPos);
+    }
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CameraMovement.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CameraMovement.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Script.h"
+#include <random>
 
 class GameObject;
 class CharacterControllerComponent;
@@ -16,9 +17,11 @@ class CameraMovement : public Script
 
     void EnableAimOffset(bool enable) { aimOffsetEnabled = enable; }
     void SetPosition(const float3& newPos);
+    void StartShake(float duration, float intensity);
 
   private:
     void FollowTarget(float deltaTime);
+    void CameraShake(float deltaTime);
 
   private:
     std::string targetName;
@@ -38,4 +41,13 @@ class CameraMovement : public Script
 
     float followDistanceThreshold                  = 0.0f;
     bool isFollowing                               = false;
+
+    GameObject* camera                             = nullptr;
+    float3 currentOffset                           = float3::zero;
+    float shakeDuration                            = 0.0f;
+    float shakeTimer                               = 0.0f;
+    float shakeIntensity                           = 0.0f;
+    float3 defaultCameraPos                        = float3::zero;
+    std::mt19937 rng;
+    std::uniform_real_distribution<float> dist;
 };

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CameraMovement.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CameraMovement.h
@@ -17,7 +17,7 @@ class CameraMovement : public Script
 
     void EnableAimOffset(bool enable) { aimOffsetEnabled = enable; }
     void SetPosition(const float3& newPos);
-    void StartShake(float duration, float intensity);
+    void StartShake(float duration, float intensity, float smoothness = 0);
 
   private:
     void FollowTarget(float deltaTime);
@@ -47,6 +47,7 @@ class CameraMovement : public Script
     float shakeDuration                            = 0.0f;
     float shakeTimer                               = 0.0f;
     float shakeIntensity                           = 0.0f;
+    float shakeSmoothness                          = 0.0f;
     float3 defaultCameraPos                        = float3::zero;
     std::mt19937 rng;
     std::uniform_real_distribution<float> dist;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Character.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Character.cpp
@@ -215,8 +215,8 @@ void Character::TakeDamage(int amount)
     isInvulnerable        = true;
     invulnerabilityTimer  = invulnerableDuration;
 
+    OnDamageTaken(amount);
     if (currentHealth <= 0) Die();
-    else OnDamageTaken(amount);
 }
 
 void Character::Restart()

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -145,7 +145,7 @@ void CuChulainn::OnDeath()
 void CuChulainn::OnDamageTaken(int amount)
 {
     UpdateHealthBarUI();
-    if (camera) camera->StartShake(0.4f, 2.0f);
+    if (camera) camera->StartShake(0.2f, 0.2f);
     // TODO: play CuChulainn take damage sound
     // TODO: fill riastrad bar dinamically
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -235,10 +235,6 @@ void CuChulainn::GetInputs()
         desiredDash     = true;
         dashBufferTimer = inputBuffer;
     }
-    if (keyboard[SDL_SCANCODE_7] == KEY_DOWN)
-    {
-        OnDamageTaken(1);
-    }
     if (mouse[SDL_BUTTON_LEFT - 1] == KEY_DOWN || controller[SDL_CONTROLLER_BUTTON_X] == KEY_DOWN)
     {
         desiredAttack     = true;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -145,6 +145,7 @@ void CuChulainn::OnDeath()
 void CuChulainn::OnDamageTaken(int amount)
 {
     UpdateHealthBarUI();
+    if (camera) camera->StartShake(0.4f, 2.0f);
     // TODO: play CuChulainn take damage sound
     // TODO: fill riastrad bar dinamically
 }
@@ -233,6 +234,10 @@ void CuChulainn::GetInputs()
     {
         desiredDash     = true;
         dashBufferTimer = inputBuffer;
+    }
+    if (keyboard[SDL_SCANCODE_7] == KEY_DOWN)
+    {
+        OnDamageTaken(1);
     }
     if (mouse[SDL_BUTTON_LEFT - 1] == KEY_DOWN || controller[SDL_CONTROLLER_BUTTON_X] == KEY_DOWN)
     {


### PR DESCRIPTION
Added the camera shake functionality to the camera script. You can call the function StartShake with a duration, an intensity and optionally a smoothness, and the camera will shake accordingly.

To test: play and get hit by enemies, and see if the shake works. You can change its values in the CuChuainn script to see the differences.