### PR TITLE
bug/low-fps-character-movement-THO-767

### DIFF
--- a/SobrassadaEngine/Scene/Components/Standalone/CharacterControllerComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/CharacterControllerComponent.cpp
@@ -292,8 +292,8 @@ void CharacterControllerComponent::Move(float deltaTime)
     else
     {
         const float desiredSpeed = isRunning ? maxSpeed : walkSpeed;
-        currentSpeed = targetDirection.LengthSq() > 0.001f ? Lerp(currentSpeed, desiredSpeed, acceleration * deltaTime)
-                                                           : Lerp(currentSpeed, 0, 100 * deltaTime);
+        currentSpeed = targetDirection.LengthSq() > 0.001f ? Lerp(currentSpeed, desiredSpeed, std::min(1.f, acceleration * deltaTime))
+                                                           : Lerp(currentSpeed, 0, std::min(1.f, 100 * deltaTime));
     }
 
     const float3 offsetXZ   = rotateDirection * currentSpeed * deltaTime;

--- a/SobrassadaEngine/Scene/Components/Standalone/CharacterControllerComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/CharacterControllerComponent.cpp
@@ -172,7 +172,7 @@ void CharacterControllerComponent::Update(float time) // SO many navmesh getters
         verticalSpeed += gravity * deltaTime;
         verticalSpeed  = std::max(verticalSpeed, maxFallSpeed); // Clamp fall speed
 
-        currentPos.y  += (verticalSpeed * deltaTime);
+        currentPos.y  += std::max(-0.5f, verticalSpeed * deltaTime);
 
         AdjustHeightToNavMesh(currentPos);
         parent->SetLocalPosition(currentPos - parent->GetParentGlobalTransform().TranslatePart());
@@ -292,23 +292,25 @@ void CharacterControllerComponent::Move(float deltaTime)
     else
     {
         const float desiredSpeed = isRunning ? maxSpeed : walkSpeed;
-        currentSpeed = targetDirection.LengthSq() > 0.001f ? Lerp(currentSpeed, desiredSpeed, std::min(1.f, acceleration * deltaTime))
-                                                           : Lerp(currentSpeed, 0, std::min(1.f, 100 * deltaTime));
+        currentSpeed             = targetDirection.LengthSq() > 0.001f
+                                     ? Lerp(currentSpeed, desiredSpeed, std::min(1.f, acceleration * deltaTime))
+                                     : Lerp(currentSpeed, 0, std::min(1.f, 100 * deltaTime));
     }
 
     const float3 offsetXZ   = rotateDirection * currentSpeed * deltaTime;
     const float3 desiredPos = currentPos + offsetXZ;
 
-    const float3 searchArea = {1.0f, 1.0f, 1.0f};
+    const float3 searchArea = {25.0f * deltaTime, 62.5f * deltaTime, 25.0f * deltaTime};
     float3 closestPoint     = float3::zero;
     bool posOverPoly        = false;
     dtStatus status         = GetClosestPointInNavmesh(desiredPos, searchArea, posOverPoly, closestPoint);
+    GLOG("Search area: %f %f %f", searchArea.x, searchArea.y, searchArea.z);
 
     if (!dtStatusSucceed(status)) return;
 
     // Prevent huge changes
-    if (fabs(closestPoint.x - currentPos.x) > 0.2f || fabs(closestPoint.y - currentPos.y) > 0.6f ||
-        fabs(closestPoint.z - currentPos.z) > 0.2f)
+    if (fabs(closestPoint.x - currentPos.x) > 12.5f * deltaTime || fabs(closestPoint.y - currentPos.y) > 25.0f ||
+        fabs(closestPoint.z - currentPos.z) > 12.5f * deltaTime)
         return;
 
     parent->SetLocalPosition(closestPoint - parent->GetParentGlobalTransform().TranslatePart());
@@ -447,16 +449,11 @@ void CharacterControllerComponent::StartDash()
 
 void CharacterControllerComponent::Dash(float deltaTime)
 {
-    if (dashTimeRemaining <= 0.0f)
-    {
-        isDashing = false;
-    }
-
     const float3 currentPos = parent->GetGlobalTransform().TranslatePart();
 
     const float3 dashOffset = dashDirection * dashSpeed * deltaTime;
     float3 desiredPos       = currentPos + dashOffset;
-    const float3 searchArea = {1.0f, 0.3f, 1.0f};
+    const float3 searchArea = {62.5f * deltaTime, 25.0f * deltaTime, 62.5f * deltaTime};
     bool posOverPoly        = false;
     float3 closestPoint     = float3::zero;
 
@@ -473,7 +470,7 @@ void CharacterControllerComponent::Dash(float deltaTime)
         const float3 currentPos = parent->GetGlobalTransform().TranslatePart();
         const float3 finalPos   = currentPos + dashDirection * dashSpeed * dashTimeRemaining;
 
-        const float3 searchArea = {0.2f, 30.0f, 0.2f};
+        const float3 searchArea = {12.5f * deltaTime, 1875.0f * deltaTime, 12.5f * deltaTime};
         float3 closestPoint     = float3::zero;
         bool posOverPoly        = false;
         dtStatus status         = GetClosestPointInNavmesh(finalPos, searchArea, posOverPoly, closestPoint);
@@ -481,6 +478,8 @@ void CharacterControllerComponent::Dash(float deltaTime)
 
         if (dashToNavmesh) CheckDashObstacles();
     }
