### PR TITLE
Tho 757 go update culling

### DIFF
--- a/SobrassadaEngine/Modules/PhysicsModule.cpp
+++ b/SobrassadaEngine/Modules/PhysicsModule.cpp
@@ -141,10 +141,6 @@ update_status PhysicsModule::PreUpdate(float time)
                     firstUserPointer.onCollisionExitCallback->Call(
                         secondUserPointer.collider->GetParent(), secondUserPointer.layer
                     );
-                if (secondUserPointer.generateCallback && secondUserPointer.collider && firstUserPointer.collider)
-                    secondUserPointer.onCollisionExitCallback->Call(
-                        firstUserPointer.collider->GetParent(), firstUserPointer.layer
-                    );
             }
         }
     }
@@ -213,7 +209,7 @@ void PhysicsModule::CreateCubeRigidBody(CubeColliderComponent* colliderComponent
     newRigidBody->setUserPointer(&colliderComponent->userPointer);
     collisionObjects[colliderComponent->GetParentUID()] = colliderComponent->userPointer;
 
-    colliderComponent->rigidBody = newRigidBody;
+    colliderComponent->rigidBody                        = newRigidBody;
 
     AddRigidBody(newRigidBody, colliderComponent->colliderType, colliderComponent->layer);
 }
@@ -257,7 +253,7 @@ void PhysicsModule::CreateSphereRigidBody(SphereColliderComponent* colliderCompo
     newRigidBody->setUserPointer(&colliderComponent->userPointer);
     collisionObjects[colliderComponent->GetParentUID()] = colliderComponent->userPointer;
 
-    colliderComponent->rigidBody = newRigidBody;
+    colliderComponent->rigidBody                        = newRigidBody;
 
     AddRigidBody(newRigidBody, colliderComponent->colliderType, colliderComponent->layer);
 }
@@ -301,7 +297,7 @@ void PhysicsModule::CreateCapsuleRigidBody(CapsuleColliderComponent* colliderCom
     newRigidBody->setUserPointer(&colliderComponent->userPointer);
     collisionObjects[colliderComponent->GetParentUID()] = colliderComponent->userPointer;
 
-    colliderComponent->rigidBody = newRigidBody;
+    colliderComponent->rigidBody                        = newRigidBody;
 
     AddRigidBody(newRigidBody, colliderComponent->colliderType, colliderComponent->layer);
 }

--- a/SobrassadaEngine/Modules/PhysicsModule.cpp
+++ b/SobrassadaEngine/Modules/PhysicsModule.cpp
@@ -44,7 +44,7 @@ update_status PhysicsModule::PreUpdate(float time)
     // REMOVE RIGID BODIES
     for (btRigidBody* rigidBody : bodiesToRemove)
     {
-        //dynamicsWorld->removeCollisionObject(rigidBody);
+        // dynamicsWorld->removeCollisionObject(rigidBody);
         dynamicsWorld->removeRigidBody(rigidBody);
         btCollisionShape* shape = rigidBody->getCollisionShape();
         delete shape;
@@ -82,12 +82,75 @@ update_status PhysicsModule::PreUpdate(float time)
             // Calculating normal
             const float3 normal = float3(contactManifold->getContactPoint(0).m_normalWorldOnB);
 
-            if (firstUserPointer->generateCallback && firstUserPointer->collider && secondUserPointer->collider)
-                firstUserPointer->onCollisionCallback->Call(secondUserPointer->collider->GetParent(), normal, secondUserPointer->layer);
-            if (secondUserPointer->generateCallback && secondUserPointer->collider && firstUserPointer->collider)
-                secondUserPointer->onCollisionCallback->Call(firstUserPointer->collider->GetParent(), -normal, firstUserPointer->layer);
+            UID g1              = firstUserPointer->collider ? firstUserPointer->collider->GetParentUID() : INVALID_UID;
+            UID g2 = secondUserPointer->collider ? secondUserPointer->collider->GetParentUID() : INVALID_UID;
+
+            // Still OnCollision
+            if (wereColliding.find(g1) != wereColliding.end())
+            {
+                if (firstUserPointer->generateCallback && firstUserPointer->collider && secondUserPointer->collider)
+                    firstUserPointer->onCollisionCallback->Call(
+                        secondUserPointer->collider->GetParent(), normal, secondUserPointer->layer
+                    );
+                if (secondUserPointer->generateCallback && secondUserPointer->collider && firstUserPointer->collider)
+                    secondUserPointer->onCollisionCallback->Call(
+                        firstUserPointer->collider->GetParent(), -normal, firstUserPointer->layer
+                    );
+            }
+            // First time colliding
+            else
+            {
+                if (firstUserPointer->generateCallback && firstUserPointer->collider && secondUserPointer->collider)
+                    firstUserPointer->onCollisionEnterCallback->Call(
+                        secondUserPointer->collider->GetParent(), normal, secondUserPointer->layer
+                    );
+                if (secondUserPointer->generateCallback && secondUserPointer->collider && firstUserPointer->collider)
+                    secondUserPointer->onCollisionEnterCallback->Call(
+                        firstUserPointer->collider->GetParent(), -normal, firstUserPointer->layer
+                    );
+            }
+
+            // Adding both elements to areColliding
+            if (areColliding.find(g1) != areColliding.end()) areColliding[g1].insert(g2);
+            else areColliding.insert({g1, {g2}});
+
+            if (areColliding.find(g2) != areColliding.end()) areColliding[g2].insert(g1);
+            else areColliding.insert({g2, {g1}});
         }
     }
+
+    // ON COLLISION EXIT CHECKS
+    for (auto& wereCollidingPair : wereColliding)
+    {
+        UID currentUID = wereCollidingPair.first;
+        for (auto& otherUID : wereCollidingPair.second)
+        {
+            bool exit = false;
+            if (areColliding.find(currentUID) == areColliding.end()) exit = true;
+            else if (areColliding.find(currentUID) != areColliding.end() &&
+                     areColliding[currentUID].find(otherUID) == areColliding[currentUID].end())
+                exit = true;
+
+            if (exit && collisionObjects.find(currentUID) != collisionObjects.end() &&
+                collisionObjects.find(otherUID) != collisionObjects.end())
+            {
+                BulletUserPointer firstUserPointer  = collisionObjects[currentUID];
+                BulletUserPointer secondUserPointer = collisionObjects[otherUID];
+
+                if (firstUserPointer.generateCallback && firstUserPointer.collider && secondUserPointer.collider)
+                    firstUserPointer.onCollisionExitCallback->Call(
+                        secondUserPointer.collider->GetParent(), secondUserPointer.layer
+                    );
+                if (secondUserPointer.generateCallback && secondUserPointer.collider && firstUserPointer.collider)
+                    secondUserPointer.onCollisionExitCallback->Call(
+                        firstUserPointer.collider->GetParent(), firstUserPointer.layer
+                    );
+            }
+        }
+    }
+
+    wereColliding.swap(areColliding);
+    areColliding.clear();
 
     return UPDATE_CONTINUE;
 }
@@ -148,6 +211,7 @@ void PhysicsModule::CreateCubeRigidBody(CubeColliderComponent* colliderComponent
     btRigidBody* newRigidBody = new btRigidBody(rbInfo);
 
     newRigidBody->setUserPointer(&colliderComponent->userPointer);
+    collisionObjects[colliderComponent->GetParentUID()] = colliderComponent->userPointer;
 
     colliderComponent->rigidBody = newRigidBody;
 
@@ -164,6 +228,7 @@ void PhysicsModule::DeleteCubeRigidBody(CubeColliderComponent* colliderComponent
 {
     if (colliderComponent->rigidBody == nullptr) return;
 
+    collisionObjects.erase(colliderComponent->GetParentUID());
     bodiesToRemove.push_back(colliderComponent->rigidBody);
     colliderComponent->rigidBody = nullptr;
 }
@@ -190,6 +255,7 @@ void PhysicsModule::CreateSphereRigidBody(SphereColliderComponent* colliderCompo
     btRigidBody* newRigidBody = new btRigidBody(rbInfo);
 
     newRigidBody->setUserPointer(&colliderComponent->userPointer);
+    collisionObjects[colliderComponent->GetParentUID()] = colliderComponent->userPointer;
 
     colliderComponent->rigidBody = newRigidBody;
 
@@ -206,6 +272,7 @@ void PhysicsModule::DeleteSphereRigidBody(SphereColliderComponent* colliderCompo
 {
     if (colliderComponent->rigidBody == nullptr) return;
 
+    collisionObjects.erase(colliderComponent->GetParentUID());
     bodiesToRemove.push_back(colliderComponent->rigidBody);
     colliderComponent->rigidBody = nullptr;
 }
@@ -232,6 +299,7 @@ void PhysicsModule::CreateCapsuleRigidBody(CapsuleColliderComponent* colliderCom
     btRigidBody* newRigidBody = new btRigidBody(rbInfo);
 
     newRigidBody->setUserPointer(&colliderComponent->userPointer);
+    collisionObjects[colliderComponent->GetParentUID()] = colliderComponent->userPointer;
 
     colliderComponent->rigidBody = newRigidBody;
 
@@ -248,6 +316,7 @@ void PhysicsModule::DeleteCapsuleRigidBody(CapsuleColliderComponent* colliderCom
 {
     if (colliderComponent->rigidBody == nullptr) return;
 
+    collisionObjects.erase(colliderComponent->GetParentUID());
     bodiesToRemove.push_back(colliderComponent->rigidBody);
     colliderComponent->rigidBody = nullptr;
 }
@@ -406,7 +475,7 @@ void PhysicsModule::EmptyWorld()
     // REMOVE RIGID BODIES
     for (btRigidBody* rigidBody : bodiesToRemove)
     {
-        //dynamicsWorld->removeCollisionObject(rigidBody);
+        // dynamicsWorld->removeCollisionObject(rigidBody);
         dynamicsWorld->removeRigidBody(rigidBody);
         btCollisionShape* shape = rigidBody->getCollisionShape();
         delete shape;
@@ -416,7 +485,7 @@ void PhysicsModule::EmptyWorld()
 
     for (int i = dynamicsWorld->getNumCollisionObjects() - 1; i >= 0; i--)
     {
-        btCollisionObject* obj         = dynamicsWorld->getCollisionObjectArray()[i];
+        btCollisionObject* obj  = dynamicsWorld->getCollisionObjectArray()[i];
         btRigidBody* rigidBody  = btRigidBody::upcast(obj);
         btCollisionShape* shape = rigidBody->getCollisionShape();
         dynamicsWorld->removeRigidBody(rigidBody);
@@ -426,6 +495,9 @@ void PhysicsModule::EmptyWorld()
         delete obj;
     }
 
+    wereColliding.clear();
+    areColliding.clear();
+    collisionObjects.clear();
     bodiesToRemove.clear();
 }
 

--- a/SobrassadaEngine/Modules/PhysicsModule.h
+++ b/SobrassadaEngine/Modules/PhysicsModule.h
@@ -2,8 +2,11 @@
 
 #include "ComponentUtils.h"
 #include "Module.h"
+#include "BulletUserPointer.h"
 
 #include <bitset>
+#include <map>
+#include <set>
 #include <vector>
 
 class btDefaultCollisionConfiguration;
@@ -79,4 +82,8 @@ class SOBRASADA_API_ENGINE PhysicsModule : public Module
 
     BulletDebugDraw* debugDraw = nullptr;
     std::vector<LayerBitset> colliderLayerConfig;
+
+    std::map<UID, std::set<UID>> wereColliding;
+    std::map<UID, std::set<UID>> areColliding;
+    std::map<UID, BulletUserPointer> collisionObjects;
 };

--- a/SobrassadaEngine/Modules/SceneModule.cpp
+++ b/SobrassadaEngine/Modules/SceneModule.cpp
@@ -266,10 +266,10 @@ void SceneModule::SwitchPlayMode(bool play)
     }
 }
 
-void SceneModule::AddGameObjectToUpdate(GameObject* gameObject)
+void SceneModule::AddGameObjectToUpdateComponents(GameObject* gameObject)
 {
     if (inPlayMode) return;
-    loadedScene->AddGameObjectToUpdate(gameObject);
+    loadedScene->AddGameObjectToUpdateComponents(gameObject);
 }
 
 void SceneModule::HandleRaycast(const KeyState* mouseButtons, const KeyState* keyboard)
@@ -451,7 +451,7 @@ void SceneModule::HandleTreesUpdates()
             loadedScene->UpdateDynamicSpatialStructure();
         }
 
-        loadedScene->UpdateGameObjects();
+        loadedScene->UpdateGameObjectsComponents();
     }
 }
 

--- a/SobrassadaEngine/Modules/SceneModule.cpp
+++ b/SobrassadaEngine/Modules/SceneModule.cpp
@@ -57,6 +57,10 @@ bool SceneModule::Init()
 
 update_status SceneModule::PreUpdate(float deltaTime)
 {
+    if (loadedScene != nullptr)
+    {
+        loadedScene->CheckObjectsToUpdate();
+    }
     return UPDATE_CONTINUE;
 }
 
@@ -164,6 +168,8 @@ update_status SceneModule::PostUpdate(float deltaTime)
             App->GetGameTimer()->Step();
             loadedScene->SetStepPlaying(false);
         }
+
+        loadedScene->ClearObjectsToUpdate();
     }
 
 #ifdef OPTICK

--- a/SobrassadaEngine/Modules/SceneModule.h
+++ b/SobrassadaEngine/Modules/SceneModule.h
@@ -43,7 +43,7 @@ class SOBRASADA_API_ENGINE SceneModule : public Module
     bool GetOnlyOnceInPlayMode() const { return onlyOncePlayMode; }
     void ResetOnlyOnceInPlayMode() { onlyOncePlayMode = false; }
 
-    void AddGameObjectToUpdate(GameObject* gameObject);
+    void AddGameObjectToUpdateComponents(GameObject* gameObject);
     void RequestSceneLoad(const std::string& scenePath);
 
 

