### PR TITLE
Fixed the MainMenuSelectorScript logic and added layer in canvas

### DIFF
--- a/SobrassadaEngine/Scene/Components/Standalone/UI/CanvasComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/UI/CanvasComponent.cpp
@@ -14,6 +14,7 @@
 #include "Transform2DComponent.h"
 #include "UILabelComponent.h"
 #include "WindowModule.h"
+#include <algorithm>
 
 #include "glew.h"
 #include "imgui.h"
@@ -201,6 +202,18 @@ void CanvasComponent::UpdateChildren()
             children.push(child);
         }
     }
+
+    std::sort(
+        sortedChildren.begin(), sortedChildren.end(),
+        [](const GameObject* a, const GameObject* b)
+        {
+            Transform2DComponent* ta = a->GetComponent<Transform2DComponent*>();
+            Transform2DComponent* tb = b->GetComponent<Transform2DComponent*>();
+            int oa   = ta ? ta->orderInCanvas : 0;
+            int ob   = tb ? tb->orderInCanvas : 0;
+            return oa < ob;
+        }
+    );
 }
 
 void CanvasComponent::UpdateMousePosition(const float2& mousePos)

--- a/SobrassadaEngine/Scene/Components/Standalone/UI/Transform2DComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/UI/Transform2DComponent.cpp
@@ -57,6 +57,8 @@ Transform2DComponent::Transform2DComponent(const rapidjson::Value& initialState,
     {
         renderAnchors = initialState["RenderAnchors"].GetBool();
     }
+
+    if (initialState.HasMember("OrderInCanvas")) orderInCanvas = initialState["OrderInCanvas"].GetInt();
 }
 
 Transform2DComponent::~Transform2DComponent()
@@ -129,6 +131,7 @@ void Transform2DComponent::Save(rapidjson::Value& targetState, rapidjson::Docume
     targetState.AddMember("Anchors", valAnchors, allocator);
 
     targetState.AddMember("RenderAnchors", renderAnchors, allocator);
+    targetState.AddMember("OrderInCanvas", orderInCanvas, allocator);
 }
 
 void Transform2DComponent::Clone(const Component* other)
@@ -225,6 +228,10 @@ void Transform2DComponent::RenderEditorInspector()
 
         if (ImGui::DragFloat2("X-axis bounds", &anchorsX.x, 0.001f, 0.0f, 1.0f)) OnAnchorsUpdated();
         if (ImGui::DragFloat2("Y-axis bounds", &anchorsY.x, 0.001f, 0.0f, 1.0f)) OnAnchorsUpdated();
+
+        ImGui::Separator();
+
+        ImGui::DragInt("Order In Canvas", &orderInCanvas, 1.0f, -1000, 1000);
 
         ImGui::Separator();
     }

--- a/SobrassadaEngine/Scene/Components/Standalone/UI/Transform2DComponent.h
+++ b/SobrassadaEngine/Scene/Components/Standalone/UI/Transform2DComponent.h
@@ -66,6 +66,8 @@ class Transform2DComponent : public Component
     float2 anchorsX;
     float2 anchorsY;
 
+    int orderInCanvas = 0;
+
   private:
     CanvasComponent* parentCanvas                      = nullptr;
     Transform2DComponent* parentTransform              = nullptr;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/GameOverScript.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/GameOverScript.cpp
@@ -64,3 +64,13 @@ void GameOverScript::PauseGame()
 {
     if (auto* t = AppEngine->GetGameTimer()) t->TogglePause();
 }
+
+void GameOverScript::Close()
+{
+    if (cachedTarget) cachedTarget->SetEnabledRecursive(false);
+
+    GameTimer* timer = AppEngine->GetGameTimer();
+    if (timer && timer->IsPaused()) timer->TogglePause();
+
+    gameOverShown = false;
+}

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/GameOverScript.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/GameOverScript.h
@@ -8,11 +8,11 @@ class GameObject;
 class GameOverScript : public Script
 {
   public:
-
     GameOverScript(GameObject* parent);
 
     bool Init() override;
     void Update(float) override;
+    void Close();
 
   private:
     void TriggerGameOver();

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MainMenuSelectorScript.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MainMenuSelectorScript.cpp
@@ -1,14 +1,17 @@
-#include "pch.h"
+﻿#include "pch.h"
 
 #include "Application.h"
 #include "CuChulainn.h"
 #include "GameObject.h"
+#include "GameOverScript.h"
 #include "GameTimer.h"
 #include "InputModule.h"
 #include "MainMenuSelectorScript.h"
+#include "PauseMenuScript.h"
 #include "ProjectModule.h"
 #include "Scene.h"
 #include "SceneModule.h"
+#include "ScriptComponent.h"
 #include "Standalone/UI/ButtonComponent.h"
 
 bool MainMenuSelectorScript::Init()
@@ -40,6 +43,20 @@ bool MainMenuSelectorScript::Init()
         }
     }
 
