### PR TITLE
Camera movement bug

### DIFF
--- a/SobrassadaEngine/Scene/Components/Standalone/CharacterControllerComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/CharacterControllerComponent.cpp
@@ -292,8 +292,8 @@ void CharacterControllerComponent::Move(float deltaTime)
     else
     {
         const float desiredSpeed = isRunning ? maxSpeed : walkSpeed;
-        currentSpeed = targetDirection.LengthSq() > 0.001f ? Lerp(currentSpeed, desiredSpeed, acceleration * deltaTime)
-                                                           : Lerp(currentSpeed, 0, 100 * deltaTime);
+        currentSpeed = targetDirection.LengthSq() > 0.001f ? Lerp(currentSpeed, desiredSpeed, std::min(1.f, acceleration * deltaTime))
+                                                           : Lerp(currentSpeed, 0, std::min(1.f, 100 * deltaTime));
     }
 
     const float3 offsetXZ   = rotateDirection * currentSpeed * deltaTime;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CameraMovement.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CameraMovement.cpp
@@ -100,7 +100,7 @@ void CameraMovement::FollowTarget(float deltaTime)
 
         currentLookAhead = Lerp(
             currentLookAhead, lookAheadIntensity * (controller->GetSpeed() / controller->GetMaxSpeed()),
-            lookAheadSmoothness * deltaTime
+            min(1, lookAheadSmoothness * deltaTime)
         );
 
         const float3& targetDir  = controller->GetFrontDirection();
@@ -108,7 +108,7 @@ void CameraMovement::FollowTarget(float deltaTime)
 
         if (isFollowing && distanceToTarget < 0.1f && controller->GetSpeed() < 0.1f) isFollowing = false;
     }
-    finalPosition = Lerp(currentPosition, desiredPosition, smoothnessVelocity * deltaTime);
+    finalPosition = Lerp(currentPosition, desiredPosition, min(1, smoothnessVelocity * deltaTime));
 
     parent->SetLocalPosition(finalPosition - parent->GetParentGlobalTransform().TranslatePart());
 }


### PR DESCRIPTION
Fixed the camera movement when the framerate drops too much / delta time increases too much. 
Previously happened when loading a new scene during play or when playing on a low performance pc.

For testing, you can use the following code to artifically increase frame duration (Just put it somewhere in the update loop): 
std::this_thread::sleep_for(std::chrono::milliseconds(15));
You should see a varity of bugs including the player falling through the floor and it not being able to move properly. Those issues will be adressed later. What should work is the camera, it should stay focused on the player all the time.