--- a/SobrassadaEngine/Scene/Components/CameraComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/CameraComponent.cpp
@@ -56,6 +56,8 @@ CameraComponent::CameraComponent(UID uid, GameObject* parent) : Component(uid, p
     }
 
     previewFramebuffer = new Framebuffer(previewWidth, previewHeight, true);
+
+    UpdateUBO();
 }
 
 CameraComponent::CameraComponent(const rapidjson::Value& initialState, GameObject* parent)

--- a/SobrassadaEngine/Scene/Components/ComponentUtils.h
+++ b/SobrassadaEngine/Scene/Components/ComponentUtils.h
@@ -68,6 +68,7 @@ constexpr const char* ColliderLayerStrings[] = {"World Objects", "Triggers",    
                                                 "Player",        "Player projectile", "Enemy projectile"};
 
 typedef Delegate<void, GameObject*, float3, ColliderLayer> CollisionDelegate;
+typedef Delegate<void, GameObject*, ColliderLayer> CollisionExitDelegate;
 
 constexpr const char* ResourceTypeStrings[] = {"Material", "Texture"};
 constexpr int ResourceTypeStringsSize       = sizeof(ResourceTypeStrings) / sizeof(char*);

--- a/SobrassadaEngine/Scene/Components/ScriptComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/ScriptComponent.cpp
@@ -226,6 +226,22 @@ void ScriptComponent::OnCollision(GameObject* otherObject, const float3 collisio
     }
 }
 
+void ScriptComponent::OnCollisionEnter(GameObject* otherObject, const float3 collisionNormal, ColliderLayer layer)
+{
+    for (auto& script : scriptInstances)
+    {
+        script->OnCollisionEnter(otherObject, collisionNormal, layer);
+    }
+}
+
+void ScriptComponent::OnCollisionExit(GameObject* otherObject, ColliderLayer layer)
+{
+    for (auto& script : scriptInstances)
+    {
+        script->OnCollisionExit(otherObject, layer);
+    }
+}
+
 bool ScriptComponent::CreateScript(const std::string& scriptType)
 {
     for (const std::string& name : scriptNames)

--- a/SobrassadaEngine/Scene/Components/ScriptComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/ScriptComponent.cpp
@@ -13,11 +13,14 @@
 
 ScriptComponent::ScriptComponent(UID uid, GameObject* parent) : Component(uid, parent, "Script", COMPONENT_SCRIPT)
 {
+    localComponentAABB = AABB(float3(-0.5, -0.5, -0.5), float3(0.5, 0.5, 0.5));
 }
 
 ScriptComponent::ScriptComponent(const rapidjson::Value& initialState, GameObject* parent)
     : Component(initialState, parent)
 {
+    localComponentAABB = AABB(float3(-0.5, -0.5, -0.5), float3(0.5, 0.5, 0.5));
+
     if (initialState.HasMember("Scripts") && initialState["Scripts"].IsArray())
     {
         for (const auto& scriptData : initialState["Scripts"].GetArray())

--- a/SobrassadaEngine/Scene/Components/ScriptComponent.h
+++ b/SobrassadaEngine/Scene/Components/ScriptComponent.h
@@ -29,7 +29,11 @@ class ScriptComponent : public Component
     void RenderEditorInspector() override;
 
     void InitScriptInstances();
+
     void OnCollision(GameObject* otherObject, const float3 collisionNormal, ColliderLayer layer);
+    void OnCollisionEnter(GameObject* otherObject, const float3 collisionNormal, ColliderLayer layer);
+    void OnCollisionExit(GameObject* otherObject, ColliderLayer layer);
+
     bool CreateScript(const std::string& scriptType);
     void DeleteScript(const int index);
     void DeleteAllScripts();

--- a/SobrassadaEngine/Scene/Components/Standalone/Physics/CapsuleColliderComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/Physics/CapsuleColliderComponent.cpp
@@ -17,11 +17,23 @@ CapsuleColliderComponent::CapsuleColliderComponent(UID uid, GameObject* parent)
 
     CalculateCollider();
 
-    onCollissionCallback = CollisionDelegate(
-        std::bind(&CapsuleColliderComponent::OnCollision, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3)
+    onCollissionCallback      = CollisionDelegate(std::bind(
+        &CapsuleColliderComponent::OnCollision, this, std::placeholders::_1, std::placeholders::_2,
+        std::placeholders::_3
+    ));
+
+    onCollissionEnterCallback = CollisionDelegate(std::bind(
+        &CapsuleColliderComponent::OnCollisionEnter, this, std::placeholders::_1, std::placeholders::_2,
+        std::placeholders::_3
+    ));
+
+    onCollissionExitCallback  = CollisionExitDelegate(
+        std::bind(&CapsuleColliderComponent::OnCollisionExit, this, std::placeholders::_1, std::placeholders::_2)
     );
 
-    userPointer = BulletUserPointer(this, &onCollissionCallback, generateCallback, layer);
+    userPointer = BulletUserPointer(
+        this, &onCollissionCallback, &onCollissionEnterCallback, &onCollissionExitCallback, generateCallback, layer
+    );
     // App->GetPhysicsModule()->CreateCapsuleRigidBody(this);
 }
 
@@ -49,11 +61,23 @@ CapsuleColliderComponent::CapsuleColliderComponent(const rapidjson::Value& initi
         centerRotation                    = {dataArray[0].GetFloat(), dataArray[1].GetFloat(), dataArray[2].GetFloat()};
     }
 
-    onCollissionCallback = CollisionDelegate(
-        std::bind(&CapsuleColliderComponent::OnCollision, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3)
+    onCollissionCallback      = CollisionDelegate(std::bind(
+        &CapsuleColliderComponent::OnCollision, this, std::placeholders::_1, std::placeholders::_2,
+        std::placeholders::_3
+    ));
+
+    onCollissionEnterCallback = CollisionDelegate(std::bind(
+        &CapsuleColliderComponent::OnCollisionEnter, this, std::placeholders::_1, std::placeholders::_2,
+        std::placeholders::_3
+    ));
+
+    onCollissionExitCallback  = CollisionExitDelegate(
+        std::bind(&CapsuleColliderComponent::OnCollisionExit, this, std::placeholders::_1, std::placeholders::_2)
     );
 
-    userPointer = BulletUserPointer(this, &onCollissionCallback, generateCallback, layer);
+    userPointer          = BulletUserPointer(
+        this, &onCollissionCallback, &onCollissionEnterCallback, &onCollissionExitCallback, generateCallback, layer
+    );
     // App->GetPhysicsModule()->CreateCapsuleRigidBody(this);
 }
 
@@ -162,7 +186,10 @@ void CapsuleColliderComponent::RenderEditorInspector()
             if (ImGui::Selectable(ColliderLayerStrings[i]))
             {
                 layer       = ColliderLayer(i);
-                userPointer = BulletUserPointer(this, &onCollissionCallback, generateCallback, layer);
+                userPointer = BulletUserPointer(
+                    this, &onCollissionCallback, &onCollissionEnterCallback, &onCollissionExitCallback,
+                    generateCallback, layer
+                );
                 App->GetPhysicsModule()->UpdateCapsuleRigidBody(this);
             }
         }
@@ -177,7 +204,9 @@ void CapsuleColliderComponent::RenderEditorInspector()
 
     if (ImGui::Checkbox("Generate Callbacks", &generateCallback))
     {
-        userPointer = BulletUserPointer(this, &onCollissionCallback, generateCallback, layer);
+        userPointer = BulletUserPointer(
+            this, &onCollissionCallback, &onCollissionEnterCallback, &onCollissionExitCallback, generateCallback, layer
+        );
     }
 }
 
@@ -218,6 +247,22 @@ void CapsuleColliderComponent::OnCollision(GameObject* otherObject, float3 colli
 
     auto script = parent->GetComponent<ScriptComponent*>();
     if (script) script->OnCollision(otherObject, collisionNormal, layer);
+}
+
+void CapsuleColliderComponent::OnCollisionEnter(GameObject* otherObject, float3 collisionNormal, ColliderLayer layer)
+{
+    if (!enabled || !otherObject->IsEnabled()) return;
+
+    auto script = parent->GetComponent<ScriptComponent*>();
+    if (script) script->OnCollisionEnter(otherObject, collisionNormal, layer);
+}
+
+void CapsuleColliderComponent::OnCollisionExit(GameObject* otherObject, ColliderLayer layer)
+{
+    if (!enabled || !otherObject->IsEnabled()) return;
+
+    auto script = parent->GetComponent<ScriptComponent*>();
+    if (script) script->OnCollisionExit(otherObject, layer);
 }
 
 void CapsuleColliderComponent::DeleteRigidBody()

--- a/SobrassadaEngine/Scene/Components/Standalone/Physics/CapsuleColliderComponent.h
+++ b/SobrassadaEngine/Scene/Components/Standalone/Physics/CapsuleColliderComponent.h
@@ -31,6 +31,8 @@ class CapsuleColliderComponent : public Component
     void ParentUpdated() override;
 
     void SOBRASADA_API_ENGINE OnCollision(GameObject* otherObject, float3 collisionNormal, ColliderLayer layer);
+    void SOBRASADA_API_ENGINE OnCollisionEnter(GameObject* otherObject, float3 collisionNormal, ColliderLayer layer);
+    void SOBRASADA_API_ENGINE OnCollisionExit(GameObject* otherObject, ColliderLayer layer);
 
     void SOBRASADA_API_ENGINE DeleteRigidBody();
 
@@ -49,7 +51,13 @@ class CapsuleColliderComponent : public Component
 
     btRigidBody* rigidBody        = nullptr;
     BulletMotionState motionState = BulletMotionState(nullptr, float3::zero, float3::zero);
+
     CollisionDelegate onCollissionCallback;
+    CollisionDelegate onCollissionEnterCallback;
+    CollisionExitDelegate onCollissionExitCallback;
+
     ColliderLayer layer           = ColliderLayer::WORLD_OBJECTS;
-    BulletUserPointer userPointer = BulletUserPointer(this, &onCollissionCallback, generateCallback, layer);
+    BulletUserPointer userPointer = BulletUserPointer(
+        this, &onCollissionCallback, &onCollissionEnterCallback, &onCollissionExitCallback, generateCallback, layer
+    );
 };

--- a/SobrassadaEngine/Scene/Components/Standalone/Physics/CubeColliderComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/Physics/CubeColliderComponent.cpp
@@ -17,10 +17,22 @@ CubeColliderComponent::CubeColliderComponent(UID uid, GameObject* parent)
 
     CalculateCollider();
 
-    onCollissionCallback = CollisionDelegate(
-        std::bind(&CubeColliderComponent::OnCollision, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3)
+    onCollissionCallback = CollisionDelegate(std::bind(
+        &CubeColliderComponent::OnCollision, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3
+    ));
+
+    onCollissionEnterCallback = CollisionDelegate(std::bind(
+        &CubeColliderComponent::OnCollisionEnter, this, std::placeholders::_1, std::placeholders::_2,
+        std::placeholders::_3
+    ));
+
+    onCollissionExitCallback  = CollisionExitDelegate(
+        std::bind(&CubeColliderComponent::OnCollisionExit, this, std::placeholders::_1, std::placeholders::_2)
     );
-    userPointer = BulletUserPointer(this, &onCollissionCallback, generateCallback, layer);
+
+    userPointer          = BulletUserPointer(
+        this, &onCollissionCallback, &onCollissionEnterCallback, &onCollissionExitCallback, generateCallback, layer
+    );
     // App->GetPhysicsModule()->CreateCubeRigidBody(this);
 }
 
@@ -51,10 +63,22 @@ CubeColliderComponent::CubeColliderComponent(const rapidjson::Value& initialStat
         size                              = {dataArray[0].GetFloat(), dataArray[1].GetFloat(), dataArray[2].GetFloat()};
     }
 
-    onCollissionCallback = CollisionDelegate(
-        std::bind(&CubeColliderComponent::OnCollision, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3)
+    onCollissionCallback      = CollisionDelegate(std::bind(
+        &CubeColliderComponent::OnCollision, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3
+    ));
+
+    onCollissionEnterCallback = CollisionDelegate(std::bind(
+        &CubeColliderComponent::OnCollisionEnter, this, std::placeholders::_1, std::placeholders::_2,
+        std::placeholders::_3
+    ));
+
+    onCollissionExitCallback  = CollisionExitDelegate(
+        std::bind(&CubeColliderComponent::OnCollisionExit, this, std::placeholders::_1, std::placeholders::_2)
     );
-    userPointer = BulletUserPointer(this, &onCollissionCallback, generateCallback, layer);
+
+    userPointer          = BulletUserPointer(
+        this, &onCollissionCallback, &onCollissionEnterCallback, &onCollissionExitCallback, generateCallback, layer
+    );
     // App->GetPhysicsModule()->CreateCubeRigidBody(this);
 }
 
@@ -163,7 +187,10 @@ void CubeColliderComponent::RenderEditorInspector()
             if (ImGui::Selectable(ColliderLayerStrings[i]))
             {
                 layer       = ColliderLayer(i);
-                userPointer = BulletUserPointer(this, &onCollissionCallback, generateCallback, layer);
+                userPointer = BulletUserPointer(
+                    this, &onCollissionCallback, &onCollissionEnterCallback, &onCollissionExitCallback,
+                    generateCallback, layer
+                );
                 App->GetPhysicsModule()->UpdateCubeRigidBody(this);
             }
         }
@@ -178,7 +205,9 @@ void CubeColliderComponent::RenderEditorInspector()
 
     if (ImGui::Checkbox("Generate Callbacks", &generateCallback))
     {
-        userPointer = BulletUserPointer(this, &onCollissionCallback, generateCallback, layer);
+        userPointer = BulletUserPointer(
+            this, &onCollissionCallback, &onCollissionEnterCallback, &onCollissionExitCallback, generateCallback, layer
+        );
     }
 }
 