+    Scene* scene     = AppEngine->GetSceneModule()->GetScene();
+    GameObject* node = parent; // start with the object that owns this script
+
+    while (node && (!pauseCtrl || !gameOverCtrl))
+    {
+        ScriptComponent* sc = node->GetComponent<ScriptComponent*>();
+        if (sc)
+        {
+            if (!pauseCtrl) pauseCtrl = sc->GetScriptByType<PauseMenuScript>();
+            if (!gameOverCtrl) gameOverCtrl = sc->GetScriptByType<GameOverScript>();
+        }
+        node = scene->GetGameObjectByUID(node->GetParent());
+    }
+
     UpdateSelection();
     return true;
 }
@@ -63,8 +80,6 @@ void MainMenuSelectorScript::Update(float deltaTime)
     const KeyState* keys           = AppEngine->GetInputModule()->GetKeyboard();
     const KeyState* gamepadButtons = AppEngine->GetInputModule()->GetControllerButtons();
     const float2& leftStick        = AppEngine->GetInputModule()->GetLeftStick();
-
-    static bool stickMoved         = false;
 
     bool moveDown                  = keys[SDL_SCANCODE_DOWN] == KEY_DOWN ||
                     gamepadButtons[SDL_CONTROLLER_BUTTON_DPAD_DOWN] == KEY_DOWN || (leftStick.y > 0.5f && !stickMoved);
@@ -97,36 +112,28 @@ void MainMenuSelectorScript::Update(float deltaTime)
 
         if (selectedItem->GetName() == "MenuItem_Continue")
         {
-            UID parentUID        = selectedItem->GetParent();
-            GameObject* parentGO = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByUID(parentUID);
-            if (parentGO)
+            if (gameOverCtrl)
             {
-                GameObject* goToDisable = selectedItem;
-                Scene* scene            = AppEngine->GetSceneModule()->GetScene();
-                while (goToDisable && goToDisable->GetName() != "GameOverPanel")
-                {
-                    goToDisable = scene->GetGameObjectByUID(goToDisable->GetParent());
-                }
-                if (goToDisable) goToDisable->SetEnabledRecursive(false);
+                gameOverCtrl->Close();
+                if (playerScript) playerScript->Respawn();
             }
-
-            GameTimer* timer = AppEngine->GetGameTimer();
-            if (timer) timer->TogglePause();
-
-            if (playerScript) playerScript->Respawn();
+            else if (pauseCtrl)
+            {
+                pauseCtrl->Close();
+            }
 
             return;
         }
+
         else if (selectedItem->GetName() == "MenuItem_Menu")
         {
-            if (auto* timer = AppEngine->GetGameTimer(); timer && timer->IsPaused()) timer->TogglePause();
+            if (pauseCtrl) pauseCtrl->Close();
             AppEngine->GetSceneModule()->GetScene()->SetStopPlaying(true);
-            std::string path = AppEngine->GetProjectModule()->GetLoadedProjectPath() + SCENES_PATH + "SCENE_MainMenu.scene";
+            std::string path =
+                AppEngine->GetProjectModule()->GetLoadedProjectPath() + SCENES_PATH + "SCENE_MainMenu.scene";
             AppEngine->GetSceneModule()->RequestSceneLoad(path);
-            return; 
+            return;
         }
-
-
     }
 }
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MainMenuSelectorScript.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MainMenuSelectorScript.h
@@ -1,9 +1,9 @@
-#pragma once
+﻿#pragma once
 #include "Script.h"
-#include <string>
 #include <vector>
 
-class GameObject;
+class PauseMenuScript;
+class GameOverScript;
 
 class MainMenuSelectorScript : public Script
 {
@@ -17,7 +17,11 @@ class MainMenuSelectorScript : public Script
   private:
     std::vector<GameObject*> menuItems;
     std::vector<GameObject*> arrowImages;
-    int selectedIndex = 0;
+    int selectedIndex            = 0;
+    bool stickMoved              = false;
+
+    PauseMenuScript* pauseCtrl   = nullptr;
+    GameOverScript* gameOverCtrl = nullptr;
 
     void UpdateSelection();
 };

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/PauseMenuScript.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/PauseMenuScript.cpp
@@ -12,47 +12,70 @@
 
 bool PauseMenuScript::Init()
 {
+    CachePanel();
+    if (cachedTarget) cachedTarget->SetEnabledRecursive(false);
+    isOpen = false;
     return true;
 }
 
