### PR TITLE
Hud cooldowns & HUD options menu with controller ( THO-746 & THO-756)

### DIFF
--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -823,8 +823,10 @@ void CuChulainn::UpdateDashCooldownUI()
 
 void CuChulainn::UpdateUltimateCooldownUI()
 {
-    if (ultimateCdTimer > 0.0f) ultimateImageComponent->ChangeTexture(1297453458525874); //cooldownTexture
-    else ultimateImageComponent->ChangeTexture(1203132322652717);
+    const UID readyTex    = 1203132322652717;
+    const UID cooldownTex = 1297453458525874;
+
+    ultimateImageComponent->ChangeTexture(ultimateCdTimer > 0.0f ? cooldownTex : readyTex);
 }
 void CuChulainn::ChargeAttack()
 {

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -212,7 +212,7 @@ void CuChulainn::HandleState(float deltaTime)
         state    = CharacterStates::IDLE;
         aimTimer = 0.0f;
     }
-    
+
     UpdateDashCooldownUI();
     UpdateUltimateCooldownUI();
 
@@ -228,7 +228,6 @@ void CuChulainn::HandleState(float deltaTime)
              state != CharacterStates::HEAL)
         Move();
 
-    
     // TODO: Some transition in the dash or idle state, to continue the combo after a dash
 
     // When finished animation, go back to idle state
@@ -817,8 +816,7 @@ void CuChulainn::UpdateDashCooldownUI()
     const UID readyTex    = 1258786293084191;
     const UID cooldownTex = 1288043360624471;
 
-    dashImageComponent->ChangeTexture(dashTimer > 0.0f ? cooldownTex : readyTex);
-
+    if (dashImageComponent) dashImageComponent->ChangeTexture(dashTimer > 0.0f ? cooldownTex : readyTex);
 }
 
 void CuChulainn::UpdateUltimateCooldownUI()
@@ -826,7 +824,7 @@ void CuChulainn::UpdateUltimateCooldownUI()
     const UID readyTex    = 1203132322652717;
     const UID cooldownTex = 1297453458525874;
 
-    ultimateImageComponent->ChangeTexture(ultimateCdTimer > 0.0f ? cooldownTex : readyTex);
+    if (ultimateImageComponent) ultimateImageComponent->ChangeTexture(ultimateCdTimer > 0.0f ? cooldownTex : readyTex);
 }
 void CuChulainn::ChargeAttack()
 {

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -71,6 +71,12 @@ bool CuChulainn::Init()
 
     };
 
+    GameObject* dashUIObject = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName("DashCooldown");
+    if (dashUIObject) dashImageComponent = dashUIObject->GetComponent<ImageComponent*>();
+
+    GameObject* ultimanteUIObject = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName("UltimateCooldown");
+    if (ultimanteUIObject) ultimateImageComponent = ultimanteUIObject->GetComponent<ImageComponent*>();
+
     playerScript = this;
 
     character    = parent->GetComponent<CharacterControllerComponent*>();
@@ -168,6 +174,9 @@ void CuChulainn::HandleState(float deltaTime)
         state    = CharacterStates::IDLE;
         aimTimer = 0.0f;
     }
+    
+    UpdateDashCooldownUI();
+    UpdateUltimateCooldownUI();
 
     if (desiredDash && CanDash()) Dash();
     else if (desiredUltimate && CanUltimate()) UltimateAttack();
@@ -177,6 +186,7 @@ void CuChulainn::HandleState(float deltaTime)
              state != CharacterStates::AIM && state != CharacterStates::FALL && state != CharacterStates::ULTIMATE)
         Move();
 
+    
     // TODO: Some transition in the dash or idle state, to continue the combo after a dash
 
     // When finished animation, go back to idle state
@@ -594,4 +604,19 @@ void CuChulainn::UpdateHealthBarUI()
 {
     if (!healthImageComponent || healthBarTextures.empty()) return;
     healthImageComponent->ChangeTexture(healthBarTextures[currentHealth]);
+}
+
+void CuChulainn::UpdateDashCooldownUI()
+{
+    const UID readyTex    = 1258786293084191;
+    const UID cooldownTex = 1288043360624471;
+
+    dashImageComponent->ChangeTexture(dashTimer > 0.0f ? cooldownTex : readyTex);
+
+}
+
+void CuChulainn::UpdateUltimateCooldownUI()
+{
+    if (ultimateCdTimer > 0.0f) ultimateImageComponent->ChangeTexture(1297453458525874); //cooldownTexture
+    else ultimateImageComponent->ChangeTexture(1203132322652717);
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
@@ -39,6 +39,8 @@ class CuChulainn : public Character
     void SetHealth(int health) { reservedHealth = health; }
     void Respawn();
     void UpdateHealthBarUI();
+    void UpdateDashCooldownUI();
+    void UpdateUltimateCooldownUI();
     bool GetIsInvulnerable() { return isInvulnerable; }
     void SetInvulnearble(bool invulnerable) { isInvulnerable = invulnerable; }
     CharacterStates GetState() const { return state; }
@@ -123,6 +125,8 @@ class CuChulainn : public Character
 
     std::vector<UID> healthBarTextures;
     ImageComponent* healthImageComponent = nullptr;
+    ImageComponent* dashImageComponent   = nullptr;
+    ImageComponent* ultimateImageComponent = nullptr;
 
     bool godMode                         = false;
 };

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/OptionsMenuSwitcherScript.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/OptionsMenuSwitcherScript.cpp
@@ -7,8 +7,21 @@
 #include "Scene.h"
 #include "SceneModule.h"
 