@@ -220,6 +249,23 @@ void CubeColliderComponent::OnCollision(GameObject* otherObject, float3 collisio
     auto script = parent->GetComponent<ScriptComponent*>();
 
     if (script) script->OnCollision(otherObject, collisionNormal, layer);
+}
+
+void SOBRASADA_API_ENGINE
+CubeColliderComponent::OnCollisionEnter(GameObject* otherObject, float3 collisionNormal, ColliderLayer layer)
+{
+    if (!enabled || !otherObject->IsEnabled()) return;
+
+    auto script = parent->GetComponent<ScriptComponent*>();
+    if (script) script->OnCollisionEnter(otherObject, collisionNormal, layer);
+}
+
+void SOBRASADA_API_ENGINE CubeColliderComponent::OnCollisionExit(GameObject* otherObject, ColliderLayer layer)
+{
+    if (!enabled || !otherObject->IsEnabled()) return;
+
+    auto script = parent->GetComponent<ScriptComponent*>();
+    if (script) script->OnCollisionExit(otherObject, layer);
 }
 
 void CubeColliderComponent::DeleteRigidBody()

--- a/SobrassadaEngine/Scene/Components/Standalone/Physics/CubeColliderComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/Physics/CubeColliderComponent.cpp
@@ -17,7 +17,7 @@ CubeColliderComponent::CubeColliderComponent(UID uid, GameObject* parent)
 
     CalculateCollider();
 
-    onCollissionCallback = CollisionDelegate(std::bind(
+    onCollissionCallback      = CollisionDelegate(std::bind(
         &CubeColliderComponent::OnCollision, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3
     ));
 
@@ -30,7 +30,7 @@ CubeColliderComponent::CubeColliderComponent(UID uid, GameObject* parent)
         std::bind(&CubeColliderComponent::OnCollisionExit, this, std::placeholders::_1, std::placeholders::_2)
     );
 
-    userPointer          = BulletUserPointer(
+    userPointer = BulletUserPointer(
         this, &onCollissionCallback, &onCollissionEnterCallback, &onCollissionExitCallback, generateCallback, layer
     );
     // App->GetPhysicsModule()->CreateCubeRigidBody(this);
@@ -76,9 +76,11 @@ CubeColliderComponent::CubeColliderComponent(const rapidjson::Value& initialStat
         std::bind(&CubeColliderComponent::OnCollisionExit, this, std::placeholders::_1, std::placeholders::_2)
     );
 
-    userPointer          = BulletUserPointer(
+    userPointer = BulletUserPointer(
         this, &onCollissionCallback, &onCollissionEnterCallback, &onCollissionExitCallback, generateCallback, layer
     );
+
+    RecalculateLocalAABB();
     // App->GetPhysicsModule()->CreateCubeRigidBody(this);
 }
 
@@ -171,12 +173,22 @@ void CubeColliderComponent::RenderEditorInspector()
     ImGui::EndDisabled();
 
     if (ImGui::DragFloat3("Center offset", &centerOffset[0], 0.05f, -10.f, 10.f))
+    {
         App->GetPhysicsModule()->UpdateCubeRigidBody(this);
+        RecalculateLocalAABB();
+    }
 
-    if (ImGui::DragFloat3("Size", &size[0], 0.05f, 0.f, 20.f)) App->GetPhysicsModule()->UpdateCubeRigidBody(this);
+    if (ImGui::DragFloat3("Size", &size[0], 0.05f, 0.f, 20.f))
+    {
+        App->GetPhysicsModule()->UpdateCubeRigidBody(this);
+        RecalculateLocalAABB();
+    }
 
     if (ImGui::DragFloat3("Center rotation", &centerRotation[0], 0.01745329f, -1.570796f, 1.570796f))
+    {
         App->GetPhysicsModule()->UpdateCubeRigidBody(this);
+        RecalculateLocalAABB();
+    }
 
     // COLLIDER LAYER SETTINGS
     if (ImGui::BeginCombo("Layer options", ColliderLayerStrings[(int)layer]))
@@ -283,5 +295,13 @@ void CubeColliderComponent::CalculateCollider()
     {
         size         = heriachyAABB.HalfSize();
         centerOffset = heriachyAABB.CenterPoint() - globalTransform.TranslatePart();
+        RecalculateLocalAABB();
     }
+}
+
+void CubeColliderComponent::RecalculateLocalAABB()
+{
+    float3 minPos      = centerOffset - size;
+    float3 maxPos      = centerOffset + size;
+    localComponentAABB = AABB(minPos, maxPos);
 }

--- a/SobrassadaEngine/Scene/Components/Standalone/Physics/CubeColliderComponent.h
+++ b/SobrassadaEngine/Scene/Components/Standalone/Physics/CubeColliderComponent.h
@@ -31,6 +31,8 @@ class CubeColliderComponent : public Component
     void ParentUpdated() override;
 
     void SOBRASADA_API_ENGINE OnCollision(GameObject* otherObject, float3 collisionNormal, ColliderLayer layer);
+    void SOBRASADA_API_ENGINE OnCollisionEnter(GameObject* otherObject, float3 collisionNormal, ColliderLayer layer);
+    void SOBRASADA_API_ENGINE OnCollisionExit(GameObject* otherObject, ColliderLayer layer);
 
     void SOBRASADA_API_ENGINE DeleteRigidBody();
 
@@ -48,7 +50,14 @@ class CubeColliderComponent : public Component
 
     btRigidBody* rigidBody        = nullptr;
     BulletMotionState motionState = BulletMotionState(nullptr, float3::zero, float3::zero);
+
     CollisionDelegate onCollissionCallback;
+    CollisionDelegate onCollissionEnterCallback;
+    CollisionExitDelegate onCollissionExitCallback;
+
     ColliderLayer layer           = ColliderLayer::WORLD_OBJECTS;
-    BulletUserPointer userPointer = BulletUserPointer(this, &onCollissionCallback, generateCallback, layer);
+
+    BulletUserPointer userPointer = BulletUserPointer(
+        this, &onCollissionCallback, &onCollissionEnterCallback, &onCollissionExitCallback, generateCallback, layer
+    );
 };

--- a/SobrassadaEngine/Scene/Components/Standalone/Physics/CubeColliderComponent.h
+++ b/SobrassadaEngine/Scene/Components/Standalone/Physics/CubeColliderComponent.h
@@ -38,6 +38,7 @@ class CubeColliderComponent : public Component
 
   private:
     void CalculateCollider();
+    void RecalculateLocalAABB();
 
   public:
     bool generateCallback         = true;

--- a/SobrassadaEngine/Scene/Components/Standalone/Physics/SphereColliderComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/Physics/SphereColliderComponent.cpp
@@ -17,11 +17,22 @@ SphereColliderComponent::SphereColliderComponent(UID uid, GameObject* parent)
 
     CalculateCollider();
 
-    onCollissionCallback = CollisionDelegate(
-        std::bind(&SphereColliderComponent::OnCollision, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3)
+    onCollissionCallback      = CollisionDelegate(std::bind(
+        &SphereColliderComponent::OnCollision, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3
+    ));
+
+    onCollissionEnterCallback = CollisionDelegate(std::bind(
+        &SphereColliderComponent::OnCollisionEnter, this, std::placeholders::_1, std::placeholders::_2,
+        std::placeholders::_3
+    ));
+
+    onCollissionExitCallback  = CollisionExitDelegate(
+        std::bind(&SphereColliderComponent::OnCollisionExit, this, std::placeholders::_1, std::placeholders::_2)
     );
 
-    userPointer = BulletUserPointer(this, &onCollissionCallback, generateCallback, layer);
+    userPointer = BulletUserPointer(
+        this, &onCollissionCallback, &onCollissionEnterCallback, &onCollissionExitCallback, generateCallback, layer
+    );
     // App->GetPhysicsModule()->CreateSphereRigidBody(this);
 }
 
@@ -47,11 +58,22 @@ SphereColliderComponent::SphereColliderComponent(const rapidjson::Value& initial
         centerRotation                    = {dataArray[0].GetFloat(), dataArray[1].GetFloat(), dataArray[2].GetFloat()};
     }
 
-    onCollissionCallback = CollisionDelegate(
-        std::bind(&SphereColliderComponent::OnCollision, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3)
+    onCollissionCallback      = CollisionDelegate(std::bind(
+        &SphereColliderComponent::OnCollision, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3
+    ));
+
+    onCollissionEnterCallback = CollisionDelegate(std::bind(
+        &SphereColliderComponent::OnCollisionEnter, this, std::placeholders::_1, std::placeholders::_2,
+        std::placeholders::_3
+    ));
+
+    onCollissionExitCallback  = CollisionExitDelegate(
+        std::bind(&SphereColliderComponent::OnCollisionExit, this, std::placeholders::_1, std::placeholders::_2)
     );
 
-    userPointer = BulletUserPointer(this, &onCollissionCallback, generateCallback, layer);
+    userPointer          = BulletUserPointer(
+        this, &onCollissionCallback, &onCollissionEnterCallback, &onCollissionExitCallback, generateCallback, layer
+    );
     // App->GetPhysicsModule()->CreateSphereRigidBody(this);
 }
 
@@ -157,7 +179,10 @@ void SphereColliderComponent::RenderEditorInspector()
             if (ImGui::Selectable(ColliderLayerStrings[i]))
             {
                 layer       = ColliderLayer(i);
-                userPointer = BulletUserPointer(this, &onCollissionCallback, generateCallback, layer);
+                userPointer = BulletUserPointer(
+                    this, &onCollissionCallback, &onCollissionEnterCallback, &onCollissionExitCallback,
+                    generateCallback, layer
+                );
                 App->GetPhysicsModule()->UpdateSphereRigidBody(this);
             }
         }
@@ -172,7 +197,9 @@ void SphereColliderComponent::RenderEditorInspector()
 
     if (ImGui::Checkbox("Generate Callbacks", &generateCallback))
     {
-        userPointer = BulletUserPointer(this, &onCollissionCallback, generateCallback, layer);
+        userPointer = BulletUserPointer(
+            this, &onCollissionCallback, &onCollissionEnterCallback, &onCollissionExitCallback, generateCallback, layer
+        );
     }
 }
 
@@ -212,8 +239,24 @@ void SphereColliderComponent::OnCollision(GameObject* otherObject, float3 collis
     if (!enabled || !otherObject->IsEnabled()) return;
 
     auto script = parent->GetComponent<ScriptComponent*>();
-
     if (script) script->OnCollision(otherObject, collisionNormal, layer);
+}
+
+void SOBRASADA_API_ENGINE
+SphereColliderComponent::OnCollisionEnter(GameObject* otherObject, float3 collisionNormal, ColliderLayer layer)
+{
+    if (!enabled || !otherObject->IsEnabled()) return;
+
+    auto script = parent->GetComponent<ScriptComponent*>();
+    if (script) script->OnCollisionEnter(otherObject, collisionNormal, layer);
+}
+
+void SOBRASADA_API_ENGINE SphereColliderComponent::OnCollisionExit(GameObject* otherObject, ColliderLayer layer)
+{
+    if (!enabled || !otherObject->IsEnabled()) return;
+
+    auto script = parent->GetComponent<ScriptComponent*>();
+    if (script) script->OnCollisionExit(otherObject, layer);
 }
 
 void SphereColliderComponent::DeleteRigidBody()

--- a/SobrassadaEngine/Scene/Components/Standalone/Physics/SphereColliderComponent.h
+++ b/SobrassadaEngine/Scene/Components/Standalone/Physics/SphereColliderComponent.h
@@ -31,6 +31,8 @@ class SphereColliderComponent : public Component
     void ParentUpdated() override;
 
     void SOBRASADA_API_ENGINE OnCollision(GameObject* otherObject, float3 collisionNormal, ColliderLayer layer);
+    void SOBRASADA_API_ENGINE OnCollisionEnter(GameObject* otherObject, float3 collisionNormal, ColliderLayer layer);
+    void SOBRASADA_API_ENGINE OnCollisionExit(GameObject* otherObject, ColliderLayer layer);
 
     void SOBRASADA_API_ENGINE DeleteRigidBody();
 
@@ -48,7 +50,13 @@ class SphereColliderComponent : public Component
 
     btRigidBody* rigidBody        = nullptr;
     BulletMotionState motionState = BulletMotionState(nullptr, float3::zero, float3::zero);
+
     CollisionDelegate onCollissionCallback;
+    CollisionDelegate onCollissionEnterCallback;
+    CollisionExitDelegate onCollissionExitCallback;
+
     ColliderLayer layer           = ColliderLayer::WORLD_OBJECTS;
-    BulletUserPointer userPointer = BulletUserPointer(this, &onCollissionCallback, generateCallback, layer);
+    BulletUserPointer userPointer = BulletUserPointer(
+        this, &onCollissionCallback, &onCollissionEnterCallback, &onCollissionExitCallback, generateCallback, layer
+    );
 };

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
@@ -304,17 +304,6 @@ void GameObject::LoadData(const rapidjson::Value& initialState)
     if (initialState.HasMember("PrefabChildUID")) prefabChildUID = initialState["PrefabChildUID"].GetUint64();
     if (initialState.HasMember("NavmeshValid")) navMeshValid = initialState["NavmeshValid"].GetBool();
 