-void PauseMenuScript::Update(float deltaTime)
+void PauseMenuScript::Show()
 {
-    const KeyState* keys           = AppEngine->GetInputModule()->GetKeyboard();
-    const KeyState* gamepadButtons = AppEngine->GetInputModule()->GetControllerButtons();
-
-    if (!cachedTarget)
+    if (isOpen) return;
+    CachePanel();
+    if (cachedTarget)
     {
-        const auto& allGameObjects = AppEngine->GetSceneModule()->GetScene()->GetAllGameObjects();
-        for (const auto& [uid, gameObject] : allGameObjects)
-            if (gameObject && gameObject->GetName() == panelToShowName)
-            {
-                cachedTarget = gameObject;
-                break;
-            }
+        cachedTarget->SetEnabledRecursive(true);
+        cachedTarget->UpdateTransformForGOBranch();
     }
-
-    if (cachedTarget &&
-        (keys[SDL_SCANCODE_ESCAPE] == KEY_DOWN || gamepadButtons[SDL_CONTROLLER_BUTTON_START] == KEY_DOWN))
-    {
-        bool newState = !cachedTarget->IsEnabled();
-        cachedTarget->SetEnabledRecursive(newState);
-
-        if (newState)
-            cachedTarget->UpdateTransformForGOBranch();
-
-        if (GameTimer* gameTimer = AppEngine->GetGameTimer()) gameTimer->TogglePause();
-    }
+    if (auto* t = AppEngine->GetGameTimer(); t && !t->IsPaused()) t->TogglePause();
+    isOpen = true;
 }
 
-void PauseMenuScript::Save(rapidjson::Value& targetState, rapidjson::Document::AllocatorType& allocator)
+void PauseMenuScript::Close()
 {
-    targetState.AddMember("PanelToShow", rapidjson::Value(panelToShowName.c_str(), allocator), allocator);
+    if (!isOpen) return;
+    if (cachedTarget) cachedTarget->SetEnabledRecursive(false);
+    if (auto* t = AppEngine->GetGameTimer(); t && t->IsPaused()) t->TogglePause();
+    isOpen = false;
 }
 
-void PauseMenuScript::Load(const rapidjson::Value& initialState)
+void PauseMenuScript::Toggle()
 {
-    if (initialState.HasMember("PanelToShow") && initialState["PanelToShow"].IsString())
+    isOpen ? Close() : Show();
+}
+
+void PauseMenuScript::Update(float)
+{
+    const KeyState* k = AppEngine->GetInputModule()->GetKeyboard();
+    if (k[SDL_SCANCODE_ESCAPE] == KEY_DOWN) Toggle();
+}
+
+void PauseMenuScript::Save(rapidjson::Value& out, rapidjson::Document::AllocatorType& a)
+{
+    out.AddMember("PanelToShow", rapidjson::Value(panelToShowName.c_str(), a), a);
+}
+
+void PauseMenuScript::Load(const rapidjson::Value& in)
+{
+    if (in.HasMember("PanelToShow") && in["PanelToShow"].IsString()) panelToShowName = in["PanelToShow"].GetString();
+}
+
+void PauseMenuScript::CachePanel()
+{
+    if (cachedTarget != nullptr) return;
+
+    Scene* scene        = AppEngine->GetSceneModule()->GetScene();
+    const auto& objects = scene->GetAllGameObjects();
+
+    for (const auto& [uid, go] : objects)
     {
-        panelToShowName = initialState["PanelToShow"].GetString();
+        if (go == nullptr)
+            continue;
+
+        if (go->GetName() == panelToShowName)
+        {
+            cachedTarget = go; 
+            return;            
+        }
     }
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/PauseMenuScript.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/PauseMenuScript.h
@@ -10,11 +10,17 @@ class PauseMenuScript : public Script
 
     bool Init() override;
     void Update(float deltaTime) override;
-    void Inspector() override {};
     void Save(rapidjson::Value& targetState, rapidjson::Document::AllocatorType& allocator) override;
     void Load(const rapidjson::Value& initialState) override;
 
+    void Show();  // open & pause
+    void Close(); // close & unpause
+    void Toggle();
+
   private:
+    void CachePanel();
+
     std::string panelToShowName = "PauseMenuPanel";
     GameObject* cachedTarget    = nullptr;
+    bool isOpen                 = false;
 };


### PR DESCRIPTION
Fixed the logic in MainMenuSelectorScript. It now works properly with both GameOverScript and PauseMenuScript.

Added a variable to Transform2D to control the draw order of elements in the Canvas (default is 0). The higher the number, the closer the element appears (it is saved and loaded properly). This prevents UI overlapping issues.

To test:
Go to The Hound Of Ulster repository, branch alpha_1, and test it in the SCENE_TUTORIAL. If it works correctly, I’ll add the prefabs to the other scenes. (I’ll recreate the changes in hound of ulster repo once the other PR removes them.)