+
+    if (dashTimeRemaining <= 0.0f) isDashing = false;
 }
 
 void CharacterControllerComponent::CheckDashObstacles()

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -24,7 +24,6 @@
 #include "ParticleSystemModule.h"
 #include "PathfinderModule.h"
 #include "PhysicsModule.h"
-#include "ParticleSystemModule.h"
 #include "ProjectModule.h"
 #include "Quadtree.h"
 #include "RenderPass.h"
@@ -58,8 +57,6 @@
 #include "Standalone/UI/ImageComponent.h"
 #include "Standalone/UI/Transform2DComponent.h"
 #include "Standalone/UI/UILabelComponent.h"
-#include <chrono>
-#include <thread>
 #include <unordered_map>
 
 #include "SDL_mouse.h"
@@ -214,7 +211,6 @@ void Scene::Init()
     UpdateStaticSpatialStructure();
     UpdateDynamicSpatialStructure();
 
-
     isSceneLoaded = true;
 }
 
@@ -284,7 +280,6 @@ update_status Scene::Update(float deltaTime)
 #ifdef OPTICK
     OPTICK_CATEGORY("Scene::Update", Optick::Category::GameLogic)
 #endif
-    //std::this_thread::sleep_for(std::chrono::milliseconds(40));
     if (App->GetSceneModule()->GetOnlyOnceInPlayMode())
     {
         for (auto& gameObject : gameObjectsContainer)
@@ -339,7 +334,6 @@ void Scene::RenderScene(float deltaTime, CameraComponent* camera)
 #endif
 
     renderPass->RenderScene(framebuffer, objectsToRender, camera);
-    
 
 #ifdef OPTICK
     OPTICK_CATEGORY("Scene::GameObject::Render", Optick::Category::Rendering)
@@ -1440,7 +1434,7 @@ void Scene::OverridePrefabs(const UID prefabUID)
         std::unordered_map<UID, GameObject*> referenceObjectsMap;
         prefab->GetGameObjectsMap(referenceObjectsMap);
 
-       // Update all the hierarchy
+        // Update all the hierarchy
         std::queue<UID> childUIDs;
         childUIDs.push(gameObject->GetUID());
 

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -58,6 +58,8 @@
 #include "Standalone/UI/ImageComponent.h"
 #include "Standalone/UI/Transform2DComponent.h"
 #include "Standalone/UI/UILabelComponent.h"
+#include <chrono>
+#include <thread>
 #include <unordered_map>
 
 #include "SDL_mouse.h"
@@ -282,7 +284,7 @@ update_status Scene::Update(float deltaTime)
 #ifdef OPTICK
     OPTICK_CATEGORY("Scene::Update", Optick::Category::GameLogic)
 #endif
-
+    //std::this_thread::sleep_for(std::chrono::milliseconds(40));
     if (App->GetSceneModule()->GetOnlyOnceInPlayMode())
     {
         for (auto& gameObject : gameObjectsContainer)

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CameraMovement.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CameraMovement.cpp
@@ -100,7 +100,7 @@ void CameraMovement::FollowTarget(float deltaTime)
 
         currentLookAhead = Lerp(
             currentLookAhead, lookAheadIntensity * (controller->GetSpeed() / controller->GetMaxSpeed()),
-            lookAheadSmoothness * deltaTime
+            min(1, lookAheadSmoothness * deltaTime)
         );
 
         const float3& targetDir  = controller->GetFrontDirection();
@@ -108,7 +108,7 @@ void CameraMovement::FollowTarget(float deltaTime)
 
         if (isFollowing && distanceToTarget < 0.1f && controller->GetSpeed() < 0.1f) isFollowing = false;
     }
-    finalPosition = Lerp(currentPosition, desiredPosition, smoothnessVelocity * deltaTime);
+    finalPosition = Lerp(currentPosition, desiredPosition, min(1, smoothnessVelocity * deltaTime));
 
     parent->SetLocalPosition(finalPosition - parent->GetParentGlobalTransform().TranslatePart());
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -178,7 +178,8 @@ void CuChulainn::OnDeath()
 {
     // TODO: include death sound for the character
     if (healthImageComponent) healthImageComponent->ChangeTexture(healthBarTextures[0]);
-    deathTimer = 0.0f;
+    isAttacking = false;
+    deathTimer  = 0.0f;
     character->EnableMovement(false);
     state = CharacterStates::DEATH;
     if (animComponent) animComponent->UseTrigger("Death");

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -267,7 +267,7 @@ void CuChulainn::HandleState(float deltaTime)
         {
             if (isAttacking) comboBufferTimer = 0.1f;
             isAttacking = false;
-            meleeVfxObject->SetEnabled(false);
+            if(meleeVfxObject)meleeVfxObject->SetEnabled(false);
         }
         else if (stateName == HashString("Charge"))
         {


### PR DESCRIPTION
Fixed the many movement bugs the player had with low framerates. Now all the navmesh queries when moving take into account deltaTime, so the lower the fps the bigger the search is, to make sure the player doesn't move further than the navmesh search is doing. Also clamped the fallSpeed to avoid going through the ground.

I've tested all the scenes with 15-20fps and everything seemed to be more or less fine, given the conditions. The only drawback is that when falling off an edge with very low fps the player snaps to the ground really fast.

Also there are no changes to enemies because I've not found weird behaviours with low fps. If you do, tell me and I'll change it here aswell

To Test: put this line in any Update() and play the game: std::this_thread::sleep_for(std::chrono::milliseconds(30)); 
You can also play it with normal fps to check nothing broke there aswell.