-    //if (initialState.HasMember("tags"))
-    //{
-    //    const rapidjson::Value& dataArray = initialState["tags"];
-
-    //    for (rapidjson::SizeType i = 0; i < dataArray.Size(); i++)
-    //    {
-    //        HashString newTag = HashString(dataArray[i].GetString());
-    //        App->GetSceneModule()->GetScene()->RequestTag(newTag, this);
-    //    }
-    //}
-
     if (initialState.HasMember("LocalTransform") && initialState["LocalTransform"].IsArray() &&
         initialState["LocalTransform"].Size() == 16)
     {
@@ -424,12 +413,12 @@ void GameObject::Save(rapidjson::Value& targetState, rapidjson::Document::Alloca
     targetState.AddMember("WasEnabled", wasEnabled, allocator);
     targetState.AddMember("NavmeshValid", navMeshValid, allocator);
 
-    rapidjson::Value gameObjectsTags(rapidjson::kArrayType);
-    for (auto& tag : tags)
-    {
-        gameObjectsTags.PushBack(rapidjson::Value(tag.c_str(), allocator), allocator);
-    }
-    targetState.AddMember("tags", gameObjectsTags, allocator);
+    //rapidjson::Value gameObjectsTags(rapidjson::kArrayType);
+    //for (auto& tag : tags)
+    //{
+    //    gameObjectsTags.PushBack(rapidjson::Value(tag.c_str(), allocator), allocator);
+    //}
+    //targetState.AddMember("tags", gameObjectsTags, allocator);
 
     if (prefabUID != INVALID_UID) targetState.AddMember("PrefabUID", prefabUID, allocator);
     if (prefabVersionUID != INVALID_UID) targetState.AddMember("PrefabVersionUID", prefabVersionUID, allocator);

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
@@ -638,7 +638,7 @@ void GameObject::RenderEditorInspector(bool drawGizmo)
 void GameObject::UpdateTransformForGOBranch()
 {
     if (!IsGloballyEnabled()) return;
-    App->GetSceneModule()->AddGameObjectToUpdate(this);
+    App->GetSceneModule()->AddGameObjectToUpdateComponents(this);
     std::stack<UID> childrenBuffer;
     childrenBuffer.push(uid);
 
@@ -648,7 +648,7 @@ void GameObject::UpdateTransformForGOBranch()
         childrenBuffer.pop();
         if (gameObject != nullptr)
         {
-            App->GetSceneModule()->AddGameObjectToUpdate(gameObject);
+            App->GetSceneModule()->AddGameObjectToUpdateComponents(gameObject);
             gameObject->OnAABBUpdated();
             for (UID child : gameObject->GetChildren())
                 childrenBuffer.push(child);
@@ -1156,7 +1156,7 @@ void GameObject::OnDrawConnectionsToggle()
 
 void GameObject::UpdateMobilityHierarchy(MobilitySettings type)
 {
-    App->GetSceneModule()->AddGameObjectToUpdate(this);
+    App->GetSceneModule()->AddGameObjectToUpdateComponents(this);
     SetMobility(type);
     std::set<UID> visitedGameObjects;
     std::stack<UID> toVisitGameObjects;
@@ -1179,7 +1179,7 @@ void GameObject::UpdateMobilityHierarchy(MobilitySettings type)
             GameObject* currentGameObject = App->GetSceneModule()->GetScene()->GetGameObjectByUID(currentUID);
 
             currentGameObject->SetMobility(type);
-            App->GetSceneModule()->AddGameObjectToUpdate(currentGameObject);
+            App->GetSceneModule()->AddGameObjectToUpdateComponents(currentGameObject);
 
             for (UID childID : currentGameObject->GetChildren())
                 toVisitGameObjects.push(childID);
@@ -1202,7 +1202,7 @@ void GameObject::UpdateMobilityHierarchy(MobilitySettings type)
             if (currentGameObject)
             {
                 currentGameObject->SetMobility(type);
-                App->GetSceneModule()->AddGameObjectToUpdate(currentGameObject);
+                App->GetSceneModule()->AddGameObjectToUpdateComponents(currentGameObject);
 
                 for (UID childID : currentGameObject->GetChildren())
                     toVisitGameObjects.push(childID);

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
@@ -250,6 +250,13 @@ GameObject::GameObject(UID parentUID, GameObject* refObject)
     enabled          = refObject->enabled;
     wasEnabled       = refObject->wasEnabled;
 
+    // Request tags
+
+    for (auto& tag : refObject->tags)
+    {
+        App->GetSceneModule()->GetScene()->RequestTag(tag, this);
+    }
+
     // Must make a copy of each manually
     for (int i = 0; i < std::tuple_size<decltype(compTuple)>::value; ++i)
     {

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
@@ -274,6 +274,13 @@ GameObject::GameObject(const rapidjson::Value& initialState) : uid(initialState[
 
 GameObject::~GameObject()
 {
+    // REMOVE FROM TAGS REMOVES IT FROM "tags"
+    std::vector<HashString> tagsCopy = tags;
+    for (int i = 0; i < tagsCopy.size(); ++i)
+    {
+        App->GetSceneModule()->GetScene()->RemoveFromTag(tags[i], this);
+    }
+
     std::apply([](auto&... tupleVar) { ((delete tupleVar, tupleVar = nullptr), ...); }, compTuple);
 }
 
@@ -297,16 +304,16 @@ void GameObject::LoadData(const rapidjson::Value& initialState)
     if (initialState.HasMember("PrefabChildUID")) prefabChildUID = initialState["PrefabChildUID"].GetUint64();
     if (initialState.HasMember("NavmeshValid")) navMeshValid = initialState["NavmeshValid"].GetBool();
 
-    if (initialState.HasMember("tags"))
-    {
-        const rapidjson::Value& dataArray = initialState["tags"];
+    //if (initialState.HasMember("tags"))
+    //{
+    //    const rapidjson::Value& dataArray = initialState["tags"];
 
-        for (rapidjson::SizeType i = 0; i < dataArray.Size(); i++)
-        {
-            HashString newTag = HashString(dataArray[i].GetString());
-            App->GetSceneModule()->GetScene()->RequestTag(newTag, this);
-        }
-    }
+    //    for (rapidjson::SizeType i = 0; i < dataArray.Size(); i++)
+    //    {
+    //        HashString newTag = HashString(dataArray[i].GetString());
+    //        App->GetSceneModule()->GetScene()->RequestTag(newTag, this);
+    //    }
+    //}
 
     if (initialState.HasMember("LocalTransform") && initialState["LocalTransform"].IsArray() &&
         initialState["LocalTransform"].Size() == 16)

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
@@ -176,6 +176,7 @@ template <std::size_t I = 0, typename... Tp>
 
 GameObject::GameObject(const std::string& name) : name(name)
 {
+    tags.reserve(maxTags);
     compTuple = std::make_tuple(COMPONENTS_NULLPTR);
 
     uid       = GenerateUID();
@@ -192,6 +193,7 @@ GameObject::GameObject(const std::string& name) : name(name)
 
 GameObject::GameObject(UID parentUID, const std::string& name) : parentUID(parentUID), name(name)
 {
+    tags.reserve(maxTags);
     compTuple = std::make_tuple(COMPONENTS_NULLPTR);
 
     uid       = GenerateUID();
@@ -207,6 +209,7 @@ GameObject::GameObject(UID parentUID, const std::string& name) : parentUID(paren
 
 GameObject::GameObject(UID parentUID, const std::string& name, UID uid) : parentUID(parentUID), name(name), uid(uid)
 {
+    tags.reserve(maxTags);
     compTuple = std::make_tuple(COMPONENTS_NULLPTR);
 
     localAABB = AABB();
@@ -222,6 +225,8 @@ GameObject::GameObject(UID parentUID, GameObject* refObject)
     : parentUID(parentUID), name(refObject->name), localTransform(refObject->localTransform),
       globalTransform(refObject->globalTransform)
 {
+    tags.reserve(maxTags);
+
     compTuple = std::make_tuple(COMPONENTS_NULLPTR);
     createdComponents.reset();
 
@@ -284,6 +289,17 @@ void GameObject::LoadData(const rapidjson::Value& initialState)
     if (initialState.HasMember("PrefabVersionUID")) prefabVersionUID = initialState["PrefabVersionUID"].GetUint64();
     if (initialState.HasMember("PrefabChildUID")) prefabChildUID = initialState["PrefabChildUID"].GetUint64();
     if (initialState.HasMember("NavmeshValid")) navMeshValid = initialState["NavmeshValid"].GetBool();
+
+    if (initialState.HasMember("tags"))
+    {
+        const rapidjson::Value& dataArray = initialState["tags"];
+
+        for (rapidjson::SizeType i = 0; i < dataArray.Size(); i++)
+        {
+            HashString newTag = HashString(dataArray[i].GetString());
+            App->GetSceneModule()->GetScene()->RequestTag(newTag, this);
+        }
+    }
 
     if (initialState.HasMember("LocalTransform") && initialState["LocalTransform"].IsArray() &&
         initialState["LocalTransform"].Size() == 16)
@@ -393,6 +409,13 @@ void GameObject::Save(rapidjson::Value& targetState, rapidjson::Document::Alloca
     targetState.AddMember("Enabled", enabled, allocator);
     targetState.AddMember("WasEnabled", wasEnabled, allocator);
     targetState.AddMember("NavmeshValid", navMeshValid, allocator);
+
+    rapidjson::Value gameObjectsTags(rapidjson::kArrayType);
+    for (auto& tag : tags)
+    {
+        gameObjectsTags.PushBack(rapidjson::Value(tag.c_str(), allocator), allocator);
+    }
+    targetState.AddMember("tags", gameObjectsTags, allocator);
 
     if (prefabUID != INVALID_UID) targetState.AddMember("PrefabUID", prefabUID, allocator);
     if (prefabVersionUID != INVALID_UID) targetState.AddMember("PrefabVersionUID", prefabVersionUID, allocator);
@@ -531,6 +554,109 @@ void GameObject::RenderEditorInspector(bool drawGizmo)
             }
             UpdateNavmeshValidState();
         }
+
+        ImGui::Spacing();
+        ImGui::Separator();
+        ImGui::Spacing();
+
+        if (ImGui::CollapsingHeader("Tags"))
+        {
+            // ------ GLOBAL TAG LIST ------
+            ImGui::SeparatorText("Global Tags");
+
+            ImGui::InputText("New Tag Name", newTagName, IM_ARRAYSIZE(newTagName));
+            if (ImGui::Button("Create Tag"))
+            {
+                HashString requestedTag(newTagName);
+                App->GetSceneModule()->GetScene()->CreateTag(std::move(requestedTag));
+                memset(newTagName, 0, sizeof(newTagName));
+            }
+
+            auto& sceneTagMap = App->GetSceneModule()->GetScene()->GetTags();
+            if (ImGui::BeginListBox(
+                    "##SceneTags", ImVec2(-FLT_MIN, ImGui::GetFrameHeightWithSpacing() * sceneTagMap.size())
+                ))
+            {
+                int i = 0;
+                for (auto& tagPair : sceneTagMap)
+                {
+                    if (ImGui::Selectable(tagPair.first.c_str(), selectedGlobalTag == i))
+                    {
+                        selectedGlobalTag = i;
+                        globalSelectedTag = tagPair.first;
+                    }
+
+                    ++i;
+                }
+                ImGui::EndListBox();
+            }
+
+            if (ImGui::Button("Add tag"))
+            {
+                App->GetSceneModule()->GetScene()->RequestTag(globalSelectedTag, this);
+                selectedGlobalTag = -1;
+                globalSelectedTag = HashString("");
+            }
+            ImGui::SameLine();
+            if (ImGui::Button("DELETE GLOBAL TAG!"))
+            {
+                App->GetSceneModule()->GetScene()->DeleteTag(globalSelectedTag);
+                selectedGlobalTag = -1;
+                globalSelectedTag = HashString("");
+            }
+
+            // !!!!!!!!!!!!!!!!!!!!!! TESTING THIS HAS TO BE BE DELETED !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+            if (ImGui::Button("TESTING GET TAGS PLEASE DELETE!"))
+            {
+                auto taggedObjects = App->GetSceneModule()->GetScene()->GetTaggedGameObjects(globalSelectedTag);
+                if (taggedObjects)
+                {
+                    GLOG("------- PRINTING %s TAGGED GAME OBJECTS -------", globalSelectedTag.c_str());
+                    for (GameObject* go : *taggedObjects)
+                    {
+                        GLOG("%s, %d", go->GetName().c_str(), go->GetUID());
+                    }
+                }
+
+                selectedGlobalTag = -1;
+                globalSelectedTag = HashString("");
+            }
+            // !!!!!!!!!!!!!!!!!!!!!! TESTING THIS HAS TO BE BE DELETED !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+            // ------ END GLOBAL TAG LIST ------
+
+            // ------ SELF TAG LIST ------
+            ImGui::SeparatorText("Game Object Tags");
+
+            if (ImGui::BeginListBox(
+                    "##GameObjectsTags", ImVec2(-FLT_MIN, ImGui::GetFrameHeightWithSpacing() * tags.size())
+                ))
+            {
+                int i = 0;
+                for (HashString& currentTag : tags)
+                {
+                    if (ImGui::Selectable(currentTag.c_str(), selectedSelfTag == i))
+                    {
+                        selectedSelfTag = i;
+                    }
+
+                    ++i;
+                }
+                ImGui::EndListBox();
+            }
+
+            if (ImGui::Button("Remove Tag"))
+            {
+                App->GetSceneModule()->GetScene()->RemoveFromTag(tags[selectedSelfTag], this);
+                selectedSelfTag = -1;
+            }
+
+            // ------ END SELF TAG LIST ------
+        }
+
+        ImGui::Spacing();
+        ImGui::Separator();
+        ImGui::Spacing();
 
         if (ImGui::Button("Add Component"))
         {
@@ -747,6 +873,45 @@ void GameObject::UpdateOpenNodeHierarchy(bool openValue)
             gameObjectToUpdate->UpdateOpenNodeHierarchy(openValue);
             if (gameObjectToUpdate->GetParent() != INVALID_UID)
                 gameObjectsToVisit.push(gameObjectToUpdate->GetParent());
+        }
+    }
+}
+
+bool GameObject::HasTag(const HashString& requestedTag)
+{
+    for (HashString& currentTag : tags)
+    {
+        if (currentTag == requestedTag) return true;
+    }
+
+    return false;
+}
+
+void GameObject::AddTag(const HashString& tag)
+{
+    if (tags.size() > maxTags) return;
+    bool add = true;
+
+    for (HashString& currentTag : tags)
+    {
+        if (currentTag == tag)
+        {
+            add = false;
+            break;
+        }
+    }
+
+    if (add) tags.push_back(tag);
+}
+
+void GameObject::RemoveTag(const HashString& tag)
+{
+    for (auto tagIterator = tags.begin(); tagIterator != tags.end(); ++tagIterator)
+    {
+        if (*tagIterator == tag)
+        {
+            tags.erase(tagIterator);
+            return;
         }
     }
 }

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.h
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.h
@@ -14,6 +14,8 @@
 #include <tuple>
 #include <vector>
 
+constexpr int maxTags = 10;
+
 class MeshComponent;
 class PointLightComponent;
 class SpotLightComponent;
@@ -124,6 +126,10 @@ class SOBRASADA_API_ENGINE GameObject
 
     bool WillUpdate() const { return willUpdate; };
 
+    bool HasTag(const HashString& requestedTag);
+    void AddTag(const HashString& tag);
+    void RemoveTag(const HashString& tag);
+
     template <typename T> T GetComponent() const { return std::get<T>(compTuple); }
     template <typename T> T GetComponentChild(Application* app) const;
     template <typename T> T GetComponentParent(Application* app) const;
@@ -191,6 +197,7 @@ class SOBRASADA_API_ENGINE GameObject
 
     bool isRenaming = false;
     char renameBuffer[128];
+    char newTagName[64]                  = "";
 
     UID prefabUID                        = INVALID_UID;
     UID prefabVersionUID                 = INVALID_UID;
@@ -217,7 +224,12 @@ class SOBRASADA_API_ENGINE GameObject
     std::tuple<COMPONENTS> compTuple     = std::make_tuple(COMPONENTS_NULLPTR);
     std::bitset<std::tuple_size<decltype(compTuple)>::value> createdComponents;
 
-    bool hasScriptsToLoad = false;
+    bool hasScriptsToLoad        = false;
+
+    int selectedSelfTag          = -1;
+    int selectedGlobalTag        = -1;
+    HashString globalSelectedTag = HashString("");
+    std::vector<HashString> tags;
 };
 
 template <typename T> inline T GameObject::GetComponentChild(Application* app) const

--- a/SobrassadaEngine/Scene/RenderPass.cpp
+++ b/SobrassadaEngine/Scene/RenderPass.cpp
@@ -426,7 +426,7 @@ void RenderPass::ShadowMapPassRender(
     FrustumPlanes lightFrustum;
     lightFrustum.UpdateFrustumPlanes(lightView, lightProj);
     std::vector<GameObject*> shadowObjectsToRender;
-    App->GetSceneModule()->GetScene()->CheckObjectsToRender(shadowObjectsToRender, lightFrustum);
+    App->GetSceneModule()->GetScene()->CheckObjectsInFrustum(shadowObjectsToRender, lightFrustum);
 
     for (const auto& gameObject : shadowObjectsToRender)
     {

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -140,7 +140,9 @@ Scene::Scene(const rapidjson::Value& initialState, UID loadedSceneUID) : sceneUI
 
             for (int j = 0; j < tagGODataArray[i].Size(); ++j)
             {
-                RequestTag(newTag, GetGameObjectByUID(tagGODataArray[i][j].GetUint64()));
+                RequestTag(
+                    HashString(tagDataArray[i].GetString()), GetGameObjectByUID(tagGODataArray[i][j].GetUint64())
+                );
             }
         }
     }

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -867,27 +867,12 @@ void Scene::CheckObjectsToUpdate()
 
     for (auto gameObject : toUpdateGameObjects)
         toUpdateGameObjectsSet.insert(gameObject->GetUID());
-
+    
+    // ADDING MAIN CAMERA MANUALLY SINCE IS NOT INSIDE ITS OWN FRUSTUM SO NO UPDATES XD
     if (mainCamera && toUpdateGameObjectsSet.find(mainCamera->GetParent()->GetUID()) == toUpdateGameObjectsSet.end())
     {
         toUpdateGameObjects.push_back(mainCamera->GetParent());
         toUpdateGameObjectsSet.insert(mainCamera->GetParent()->GetUID());
-    }
-
-    // ADDING MANUALLY BECAUSE SOME OBJECTS WITH SCRIPTS ARE NOT BEING RETURNED LDGJFHFNLKAJDSFLKAD
-
-    GameObject* walk = GetGameObjectByName("walk");
-    if (walk && toUpdateGameObjectsSet.find(walkxd->GetUID()) == toUpdateGameObjectsSet.end())
-    {
-        toUpdateGameObjects.push_back(walkxd);
-        toUpdateGameObjectsSet.insert(walkxd->GetUID());
-    }
-
-    GameObject* cameraPivot = GetGameObjectByName("Camera Pivot");
-    if (cameraPivot && toUpdateGameObjectsSet.find(cameraPivot->GetUID()) == toUpdateGameObjectsSet.end())
-    {
-        toUpdateGameObjects.push_back(cameraPivot);
-        toUpdateGameObjectsSet.insert(cameraPivot->GetUID());
     }
 }
 

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -372,9 +372,14 @@ void Scene::RenderScene(float deltaTime, CameraComponent* camera)
     }
 
 #ifndef GAME
-    for (const auto& gameObject : gameObjectsContainer)
+    // for (const auto& gameObject : gameObjectsContainer)
+    //{
+    //     gameObject.second->DrawGizmos();
+    // }
+
+    for (const auto& gameObject : toUpdateGameObjects)
     {
-        gameObject.second->DrawGizmos();
+        gameObject->DrawGizmos();
     }
 #endif
 

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -206,7 +206,7 @@ void Scene::Init()
         if (mesh) mesh->InitSkin();
     }
 
-    // Call this after overriding the prefabs to avoid duplicates in gameObjectsToUpdate
+    // Call this after overriding the prefabs to avoid duplicates in gameObjectsToUpdateComponents
     GetGameObjectByUID(gameObjectRootUID)->UpdateTransformForGOBranch();
 
     UpdateStaticSpatialStructure();
@@ -724,18 +724,18 @@ void Scene::RemoveGameObjectHierarchy(UID gameObjectUID)
     }
 }
 
-void Scene::AddGameObjectToUpdate(GameObject* gameObject)
+void Scene::AddGameObjectToUpdateComponents(GameObject* gameObject)
 {
     if (!gameObject->WillUpdate())
     {
         gameObject->SetWillUpdate(true);
-        gameObjectsToUpdate.push_back(gameObject);
+        gameObjectsToUpdateComponents.push_back(gameObject);
     }
 }
 
-void Scene::UpdateGameObjects()
+void Scene::UpdateGameObjectsComponents()
 {
-    for (GameObject* gameObject : gameObjectsToUpdate)
+    for (GameObject* gameObject : gameObjectsToUpdateComponents)
     {
         if (gameObject)
         {
@@ -743,12 +743,12 @@ void Scene::UpdateGameObjects()
             gameObject->SetWillUpdate(false);
         }
     }
-    gameObjectsToUpdate.clear();
+    gameObjectsToUpdateComponents.clear();
 }
 
-void Scene::ClearGameObjectsToUpdate()
+void Scene::ClearGameObjectsToUpdateComponents()
 {
-    gameObjectsToUpdate.clear();
+    gameObjectsToUpdateComponents.clear();
 }
 
 void Scene::AddGameObjectToSelection(UID gameObject, UID gameObjectParent)
@@ -840,7 +840,7 @@ void Scene::DeleteMultiselection()
     }
     selectedGameObjects.clear();
     selectedGameObjectsMobility.clear();
-    ClearGameObjectsToUpdate();
+    ClearGameObjectsToUpdateComponents();
 }
 
 UID Scene::GetMultiselectUID() const

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -1,4 +1,5 @@
 #include "Scene.h"
+#include "Scene.h"
 
 #include "Application.h"
 #include "BatchManager.h"
@@ -952,11 +953,19 @@ void Scene::CheckObjectsToUpdate()
     for (auto gameObject : toUpdateGameObjects)
         toUpdateGameObjectsSet.insert(gameObject->GetUID());
 
-    // ADDING MAIN CAMERA MANUALLY SINCE IS NOT INSIDE ITS OWN FRUSTUM SO NO UPDATES XD
-    if (mainCamera && toUpdateGameObjectsSet.find(mainCamera->GetParent()->GetUID()) == toUpdateGameObjectsSet.end())
+
+    GameObject* camera = GetGameObjectByName("Camera");
+    if (camera && toUpdateGameObjectsSet.find(camera->GetUID()) == toUpdateGameObjectsSet.end())
     {
-        toUpdateGameObjects.push_back(mainCamera->GetParent());
-        toUpdateGameObjectsSet.insert(mainCamera->GetParent()->GetUID());
+        toUpdateGameObjects.push_back(camera);
+        toUpdateGameObjectsSet.insert(camera->GetUID());
+    }
+    GameObject* cameraParent = GetGameObjectByUID(camera->GetParent());
+
+    if (toUpdateGameObjectsSet.find(cameraParent->GetUID()) == toUpdateGameObjectsSet.end())
+    {
+        toUpdateGameObjects.push_back(cameraParent);
+        toUpdateGameObjectsSet.insert(cameraParent->GetUID());
     }
 }
 

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -95,6 +95,17 @@ Scene::Scene(const rapidjson::Value& initialState, UID loadedSceneUID) : sceneUI
 
     App->GetPhysicsModule()->LoadLayerData(&initialState);
 
+    if (initialState.HasMember("tags"))
+    {
+        const rapidjson::Value& dataArray = initialState["tags"];
+
+        for (rapidjson::SizeType i = 0; i < dataArray.Size(); i++)
+        {
+            HashString newTag = HashString(dataArray[i].GetString());
+            CreateTag(std::move(newTag));
+        }
+    }
+
     // Load navmesh from scene.
     if (navmeshUID != INVALID_UID)
     {
@@ -241,6 +252,13 @@ void Scene::Save(
 
     App->GetPhysicsModule()->SaveLayerData(targetState, allocator);
 
+    rapidjson::Value sceneTagsJSON(rapidjson::kArrayType);
+    for (auto& tagPair : tags)
+    {
+        sceneTagsJSON.PushBack(rapidjson::Value(tagPair.first.c_str(), allocator), allocator);
+    }
+    targetState.AddMember("tags", sceneTagsJSON, allocator);
+
     // Serialize GameObjects
     rapidjson::Value gameObjectsJSON(rapidjson::kArrayType);
 
@@ -294,11 +312,11 @@ update_status Scene::Update(float deltaTime)
         App->GetSceneModule()->ResetOnlyOnceInPlayMode();
     }
 
-    //for (auto& gameObject : gameObjectsContainer)
-    //    gameObject.second->UpdateComponents(deltaTime);
+    // for (auto& gameObject : gameObjectsContainer)
+    //     gameObject.second->UpdateComponents(deltaTime);
 
-     for (auto gameObject : toUpdateGameObjects)
-         gameObject->UpdateComponents(deltaTime);
+    for (auto gameObject : toUpdateGameObjects)
+        gameObject->UpdateComponents(deltaTime);
 
     ImGuiWindow* window = ImGui::FindWindowByName(sceneName.c_str());
     if (window && !(window->Hidden || window->Collapsed)) sceneVisible = true;
@@ -846,6 +864,67 @@ void Scene::DeleteMultiselection()
     ClearGameObjectsToUpdateComponents();
 }
 
+void Scene::CreateTag(HashString&& newTag)
+{
+    if (newTag != emptyString && tags.find(newTag) == tags.end())
+    {
+        tags.insert({std::move(newTag), {}});
+    }
+}
+
+void Scene::DeleteTag(const HashString& tagToDelete)
+{
+    auto tagIterator = tags.find(tagToDelete);
+    if (tagIterator != tags.end())
+    {
+        for (GameObject* gameObject : tagIterator->second)
+        {
+            gameObject->RemoveTag(tagToDelete);
+        }
+
+        tags.erase(tagIterator);
+    }
+}
+
+void Scene::RequestTag(const HashString& requestTag, GameObject* gameObject)
+{
+    auto tagIterator = tags.find(requestTag);
+    if (tagIterator != tags.end() && !gameObject->HasTag(requestTag))
+    {
+        tags[requestTag].push_back(gameObject);
+        gameObject->AddTag(requestTag);
+    }
+}
+
+void Scene::RemoveFromTag(const HashString& requestTag, GameObject* gameObject)
+{
+    auto tagIterator = tags.find(requestTag);
+    if (tagIterator != tags.end() && gameObject->HasTag(requestTag))
+    {
+        std::vector<GameObject*>& gameObjects = tags[requestTag];
+
+        for (auto goIterator = gameObjects.begin(); goIterator != gameObjects.end(); ++goIterator)
+        {
+            if (*goIterator == gameObject)
+            {
+                gameObject->RemoveTag(requestTag);
+                gameObjects.erase(goIterator);
+                return;
+            }
+        }
+    }
+}
+
+const std::vector<GameObject*>* Scene::GetTaggedGameObjects(const HashString& requestTag)
+{
+    if (tags.find(requestTag) != tags.end())
+    {
+        return &tags[requestTag];
+    }
+
+    return nullptr;
+}
+
 UID Scene::GetMultiselectUID() const
 {
     return multiSelectParent->GetUID();
@@ -867,7 +946,7 @@ void Scene::CheckObjectsToUpdate()
 
     for (auto gameObject : toUpdateGameObjects)
         toUpdateGameObjectsSet.insert(gameObject->GetUID());
-    
+
     // ADDING MAIN CAMERA MANUALLY SINCE IS NOT INSIDE ITS OWN FRUSTUM SO NO UPDATES XD
     if (mainCamera && toUpdateGameObjectsSet.find(mainCamera->GetParent()->GetUID()) == toUpdateGameObjectsSet.end())
     {

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -24,7 +24,6 @@
 #include "ParticleSystemModule.h"
 #include "PathfinderModule.h"
 #include "PhysicsModule.h"
-#include "ParticleSystemModule.h"
 #include "ProjectModule.h"
 #include "Quadtree.h"
 #include "RenderPass.h"
@@ -209,9 +208,11 @@ void Scene::Init()
     // Call this after overriding the prefabs to avoid duplicates in gameObjectsToUpdateComponents
     GetGameObjectByUID(gameObjectRootUID)->UpdateTransformForGOBranch();
 
+    // Worst case all objects are in frustum
+    toUpdateGameObjects.reserve(gameObjectsContainer.size());
+
     UpdateStaticSpatialStructure();
     UpdateDynamicSpatialStructure();
-
 
     isSceneLoaded = true;
 }
@@ -293,8 +294,11 @@ update_status Scene::Update(float deltaTime)
         App->GetSceneModule()->ResetOnlyOnceInPlayMode();
     }
 
-    for (auto& gameObject : gameObjectsContainer)
-        gameObject.second->UpdateComponents(deltaTime);
+    //for (auto& gameObject : gameObjectsContainer)
+    //    gameObject.second->UpdateComponents(deltaTime);
+
+     for (auto gameObject : toUpdateGameObjects)
+         gameObject->UpdateComponents(deltaTime);
 
     ImGuiWindow* window = ImGui::FindWindowByName(sceneName.c_str());
     if (window && !(window->Hidden || window->Collapsed)) sceneVisible = true;
@@ -326,23 +330,22 @@ void Scene::RenderScene(float deltaTime, CameraComponent* camera)
                              : camera != nullptr                      ? camera->GetFramebuffer()
                                                                       : App->GetOpenGLModule()->GetFramebuffer();
 
-    FrustumPlanes frustumPlanes;
-    if (camera == nullptr) frustumPlanes = App->GetCameraModule()->GetFrustrumPlanes();
-    else frustumPlanes = camera->GetFrustrumPlanes();
-    std::vector<GameObject*> objectsToRender;
-    CheckObjectsToRender(objectsToRender, frustumPlanes);
+    // FrustumPlanes frustumPlanes;
+    // if (camera == nullptr) frustumPlanes = App->GetCameraModule()->GetFrustrumPlanes();
+    // else frustumPlanes = camera->GetFrustrumPlanes();
+    // std::vector<GameObject*> objectsToRender;
+    // CheckObjectsInFrustum(objectsToRender, frustumPlanes);
 
 #ifdef OPTICK
     OPTICK_CATEGORY("Scene::MeshesToRender", Optick::Category::GameLogic)
 #endif
 
-    renderPass->RenderScene(framebuffer, objectsToRender, camera);
-    
+    renderPass->RenderScene(framebuffer, toUpdateGameObjects, camera);
 
 #ifdef OPTICK
     OPTICK_CATEGORY("Scene::GameObject::Render", Optick::Category::Rendering)
 #endif
-    for (const auto& gameObject : objectsToRender)
+    for (const auto& gameObject : toUpdateGameObjects)
     {
         if (gameObject != nullptr)
         {
@@ -854,6 +857,46 @@ void Scene::SetMultiselectPosition(const float3& newPosition)
     multiSelectParent->SetLocalTransform(localMat);
 }
 
+void Scene::CheckObjectsToUpdate()
+{
+    CameraComponent* mainCamera = App->GetSceneModule()->GetScene()->GetMainCamera();
+    if (App->GetSceneModule()->GetInPlayMode() && mainCamera != nullptr)
+        CheckObjectsInFrustum(toUpdateGameObjects, mainCamera->GetFrustrumPlanes());
+
+    else CheckObjectsInFrustum(toUpdateGameObjects, App->GetCameraModule()->GetFrustrumPlanes());
+
+    for (auto gameObject : toUpdateGameObjects)
+        toUpdateGameObjectsSet.insert(gameObject->GetUID());
+
+    if (mainCamera && toUpdateGameObjectsSet.find(mainCamera->GetParent()->GetUID()) == toUpdateGameObjectsSet.end())
+    {
+        toUpdateGameObjects.push_back(mainCamera->GetParent());
+        toUpdateGameObjectsSet.insert(mainCamera->GetParent()->GetUID());
+    }
+
+    // ADDING MANUALLY BECAUSE SOME OBJECTS WITH SCRIPTS ARE NOT BEING RETURNED LDGJFHFNLKAJDSFLKAD
+
+    GameObject* walk = GetGameObjectByName("walk");
+    if (walk && toUpdateGameObjectsSet.find(walkxd->GetUID()) == toUpdateGameObjectsSet.end())
+    {
+        toUpdateGameObjects.push_back(walkxd);
+        toUpdateGameObjectsSet.insert(walkxd->GetUID());
+    }
+
+    GameObject* cameraPivot = GetGameObjectByName("Camera Pivot");
+    if (cameraPivot && toUpdateGameObjectsSet.find(cameraPivot->GetUID()) == toUpdateGameObjectsSet.end())
+    {
+        toUpdateGameObjects.push_back(cameraPivot);
+        toUpdateGameObjectsSet.insert(cameraPivot->GetUID());
+    }
+}
+
+void Scene::ClearObjectsToUpdate()
+{
+    toUpdateGameObjectsSet.clear();
+    toUpdateGameObjects.clear();
+}
+
 void Scene::CreateStaticSpatialDataStruct()
 {
     // PARAMETRIZED IN FUTURE
@@ -912,10 +955,10 @@ void Scene::UpdateDynamicSpatialStructure()
     CreateDynamicSpatialDataStruct();
 }
 
-void Scene::CheckObjectsToRender(std::vector<GameObject*>& outRenderGameObjects, FrustumPlanes frustumPlanes) const
+void Scene::CheckObjectsInFrustum(std::vector<GameObject*>& outRenderGameObjects, FrustumPlanes frustumPlanes) const
 {
 #ifdef OPTICK
-    OPTICK_CATEGORY("Scene::CheckObjectsToRender", Optick::Category::GameLogic)
+    OPTICK_CATEGORY("Scene::CheckObjectsInFrustum", Optick::Category::GameLogic)
 #endif
     std::vector<GameObject*> queriedObjects;
 
@@ -1438,7 +1481,7 @@ void Scene::OverridePrefabs(const UID prefabUID)
         std::unordered_map<UID, GameObject*> referenceObjectsMap;
         prefab->GetGameObjectsMap(referenceObjectsMap);
 
-       // Update all the hierarchy
+        // Update all the hierarchy
         std::queue<UID> childUIDs;
         childUIDs.push(gameObject->GetUID());
 

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -1,5 +1,4 @@
 #include "Scene.h"
-#include "Scene.h"
 
 #include "Application.h"
 #include "BatchManager.h"
@@ -96,17 +95,6 @@ Scene::Scene(const rapidjson::Value& initialState, UID loadedSceneUID) : sceneUI
 
     App->GetPhysicsModule()->LoadLayerData(&initialState);
 
-    if (initialState.HasMember("tags"))
-    {
-        const rapidjson::Value& dataArray = initialState["tags"];
-
-        for (rapidjson::SizeType i = 0; i < dataArray.Size(); i++)
-        {
-            HashString newTag = HashString(dataArray[i].GetString());
-            CreateTag(std::move(newTag));
-        }
-    }
-
     // Load navmesh from scene.
     if (navmeshUID != INVALID_UID)
     {
@@ -139,6 +127,23 @@ Scene::Scene(const rapidjson::Value& initialState, UID loadedSceneUID) : sceneUI
     }
 
     renderPass = new RenderPass();
+
+    if (initialState.HasMember("tags") && initialState.HasMember("tagsGO"))
+    {
+        const rapidjson::Value& tagDataArray   = initialState["tags"];
+        const rapidjson::Value& tagGODataArray = initialState["tagsGO"];
+
+        for (rapidjson::SizeType i = 0; i < tagDataArray.Size(); i++)
+        {
+            HashString newTag = HashString(tagDataArray[i].GetString());
+            CreateTag(std::move(newTag));
+
+            for (int j = 0; j < tagGODataArray[i].Size(); ++j)
+            {
+                RequestTag(newTag, GetGameObjectByUID(tagGODataArray[i][j].GetUint64()));
+            }
+        }
+    }
 
     // GLOG("%s scene loaded", sceneName.c_str());
 }
@@ -253,12 +258,21 @@ void Scene::Save(
 
     App->GetPhysicsModule()->SaveLayerData(targetState, allocator);
 
+    // SAVING FIRST 
     rapidjson::Value sceneTagsJSON(rapidjson::kArrayType);
+    rapidjson::Value sceneTagsGameObjectsJSON(rapidjson::kArrayType);
     for (auto& tagPair : tags)
     {
+        rapidjson::Value currentTagGO(rapidjson::kArrayType);
+        for (GameObject* currentGO : tagPair.second)
+        {
+            currentTagGO.PushBack(currentGO->GetUID(), allocator);
+        }
         sceneTagsJSON.PushBack(rapidjson::Value(tagPair.first.c_str(), allocator), allocator);
+        sceneTagsGameObjectsJSON.PushBack(currentTagGO, allocator);
     }
     targetState.AddMember("tags", sceneTagsJSON, allocator);
+    targetState.AddMember("tagsGO", sceneTagsGameObjectsJSON, allocator);
 
     // Serialize GameObjects
     rapidjson::Value gameObjectsJSON(rapidjson::kArrayType);
@@ -894,6 +908,7 @@ void Scene::DeleteTag(const HashString& tagToDelete)
 
 void Scene::RequestTag(const HashString& requestTag, GameObject* gameObject)
 {
+    if (!gameObject) return;
     auto tagIterator = tags.find(requestTag);
     if (tagIterator != tags.end() && !gameObject->HasTag(requestTag))
     {
@@ -904,6 +919,7 @@ void Scene::RequestTag(const HashString& requestTag, GameObject* gameObject)
 
 void Scene::RemoveFromTag(const HashString& requestTag, GameObject* gameObject)
 {
+    if (!gameObject) return;
     auto tagIterator = tags.find(requestTag);
     if (tagIterator != tags.end() && gameObject->HasTag(requestTag))
     {
@@ -953,19 +969,36 @@ void Scene::CheckObjectsToUpdate()
     for (auto gameObject : toUpdateGameObjects)
         toUpdateGameObjectsSet.insert(gameObject->GetUID());
 
+    // ADDING OBJECTS ASSIGNED TO LOCATION
+    auto taggedLocationObjects = GetTaggedGameObjects(playerLocation);
+    if (taggedLocationObjects)
+    {
+        for (GameObject* currentGameObject : *taggedLocationObjects)
+        {
+            if (toUpdateGameObjectsSet.find(currentGameObject->GetUID()) == toUpdateGameObjectsSet.end())
+            {
+                toUpdateGameObjects.push_back(currentGameObject);
+                toUpdateGameObjectsSet.insert(currentGameObject->GetUID());
+            }
+        }
+    }
 
+    // ADDING CAMERA MANUALLY BECAUSE ITS NOT INSIDE ITS OWN FRUSTUM
     GameObject* camera = GetGameObjectByName("Camera");
     if (camera && toUpdateGameObjectsSet.find(camera->GetUID()) == toUpdateGameObjectsSet.end())
     {
         toUpdateGameObjects.push_back(camera);
         toUpdateGameObjectsSet.insert(camera->GetUID());
     }
-    GameObject* cameraParent = GetGameObjectByUID(camera->GetParent());
-
-    if (toUpdateGameObjectsSet.find(cameraParent->GetUID()) == toUpdateGameObjectsSet.end())
+    if (camera)
     {
-        toUpdateGameObjects.push_back(cameraParent);
-        toUpdateGameObjectsSet.insert(cameraParent->GetUID());
+        GameObject* cameraParent = GetGameObjectByUID(camera->GetParent());
+
+        if (toUpdateGameObjectsSet.find(cameraParent->GetUID()) == toUpdateGameObjectsSet.end())
+        {
+            toUpdateGameObjects.push_back(cameraParent);
+            toUpdateGameObjectsSet.insert(cameraParent->GetUID());
+        }
     }
 }
 

--- a/SobrassadaEngine/Scene/Scene.h
+++ b/SobrassadaEngine/Scene/Scene.h
@@ -138,11 +138,8 @@ class SOBRASADA_API_ENGINE Scene
     void CheckObjectsToUpdate();
     void ClearObjectsToUpdate();
     void CheckObjectsInFrustum(std::vector<GameObject*>& outOpaqueRenderGameObjects, FrustumPlanes frustumPlanes) const;
-    void SetPlayerPosition(const HashString& newPlayerLocation)
-    {
-        playerLocation = newPlayerLocation;
-        GLOG("Player entered: %s", playerLocation.c_str());
-    }
+    const HashString& GetPlayerLocation() { return playerLocation; }
+    void SetPlayerPosition(const HashString& newPlayerLocation) { playerLocation = newPlayerLocation; }
 
     bool isSceneLoaded = false;
 

--- a/SobrassadaEngine/Scene/Scene.h
+++ b/SobrassadaEngine/Scene/Scene.h
@@ -7,6 +7,7 @@
 #include "Math/float4x4.h"
 #include <functional>
 #include <map>
+#include <set>
 #include <tuple>
 #include <unordered_map>
 #include <vector>
@@ -67,9 +68,9 @@ class SOBRASADA_API_ENGINE Scene
     void AddGameObject(UID uid, GameObject* newGameObject) { gameObjectsContainer.insert({uid, newGameObject}); }
     void RemoveGameObjectHierarchy(UID gameObjectUUID);
 
-    void AddGameObjectToUpdate(GameObject* gameObject);
-    void UpdateGameObjects();
-    void ClearGameObjectsToUpdate();
+    void AddGameObjectToUpdateComponents(GameObject* gameObject);
+    void UpdateGameObjectsComponents();
+    void ClearGameObjectsToUpdateComponents();
 
     void AddGameObjectToSelection(UID gameObject, UID gameObjectParent);
     void ClearObjectSelection();
@@ -162,7 +163,9 @@ class SOBRASADA_API_ENGINE Scene
     bool staticModified                          = false;
     bool dynamicModified                         = false;
 
-    std::vector<GameObject*> gameObjectsToUpdate;
+    std::vector<GameObject*> gameObjectsToUpdateComponents;
+
+    std::set<UID> inFrustumGameObjects;
 
     GameObject* multiSelectParent = nullptr;
     std::map<UID, UID> selectedGameObjects;

--- a/SobrassadaEngine/Scene/Scene.h
+++ b/SobrassadaEngine/Scene/Scene.h
@@ -126,7 +126,9 @@ class SOBRASADA_API_ENGINE Scene
     void SetStaticModified() { staticModified = true; }
     void SetDynamicModified() { dynamicModified = true; }
     void SetMultiselectPosition(const float3& newPosition);
-    void CheckObjectsToRender(std::vector<GameObject*>& outOpaqueRenderGameObjects, FrustumPlanes frustumPlanes) const;
+    void CheckObjectsToUpdate();
+    void ClearObjectsToUpdate();
+    void CheckObjectsInFrustum(std::vector<GameObject*>& outOpaqueRenderGameObjects, FrustumPlanes frustumPlanes) const;
 
     bool isSceneLoaded = false;
 
@@ -165,7 +167,8 @@ class SOBRASADA_API_ENGINE Scene
 
     std::vector<GameObject*> gameObjectsToUpdateComponents;
 
-    std::set<UID> inFrustumGameObjects;
+    std::set<UID> toUpdateGameObjectsSet;
+    std::vector<GameObject*> toUpdateGameObjects;
 
     GameObject* multiSelectParent = nullptr;
     std::map<UID, UID> selectedGameObjects;

--- a/SobrassadaEngine/Scene/Scene.h
+++ b/SobrassadaEngine/Scene/Scene.h
@@ -2,6 +2,7 @@
 
 #include "Globals.h"
 #include "LightsConfig.h"
+#include "HashString.h"
 
 #include "Math/float3x4.h"
 #include "Math/float4x4.h"
@@ -75,6 +76,13 @@ class SOBRASADA_API_ENGINE Scene
     void AddGameObjectToSelection(UID gameObject, UID gameObjectParent);
     void ClearObjectSelection();
     void DeleteMultiselection();
+
+    void CreateTag(HashString&& newTag);
+    void DeleteTag(const HashString& tagToDelete);
+    void RequestTag(const HashString& requestTag, GameObject* gameObject);
+    void RemoveFromTag(const HashString& requestTag, GameObject* gameObject);
+    const std::vector<GameObject*>* GetTaggedGameObjects(const HashString& requestTag); 
+    const std::map<HashString, std::vector<GameObject*>>& GetTags() { return tags; };
 
     const std::string& GetSceneName() const { return sceneName; }
     UID GetSceneUID() const { return sceneUID; }
@@ -176,6 +184,9 @@ class SOBRASADA_API_ENGINE Scene
     std::map<UID, float4x4> selectedGameObjectsOgLocals;
 
     std::unordered_map<uint64_t, const rapidjson::Value*> gameObjectDataMap;
+
+    HashString emptyString = HashString("");
+    std::map<HashString, std::vector<GameObject*>> tags;
 
     RenderPass* renderPass = nullptr;
 };

--- a/SobrassadaEngine/Scene/Scene.h
+++ b/SobrassadaEngine/Scene/Scene.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "Globals.h"
-#include "LightsConfig.h"
 #include "HashString.h"
+#include "LightsConfig.h"
 
 #include "Math/float3x4.h"
 #include "Math/float4x4.h"
@@ -81,7 +81,7 @@ class SOBRASADA_API_ENGINE Scene
     void DeleteTag(const HashString& tagToDelete);
     void RequestTag(const HashString& requestTag, GameObject* gameObject);
     void RemoveFromTag(const HashString& requestTag, GameObject* gameObject);
-    const std::vector<GameObject*>* GetTaggedGameObjects(const HashString& requestTag); 
+    const std::vector<GameObject*>* GetTaggedGameObjects(const HashString& requestTag);
     const std::map<HashString, std::vector<GameObject*>>& GetTags() { return tags; };
 
     const std::string& GetSceneName() const { return sceneName; }
@@ -134,9 +134,15 @@ class SOBRASADA_API_ENGINE Scene
     void SetStaticModified() { staticModified = true; }
     void SetDynamicModified() { dynamicModified = true; }
     void SetMultiselectPosition(const float3& newPosition);
+
     void CheckObjectsToUpdate();
     void ClearObjectsToUpdate();
     void CheckObjectsInFrustum(std::vector<GameObject*>& outOpaqueRenderGameObjects, FrustumPlanes frustumPlanes) const;
+    void SetPlayerPosition(const HashString& newPlayerLocation)
+    {
+        playerLocation = newPlayerLocation;
+        GLOG("Player entered: %s", playerLocation.c_str());
+    }
 
     bool isSceneLoaded = false;
 
@@ -185,7 +191,8 @@ class SOBRASADA_API_ENGINE Scene
 
     std::unordered_map<uint64_t, const rapidjson::Value*> gameObjectDataMap;
 
-    HashString emptyString = HashString("");
+    HashString emptyString    = HashString("");
+    HashString playerLocation = HashString("");
     std::map<HashString, std::vector<GameObject*>> tags;
 
     RenderPass* renderPass = nullptr;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Archer.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Archer.cpp
@@ -84,6 +84,8 @@ void Archer::Update(float deltaTime)
 void Archer::OnPlayerExitLocation()
 {
     currentState = ArcherStates::PATROL;
+    agentAI->SetPathNavigation(startPos);
+    reachedPatrolPoint = false;
 }
 
 void Archer::OnDeath()
@@ -146,7 +148,10 @@ void Archer::PatrolAI()
 {
     if (animComponent) animComponent->UseTrigger("run");
 
-    if (!playerScript->IsDead())
+    const HashString& playerLocation = AppEngine->GetSceneModule()->GetScene()->GetPlayerLocation();
+    bool playerInLocation            = parent->HasTag(playerLocation);
+
+    if (!playerScript->IsDead() && playerInLocation)
     {
         const HashString& playerLocation = AppEngine->GetSceneModule()->GetScene()->GetPlayerLocation();
         if (CheckDistanceWithPlayer() == PlayerDistances::Medium && parent->HasTag(playerLocation))

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Archer.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Archer.cpp
@@ -81,6 +81,11 @@ void Archer::Update(float deltaTime)
     }
 }
 
+void Archer::OnPlayerExitLocation()
+{
+    currentState = ArcherStates::PATROL;
+}
+
 void Archer::OnDeath()
 {
     // TODO: include death sound for the character
@@ -143,7 +148,9 @@ void Archer::PatrolAI()
 
     if (!playerScript->IsDead())
     {
-        if (CheckDistanceWithPlayer() == PlayerDistances::Medium) currentState = ArcherStates::CHASE;
+        const HashString& playerLocation = AppEngine->GetSceneModule()->GetScene()->GetPlayerLocation();
+        if (CheckDistanceWithPlayer() == PlayerDistances::Medium && parent->HasTag(playerLocation))
+            currentState = ArcherStates::CHASE;
         else if (CheckDistanceWithPlayer() == PlayerDistances::Close) currentState = ArcherStates::BASIC_ATTACK;
     }
 
@@ -244,7 +251,8 @@ void Archer::ChangeState()
     }
 
     const float distance = GetDistanceFromPlayer();
-    if (character->GetLastPosition().Distance(parent->GetGlobalTransform().TranslatePart()) < rangeEscape) currentState = ArcherStates::ESCAPE;
+    if (character->GetLastPosition().Distance(parent->GetGlobalTransform().TranslatePart()) < rangeEscape)
+        currentState = ArcherStates::ESCAPE;
     else if (distance <= rangeAIAttack) currentState = ArcherStates::BASIC_ATTACK;
     else if (distance <= rangeAIChase) currentState = ArcherStates::CHASE;
     else if (distance > maxDetectionRange) currentState = ArcherStates::SEARCH;
@@ -293,7 +301,8 @@ void Archer::Escape(float deltaTime)
     if (escapeDir.LengthSq() < 0.0001f) escapeDir = float3::unitZ;
     escapeDir.Normalize();
 
-    float escapeDistance = rangeAIAttack - character->GetLastPosition().Distance(parent->GetGlobalTransform().TranslatePart());
+    float escapeDistance =
+        rangeAIAttack - character->GetLastPosition().Distance(parent->GetGlobalTransform().TranslatePart());
     const float angleStep = 15.0f * (3.14159265f / 180.0f);
     float angleAccum      = 0.0f;
     bool found            = false;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Archer.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Archer.h
@@ -25,6 +25,8 @@ class Archer : public Character
     bool Init() override;
     void Update(float deltaTime) override;
 
+    void OnPlayerExitLocation() override;
+
   private:
     void OnDeath() override;
     void OnDamageTaken(int amount) override;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Banshee.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Banshee.cpp
@@ -98,6 +98,11 @@ void Banshee::Update(float deltaTime)
     }
 }
 
+void Banshee::OnPlayerExitLocation()
+{
+    currentState = BansheeStates::Idle;
+}
+
 void Banshee::OnDeath()
 {
     parent->SetEnabled(false);
@@ -222,10 +227,12 @@ void Banshee::ChangeState()
         currentState = BansheeStates::Idle;
         return;
     }
+    const HashString& playerLocation = AppEngine->GetSceneModule()->GetScene()->GetPlayerLocation();
+    bool playerInLocation            = parent->HasTag(playerLocation);
 
-    const float distance = GetDistanceFromPlayer();
-    if (distance <= rangeAIAttack) currentState = BansheeStates::Attack;
-    else if (distance <= rangeAIChase) currentState = BansheeStates::Chase;
+    const float distance             = GetDistanceFromPlayer();
+    if (distance <= rangeAIAttack && playerInLocation) currentState = BansheeStates::Attack;
+    else if (distance <= rangeAIChase && playerInLocation) currentState = BansheeStates::Chase;
     else currentState = BansheeStates::Idle;
 }
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Banshee.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Banshee.h
@@ -27,6 +27,8 @@ class Banshee : public Character
     bool Init() override;
     void Update(float deltaTime) override;
 
+    void OnPlayerExitLocation() override;
+
   private:
     void OnDeath() override;
     void OnDamageTaken(int amount) override;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Changeling.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Changeling.cpp
@@ -133,6 +133,8 @@ void Changeling::Update(float deltaTime)
 void Changeling::OnPlayerExitLocation()
 {
     currentState = ChangelingStates::PATROL;
+    agentAI->SetPathNavigation(startPos);
+    reachedPatrolPoint = false;
 }
 
 void Changeling::OnDeath()

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Changeling.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Changeling.cpp
@@ -130,6 +130,11 @@ void Changeling::Update(float deltaTime)
     }
 }
 
+void Changeling::OnPlayerExitLocation()
+{
+    currentState = ChangelingStates::PATROL;
+}
+
 void Changeling::OnDeath()
 {
     // TODO: include death sound for the character
@@ -187,8 +192,13 @@ void Changeling::PatrolAI()
 {
     // animComponent->UseTrigger("run");
 
-    if (CheckDistanceWithPlayer() == PlayerDistances::Medium) currentState = ChangelingStates::CHASE;
-    else if (CheckDistanceWithPlayer() == PlayerDistances::Close) currentState = ChangelingStates::BASIC_ATTACK;
+    const HashString& playerLocation = AppEngine->GetSceneModule()->GetScene()->GetPlayerLocation();
+    bool playerInLocation            = parent->HasTag(playerLocation);
+
+    if (CheckDistanceWithPlayer() == PlayerDistances::Medium && playerInLocation)
+        currentState = ChangelingStates::CHASE;
+    else if (CheckDistanceWithPlayer() == PlayerDistances::Close && playerInLocation)
+        currentState = ChangelingStates::BASIC_ATTACK;
 
     bool valid = false;
     if (reachedPatrolPoint)

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Changeling.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Changeling.h
@@ -24,6 +24,8 @@ class Changeling : public Character
     bool Init() override;
     void Update(float deltaTime) override;
 
+    void OnPlayerExitLocation() override;
+
   private:
     void OnDeath() override;
     void OnDamageTaken(int amount) override;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/PlayerLocationScript.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/PlayerLocationScript.cpp
@@ -20,10 +20,10 @@ bool PlayerLocationScript::Init()
 
 void PlayerLocationScript::OnCollisionEnter(GameObject* otherObject, const float3 collisionNormal, ColliderLayer layer)
 {
-
+    AppEngine->GetSceneModule()->GetScene()->SetPlayerPosition(locationTag);
 }
 
 void PlayerLocationScript::OnCollisionExit(GameObject* otherObject, ColliderLayer layer)
 {
-
+    AppEngine->GetSceneModule()->GetScene()->SetPlayerPosition(HashString(""));
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/PlayerLocationScript.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/PlayerLocationScript.cpp
@@ -1,0 +1,29 @@
+#include "pch.h"
+#include "PlayerLocationScript.h"
+
+
+#include "Scene.h"
+#include "GameObject.h"
+#include "SceneModule.h"
+
+PlayerLocationScript::PlayerLocationScript(GameObject* parent) : Script(parent)
+{
+    fields.push_back({"Location tag", InspectorField::FieldType::InputText, &locationTagString});
+}
+
+bool PlayerLocationScript::Init()
+{
+    locationTag = HashString(locationTagString);
+
+    return true;
+}
+
+void PlayerLocationScript::OnCollisionEnter(GameObject* otherObject, const float3 collisionNormal, ColliderLayer layer)
+{
+
+}
+
+void PlayerLocationScript::OnCollisionExit(GameObject* otherObject, ColliderLayer layer)
+{
+
+}

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/PlayerLocationScript.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/PlayerLocationScript.cpp
@@ -5,6 +5,8 @@
 #include "Scene.h"
 #include "GameObject.h"
 #include "SceneModule.h"
+#include "ScriptComponent.h"
+#include "Character.h"
 
 PlayerLocationScript::PlayerLocationScript(GameObject* parent) : Script(parent)
 {
@@ -26,4 +28,18 @@ void PlayerLocationScript::OnCollisionEnter(GameObject* otherObject, const float
 void PlayerLocationScript::OnCollisionExit(GameObject* otherObject, ColliderLayer layer)
 {
     AppEngine->GetSceneModule()->GetScene()->SetPlayerPosition(HashString(""));
+
+    auto taggedGameObjects = AppEngine->GetSceneModule()->GetScene()->GetTaggedGameObjects(locationTag);
+    if (taggedGameObjects)
+    {
+        for (GameObject* currentGameObject : *taggedGameObjects)
+        {
+            ScriptComponent* script = currentGameObject->GetComponent<ScriptComponent*>();
+            if (script)
+            {
+                Character * character = script->GetScriptByType<Character>();
+                if (character) character->OnPlayerExitLocation();
+            }
+        }
+    }
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/PlayerLocationScript.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/PlayerLocationScript.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "Script.h"
+#include "HashString.h"
+
+class PlayerLocationScript : public Script
+{
+  public:
+    PlayerLocationScript(GameObject* parent);
+    bool Init() override;
+    void Update(float deltaTime) override {}
+
+    void OnCollisionEnter(GameObject* otherObject, const float3 collisionNormal, ColliderLayer layer) override;
+    void OnCollisionExit(GameObject* otherObject, ColliderLayer layer) override;
+
+  private:
+    std::string locationTagString;
+    HashString locationTag;
+
+};

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Script.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Script.h
@@ -66,6 +66,7 @@ class Script
     virtual void OnCollision(GameObject* otherObject, const float3 collisionNormal, ColliderLayer layer) {};
     virtual void OnCollisionEnter(GameObject* otherObject, const float3 collisionNormal, ColliderLayer layer) {};
     virtual void OnCollisionExit(GameObject* otherObject, ColliderLayer layer) {};
+    virtual void OnPlayerExitLocation() {};
     virtual void OnDestroy() {};
 
     virtual const std::vector<InspectorField>& GetFields() const { return fields; }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Script.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Script.h
@@ -3,8 +3,8 @@
 #include "ComponentUtils.h"
 #include "Math/float3.h"
 #include "rapidjson/document.h"
-#include <vector>
 #include <functional>
+#include <vector>
 
 class Script;
 class GameObject;
@@ -64,6 +64,8 @@ class Script
     virtual void Load(const rapidjson::Value& initialState);
     virtual void CloneFields(const std::vector<InspectorField>& fields);
     virtual void OnCollision(GameObject* otherObject, const float3 collisionNormal, ColliderLayer layer) {};
+    virtual void OnCollisionEnter(GameObject* otherObject, const float3 collisionNormal, ColliderLayer layer) {};
+    virtual void OnCollisionExit(GameObject* otherObject, ColliderLayer layer) {};
     virtual void OnDestroy() {};
 
     virtual const std::vector<InspectorField>& GetFields() const { return fields; }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/ScriptExport.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/ScriptExport.cpp
@@ -27,6 +27,7 @@
 #include "SpawnUI.h"
 #include "TileFloatScript.h"
 #include "VSyncToggleScript.h"
+#include "PlayerLocationScript.h"
 
 #include <string>
 
@@ -62,7 +63,8 @@ constexpr const char* scripts[] = {
     "SpawnUI",
     "MenuChangeSceneScript",
     "MoveGOInSpline",
-    "Mushroom"
+    "Mushroom",
+    "PlayerLocationScript"
 };
 
 Application* AppEngine = nullptr;
@@ -100,6 +102,7 @@ extern "C" SOBRASSADA_API Script* CreateScript(const std::string& scriptType, Ga
     if (scriptType == "FireballTrap") return new FireballTrap(parent);
     if (scriptType == "Mushroom") return new Mushroom(parent);
     if (scriptType == "SpawnPoint") return new SpawnPoint(parent);
+    if (scriptType == "PlayerLocationScript") return new PlayerLocationScript(parent);
 
     /* Utils */
     if (scriptType == "RotateGameObjectScript") return new RotateGameObject(parent);

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj
@@ -486,6 +486,7 @@
     <ClInclude Include="PauseMenuScript.h" />
     <ClInclude Include="GodMode.h" />
     <ClInclude Include="pch.h" />
+    <ClInclude Include="PlayerLocationScript.h" />
     <ClInclude Include="PressAnyKeyScript.h" />
     <ClInclude Include="Projectile.h" />
     <ClInclude Include="resource.h" />
@@ -2061,6 +2062,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Game|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Profile Game|x64'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="PlayerLocationScript.cpp" />
     <ClCompile Include="PressAnyKeyScript.cpp" />
     <ClCompile Include="Projectile.cpp" />
     <ClCompile Include="RotateGameObject.cpp" />

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj.filters
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj.filters
@@ -127,6 +127,9 @@
     <ClInclude Include="Changeling.h">
       <Filter>Characters\Enemies</Filter>
     </ClInclude>
+    <ClInclude Include="PlayerLocationScript.h">
+      <Filter>Environment</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\Libs\MathGeoLib\include\Time\Clock.cpp">
@@ -794,6 +797,9 @@
     </ClCompile>
     <ClCompile Include="Changeling.cpp">
       <Filter>Characters\Enemies</Filter>
+    </ClCompile>
+    <ClCompile Include="PlayerLocationScript.cpp">
+      <Filter>Environment</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.cpp
@@ -76,6 +76,11 @@ void Soldier::Update(float deltaTime)
     }
 }
 
+void Soldier::OnPlayerExitLocation()
+{
+    currentState = SoldierStates::PATROL;
+}
+
 void Soldier::OnDeath()
 {
     // TODO: include death sound for the character
@@ -143,8 +148,12 @@ void Soldier::PatrolAI()
 {
     if (!playerScript->IsDead())
     {
-        if (CheckDistanceWithPlayer() == PlayerDistances::Medium) currentState = SoldierStates::CHASE;
-        else if (CheckDistanceWithPlayer() == PlayerDistances::Close) currentState = SoldierStates::BASIC_ATTACK;
+        const HashString& playerLocation = AppEngine->GetSceneModule()->GetScene()->GetPlayerLocation();
+        bool playerInLocation            = parent->HasTag(playerLocation);
+        if (CheckDistanceWithPlayer() == PlayerDistances::Medium && playerInLocation)
+            currentState = SoldierStates::CHASE;
+        else if (CheckDistanceWithPlayer() == PlayerDistances::Close && playerInLocation)
+            currentState = SoldierStates::BASIC_ATTACK;
     }
 
     bool valid = false;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.cpp
@@ -79,6 +79,8 @@ void Soldier::Update(float deltaTime)
 void Soldier::OnPlayerExitLocation()
 {
     currentState = SoldierStates::PATROL;
+    agentAI->SetPathNavigation(startPos);
+    reachedPatrolPoint = false;
 }
 
 void Soldier::OnDeath()
@@ -146,13 +148,14 @@ void Soldier::HandleState(float deltaTime)
 
 void Soldier::PatrolAI()
 {
-    if (!playerScript->IsDead())
+    const HashString& playerLocation = AppEngine->GetSceneModule()->GetScene()->GetPlayerLocation();
+    bool playerInLocation            = parent->HasTag(playerLocation);
+
+    if (!playerScript->IsDead() && playerInLocation)
     {
-        const HashString& playerLocation = AppEngine->GetSceneModule()->GetScene()->GetPlayerLocation();
-        bool playerInLocation            = parent->HasTag(playerLocation);
-        if (CheckDistanceWithPlayer() == PlayerDistances::Medium && playerInLocation)
+        if (CheckDistanceWithPlayer() == PlayerDistances::Medium)
             currentState = SoldierStates::CHASE;
-        else if (CheckDistanceWithPlayer() == PlayerDistances::Close && playerInLocation)
+        else if (CheckDistanceWithPlayer() == PlayerDistances::Close)
             currentState = SoldierStates::BASIC_ATTACK;
     }
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.h
@@ -23,6 +23,8 @@ class Soldier : public Character
     bool Init() override;
     void Update(float deltaTime) override;
 
+    void OnPlayerExitLocation() override;
+
   private:
     void OnDeath() override;
     void OnDamageTaken(int amount) override;

--- a/SobrassadaEngine/Utils/Physics/BulletUserPointer.h
+++ b/SobrassadaEngine/Utils/Physics/BulletUserPointer.h
@@ -10,16 +10,34 @@ class GameObject;
 
 struct BulletUserPointer
 {
-    BulletUserPointer(Component* component, CollisionDelegate* newCallback, bool generateCallback, ColliderLayer newLayer)
+    BulletUserPointer() = default;
+    BulletUserPointer(
+        Component* component, CollisionDelegate* onCollisionCall, CollisionDelegate* onCollisionEnterCall,
+        CollisionExitDelegate* onCollisionExitCall, bool generateCallback, ColliderLayer newLayer
+    )
     {
-        collider            = component;
-        onCollisionCallback = newCallback;
-        this->generateCallback = generateCallback;
-        layer = newLayer;
+        collider                 = component;
+        onCollisionCallback      = onCollisionCall;
+        onCollisionEnterCallback = onCollisionEnterCall;
+        onCollisionExitCallback  = onCollisionExitCall;
+        this->generateCallback   = generateCallback;
+        layer                    = newLayer;
+    }
+
+    BulletUserPointer(const BulletUserPointer& otherBulletPointer)
+    {
+        collider                 = otherBulletPointer.collider;
+        onCollisionCallback      = otherBulletPointer.onCollisionCallback;
+        onCollisionEnterCallback = otherBulletPointer.onCollisionEnterCallback;
+        onCollisionExitCallback  = otherBulletPointer.onCollisionExitCallback;
+        generateCallback         = otherBulletPointer.generateCallback;
+        layer                    = otherBulletPointer.layer;
     }
 
     Component* collider;
     CollisionDelegate* onCollisionCallback;
+    CollisionDelegate* onCollisionEnterCallback;
+    CollisionExitDelegate* onCollisionExitCallback;
     ColliderLayer layer;
     bool generateCallback;
 };

--- a/SobrassadaEngine/Utils/Script.h
+++ b/SobrassadaEngine/Utils/Script.h
@@ -38,13 +38,15 @@ class Script
   public:
     virtual ~Script() {}
 
-    virtual bool Init()                                                                             = 0;
-    virtual void Update(float deltaTime)                                                            = 0;
-    virtual void Inspector()                                                                        = 0;
-    virtual void Save(rapidjson::Value& targetState, rapidjson::Document::AllocatorType& allocator) = 0;
-    virtual void Load(const rapidjson::Value& initialState)                                         = 0;
-    virtual void CloneFields(const std::vector<InspectorField>& fields)                             = 0;
-    virtual void OnCollision(GameObject* otherObject, const float3 collisionNormal, ColliderLayer layer)                = 0;
+    virtual bool Init()                                                                                       = 0;
+    virtual void Update(float deltaTime)                                                                      = 0;
+    virtual void Inspector()                                                                                  = 0;
+    virtual void Save(rapidjson::Value& targetState, rapidjson::Document::AllocatorType& allocator)           = 0;
+    virtual void Load(const rapidjson::Value& initialState)                                                   = 0;
+    virtual void CloneFields(const std::vector<InspectorField>& fields)                                       = 0;
+    virtual void OnCollision(GameObject* otherObject, const float3 collisionNormal, ColliderLayer layer)      = 0;
+    virtual void OnCollisionEnter(GameObject* otherObject, const float3 collisionNormal, ColliderLayer layer) = 0;
+    virtual void OnCollisionExit(GameObject* otherObject, ColliderLayer layer)                                = 0;
     virtual void OnDestroy() {};
 
     virtual const std::vector<InspectorField>& GetFields() = 0;

--- a/SobrassadaEngine/Utils/Script.h
+++ b/SobrassadaEngine/Utils/Script.h
@@ -47,6 +47,7 @@ class Script
     virtual void OnCollision(GameObject* otherObject, const float3 collisionNormal, ColliderLayer layer)      = 0;
     virtual void OnCollisionEnter(GameObject* otherObject, const float3 collisionNormal, ColliderLayer layer) = 0;
     virtual void OnCollisionExit(GameObject* otherObject, ColliderLayer layer)                                = 0;
+    virtual void OnPlayerExitLocation()                                                                       = 0;
     virtual void OnDestroy() {};
 
     virtual const std::vector<InspectorField>& GetFields() = 0;


### PR DESCRIPTION
FIRST, DO NOT MERGE THIS PR BEFORE ALPHA_1 DELIVERY.

This PR contains several features, mainly only objects inside a given area and the camera frustum are updated and rendere, so we don't waste time calculating logic and animations for the whole scene. It also includes:

- OnCollisionEnter / Exit for colliders.
- Tag system (and add up to 10 tags to a game object and get all game objects that containg a given tag).
- Player location tag and script to manage the player location.

With those changes we will need to create a trigger collider and asign the PlayerLocationScript to it, once a tag is set in the script and the desired gameObjects they will update even if they are not inside the frustum.

HOW TO TEST:
1. Go to task/updateCulling branch in Hound of Ulster.
2. Delete Library.
3. Play through the level.

Comparison of performance in Level2 (worst case scenario):

![image](https://github.com/user-attachments/assets/7c7b7b96-ad4c-45ac-8cfb-ac81ade8335b)

With those changes:

![LEVEL_2_UPDATE_CULLING](https://github.com/user-attachments/assets/31fae31d-93e0-4478-8c19-ad72d4e933ab)