+
+const std::unordered_map<std::string, TexPair> OptionsMenuSwitcherScript::panelInput = {
+    {"OptionsKeyboardPanel",   {1203489876831052, 1296460430598403}},
+    {"OptionsControllerPanel", {1202209373146889, 1250571013944449}},
+    {"OptionsAudioPanel",      {1207353832276846, 1237658736782493}},
+    {"OptionsVideoPanel",      {1204790345600293, 1291434436557419}}
+};
+
+const std::vector<std::string> OptionsMenuSwitcherScript::panelNames = {
+    "OptionsKeyboardPanel", "OptionsControllerPanel", "OptionsAudioPanel", "OptionsVideoPanel"
+};
+
 bool OptionsMenuSwitcherScript::Init()
 {
+
     ShowOnlyCurrentPanel();
     return true;
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/OptionsMenuSwitcherScript.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/OptionsMenuSwitcherScript.cpp
@@ -6,6 +6,7 @@
 #include "OptionsMenuSwitcherScript.h"
 #include "Scene.h"
 #include "SceneModule.h"
+#include "Components/Standalone/UI/ImageComponent.h"
 
 
 const std::unordered_map<std::string, TexPair> OptionsMenuSwitcherScript::panelInput = {
@@ -21,7 +22,8 @@ const std::vector<std::string> OptionsMenuSwitcherScript::panelNames = {
 
 bool OptionsMenuSwitcherScript::Init()
 {
-
+    lastKbState = AppEngine->GetInputModule()->IsUsingKeyboard();
+    ApplyDeviceTextures(lastKbState);
     ShowOnlyCurrentPanel();
     return true;
 }
@@ -34,6 +36,13 @@ void OptionsMenuSwitcherScript::Update(float deltaTime)
     {
         ShowOnlyCurrentPanel();
         initialized = true;
+    }
+
+    bool nowKb                     = AppEngine->GetInputModule()->IsUsingKeyboard();
+    if (nowKb != lastKbState)
+    {
+        ApplyDeviceTextures(nowKb);
+        lastKbState = nowKb;
     }
 
     const KeyState* keys           = AppEngine->GetInputModule()->GetKeyboard();
@@ -72,6 +81,21 @@ void OptionsMenuSwitcherScript::Update(float deltaTime)
 
         parent->SetEnabledRecursive(false);
         initialized = false;
+    }
+}
+
+void OptionsMenuSwitcherScript::ApplyDeviceTextures(bool usingKb)
+{
+    for (const std::string& name : panelNames)
+    {
+        GameObject* go = FindPanelByName(name);
+        if (!go) continue;
+
+        ImageComponent* img = go->GetComponent<ImageComponent*>();
+        if (!img) continue;
+
+        const TexPair& tp = panelInput.at(name);
+        img->ChangeTexture(usingKb ? tp.texKeyboard : tp.texGamepad);
     }
 }
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/OptionsMenuSwitcherScript.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/OptionsMenuSwitcherScript.h
@@ -2,7 +2,15 @@
 #include "Script.h"
 #include <string>
 #include <vector>
+#include <unordered_map>
+
 class GameObject;
+
+struct TexPair
+{
+    UID texKeyboard;
+    UID texGamepad;
+};
 
 class OptionsMenuSwitcherScript : public Script
 {
@@ -17,9 +25,8 @@ class OptionsMenuSwitcherScript : public Script
 
 
   private:
-    std::vector<std::string> panelNames = {
-        "OptionsKeyboardPanel", "OptionsControllerPanel", "OptionsAudioPanel", "OptionsVideoPanel"
-    };
+    static const std::unordered_map<std::string, TexPair> panelNames;
+    static const std::vector<std::string> panelOrder;
 
     int currentIndex = 0;
     bool initialized = false;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/OptionsMenuSwitcherScript.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/OptionsMenuSwitcherScript.h
@@ -25,12 +25,14 @@ class OptionsMenuSwitcherScript : public Script
 
 
   private:
-    static const std::unordered_map<std::string, TexPair> panelNames;
-    static const std::vector<std::string> panelOrder;
+    static const std::unordered_map<std::string, TexPair> panelInput;
+    static const std::vector<std::string> panelNames;
 
+    bool lastKbState = true;
     int currentIndex = 0;
     bool initialized = false;
 
+    void ApplyDeviceTextures(bool usingKb);
     void ShowOnlyCurrentPanel();
     GameObject* FindPanelByName(const std::string& name) const;
 };


### PR DESCRIPTION
UI has been updated and now it has visual feedback of the cooldowns for dask and ultimate attack. Whenever it is used one of them, it's representative image changes to a less colorful one until cooldown is over.

![CooldownDemonstration](https://github.com/user-attachments/assets/0955ddcd-fc01-45ad-841e-5f884fbeb416)

Also, this pr includes changing the buttons of the options menu if you control with the gamepad or keyboard.

In order to test both features, you need to be in branch UI-Cooldown in The Hound of Ulster repository.

To test options menu:
- go to the main menu scene
- go to options menu
- Click Q/E to pass the diferent configuration options.
- connect a gamepad and click any button (this would make to change the navigation buttons from keyboard to gamepad)
- navigate with gamepad
- click again aky key of the keyboard to change the navigation buttons feedback to keyboard again.

To test cooldown feature:
- Load tutorial scene
- in play mode, make a dash or ultimate attack (it will shown the visual feedback of the icons (located on bottom left part of the screen)


NOTE: take into account that only it is implemented the visual cooldown feedback in the tutorial scene. Once is approved this, it will be replicated in the rest of the scenes.