### PR TITLE
bug/RenderPopping-THO-653

### DIFF
--- a/SobrassadaEngine/FileSystem/Batching/GeometryBatch.cpp
+++ b/SobrassadaEngine/FileSystem/Batching/GeometryBatch.cpp
@@ -252,8 +252,16 @@ void GeometryBatch::GenerateCommands(const std::vector<MeshComponent*>& meshes, 
     totalVertexCount = 0;
     totalIndexCount  = 0;
 
-    for (const MeshComponent* component : meshes)
+    for (MeshComponent* component : meshes)
     {
+        if (!component->GetWasEnabled() && !component->GetBatchWasEnabled())
+        {
+            GLOG("%s", component->GetParent()->GetName());
+            GLOG("%d", component->GetBatchWasEnabled());
+            component->SetBatchWasEnabled();
+            continue;
+        }
+
         const ResourceMesh* resource   = component->GetResourceMesh();
 
         const unsigned int vertexCount = static_cast<unsigned int>(resource->GetVertexCount());

--- a/SobrassadaEngine/FileSystem/Batching/GeometryBatch.cpp
+++ b/SobrassadaEngine/FileSystem/Batching/GeometryBatch.cpp
@@ -256,8 +256,6 @@ void GeometryBatch::GenerateCommands(const std::vector<MeshComponent*>& meshes, 
     {
         if (!component->GetWasEnabled() && !component->GetBatchWasEnabled())
         {
-            GLOG("%s", component->GetParent()->GetName());
-            GLOG("%d", component->GetBatchWasEnabled());
             component->SetBatchWasEnabled();
             continue;
         }

--- a/SobrassadaEngine/Scene/Components/Standalone/MeshComponent.h
+++ b/SobrassadaEngine/Scene/Components/Standalone/MeshComponent.h
@@ -49,6 +49,7 @@ class MeshComponent : public Component
     GeometryBatch* GetBatch() const { return batch; }
     int GetRenderMode() const { return renderMode; }
     bool GetProduceShadows() const { return produceShadows; }
+    bool GetBatchWasEnabled() { return batchWasEnabled; }
 
     void SetBones(const std::vector<GameObject*>& bones, const std::vector<UID> bonesIds)
     {
@@ -61,6 +62,14 @@ class MeshComponent : public Component
     {
         this->skinIndex = newIndex;
         hasBones        = true;
+    }
+    void SetBatchWasEnabled() { batchWasEnabled = true; }
+
+    void SetEnabled(bool newEnabled) override
+    {
+        wasEnabled = enabled;
+        enabled    = newEnabled;
+        batchWasEnabled = false;
     }
 
   private:
@@ -84,7 +93,9 @@ class MeshComponent : public Component
     GeometryBatch* batch    = nullptr;
     bool uniqueBatch        = false;
 
-    int renderMode   = 0; //0 = Opaque, 1 = Alpha Blend, 2 = Alpha Discard
+    int renderMode          = 0; // 0 = Opaque, 1 = Alpha Blend, 2 = Alpha Discard
 
     bool produceShadows     = true;
+
+    bool batchWasEnabled    = false;
 };

--- a/SobrassadaEngine/Scene/Components/Standalone/MeshComponent.h
+++ b/SobrassadaEngine/Scene/Components/Standalone/MeshComponent.h
@@ -67,8 +67,8 @@ class MeshComponent : public Component
 
     void SetEnabled(bool newEnabled) override
     {
-        wasEnabled = enabled;
-        enabled    = newEnabled;
+        Component::SetEnabled(newEnabled);
+
         batchWasEnabled = false;
     }
 


### PR DESCRIPTION
Fixed popping with game objects that were enabled disabled frequently.
There is still an issue with the trail of the range attack.

How to test:
Try using range attack, ultimate and see that for a frame there is not an incorrect position of these meshes.