### PR TITLE
New iteration of player final version

### DIFF
--- a/SobrassadaEngine/ResourceManagement/Resources/ResourceMaterial.cpp
+++ b/SobrassadaEngine/ResourceManagement/Resources/ResourceMaterial.cpp
@@ -526,3 +526,10 @@ void ResourceMaterial::FreeMaterials() const
         glDeleteTextures(1, &emmisiveTexture.textureID);
     }
 }
+
+void ResourceMaterial::SetDiffColor(const float4& newColor)
+{
+    material.diffColor = newColor;
+    //SaveToMeta();
+    App->GetSceneModule()->GetScene()->UpdateAllMaterialInstances(uid);
+}

--- a/SobrassadaEngine/ResourceManagement/Resources/ResourceMaterial.h
+++ b/SobrassadaEngine/ResourceManagement/Resources/ResourceMaterial.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include "Resource.h"
+#include "Globals.h"
 
 #include "Math/float3.h"
 #include "Math/float4.h"
@@ -68,6 +69,8 @@ class ResourceMaterial : public Resource
     unsigned int GetNormalTextureID() const { return normalTexture.textureID; }
     unsigned int GetEmissiveTextureID() const { return emmisiveTexture.textureID; }
     unsigned int GetOcclusionTextureID() const { return occlusionTexture.textureID; }
+
+    SOBRASADA_API_ENGINE void SetDiffColor(const float4& newColor);
 
   private:
     TextureInfo diffuseTexture;

--- a/SobrassadaEngine/ResourceManagement/Resources/ResourceStateMachine.cpp
+++ b/SobrassadaEngine/ResourceManagement/Resources/ResourceStateMachine.cpp
@@ -335,3 +335,8 @@ void ResourceStateMachine::ResetClipsSpeed()
         clips[i].animationSpeed = clipsDefaultSpeed[i];
     }
 }
+
+void ResourceStateMachine::RemoveAllClips()
+{
+    clips.clear();
+}

--- a/SobrassadaEngine/ResourceManagement/Resources/ResourceStateMachine.h
+++ b/SobrassadaEngine/ResourceManagement/Resources/ResourceStateMachine.h
@@ -73,6 +73,8 @@ class SOBRASADA_API_ENGINE ResourceStateMachine : public Resource
     void SetDefaultState(int state) { defaultStateIndex = state; }
     void ResetClipsSpeed();
 
+    void RemoveAllClips();
+
   public:
     std::vector<Clip> clips;
     std::vector<State> states;

--- a/SobrassadaEngine/Scene/Components/Standalone/AnimationComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/AnimationComponent.cpp
@@ -15,6 +15,7 @@
 #include "ResourcesModule.h"
 #include "SceneModule.h"
 #include "StateMachineEditor.h"
+#include "GameTimer.h"
 
 #include "Math/Quat.h"
 #include "imgui.h"
@@ -27,7 +28,7 @@
 AnimationComponent::AnimationComponent(const UID uid, GameObject* parent)
     : Component(uid, parent, "Animation", COMPONENT_ANIMATION)
 {
-    animController = new AnimController();
+    animController     = new AnimController();
 
     localComponentAABB = AABB(float3(-0.5, -0.5, -0.5), float3(0.5, 0.5, 0.5));
 }
@@ -103,8 +104,6 @@ void AnimationComponent::OnPlay(bool isTransition)
                             else animController->Play(clip.animationResourceUID, clip.loop, clip.animationSpeed);
                             resource = clip.animationResourceUID;
                         }
-
-                        
                     }
                 }
             }
@@ -398,7 +397,10 @@ void AnimationComponent::Update(float deltaTime)
             SetBoneMapping();
         }
 
-        animController->Update(deltaTime);
+        // If in game, update animations with game timer so they are paused
+        float currentDelta =
+            App->GetSceneModule()->GetInPlayMode() ? App->GetGameTimer()->GetDeltaTime() / 1000.0f : deltaTime;
+        animController->Update(currentDelta);
 
         std::set<GameObject*> modifiedBones;
 
@@ -406,7 +408,7 @@ void AnimationComponent::Update(float deltaTime)
         {
             const HashString& boneName = channel;
 
-            auto boneIt = boneMapping.find(boneName);
+            auto boneIt                = boneMapping.find(boneName);
 
             if (boneIt != boneMapping.end())
             {

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Character.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Character.cpp
@@ -219,6 +219,8 @@ void Character::UpdateTimers(float deltaTime)
 
     searchTimer -= deltaTime;
     if (searchTimer < 0.0f) searchTimer = 0.0f;
+
+
 }
 
 void Character::TakeDamage(int amount)

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Character.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Character.cpp
@@ -135,10 +135,6 @@ void Character::OnCollisionEnter(GameObject* otherObject, const float3 collision
 
     if (otherScript && otherWeapon && otherWeapon->GetEnabled())
     {
-        // Charged attack check
-        if (playerScript && playerScript->GetState() == CharacterStates::CHARGED_ATTACK)
-            TakeDamage(playerScript->GetChargedAttackDamage());
-
         // Standard attack check
         Character* enemyScript = otherScript->GetScriptByType<Character>();
         if (enemyScript)
@@ -153,6 +149,10 @@ void Character::OnCollisionEnter(GameObject* otherObject, const float3 collision
         CuChulainn* playerScript = otherScript->GetScriptByType<CuChulainn>();
         if (playerScript && playerScript->GetState() == CharacterStates::ULTIMATE)
             TakeDamage(playerScript->GetUltimateDamage());
+
+        // Charged attack check
+        if (playerScript && playerScript->GetState() == CharacterStates::CHARGED_ATTACK)
+            TakeDamage(playerScript->GetChargedAttackDamage());
 
         // Heal knockback check
         if (playerScript && playerScript->GetState() == CharacterStates::HEAL)

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Character.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Character.cpp
@@ -118,7 +118,6 @@ void Character::OnCollision(GameObject* otherObject, const float3 collisionNorma
 
     if (otherScript && otherWeapon && otherWeapon->GetEnabled())
     {
-
         // Charged attack check
         if (playerScript && playerScript->GetState() == CharacterStates::CHARGED_ATTACK)
             TakeDamage(playerScript->GetChargedAttackDamage());
@@ -137,6 +136,10 @@ void Character::OnCollision(GameObject* otherObject, const float3 collisionNorma
         CuChulainn* playerScript = otherScript->GetScriptByType<CuChulainn>();
         if (playerScript && playerScript->GetState() == CharacterStates::ULTIMATE)
             TakeDamage(playerScript->GetUltimateDamage());
+
+        // Heal knockback check
+        if (playerScript && playerScript->GetState() == CharacterStates::HEAL)
+            TakeDamage(0);
     }
 
     if (otherWeapon && otherWeapon->GetEnabled() && otherObject->GetName() == "DarkPath")

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Character.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Character.cpp
@@ -154,8 +154,9 @@ void Character::OnCollisionEnter(GameObject* otherObject, const float3 collision
         if (playerScript && playerScript->GetState() == CharacterStates::CHARGED_ATTACK)
             TakeDamage(playerScript->GetChargedAttackDamage());
 
-        // Heal knockback check
-        if (playerScript && playerScript->GetState() == CharacterStates::HEAL)
+        // Heal & Riastrad knockback check
+        if (playerScript && (playerScript->GetState() == CharacterStates::HEAL ||
+                             playerScript->GetState() == CharacterStates::TRANSFORM))
             TakeDamage(0);
     }
 
@@ -219,8 +220,6 @@ void Character::UpdateTimers(float deltaTime)
 
     searchTimer -= deltaTime;
     if (searchTimer < 0.0f) searchTimer = 0.0f;
-
-
 }
 
 void Character::TakeDamage(int amount)

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -96,6 +96,7 @@ CuChulainn::CuChulainn(GameObject* parent)
     fields.push_back({"Dash decal object", InspectorField::FieldType::InputText, &dashDecalName});
     fields.push_back({"Dash decal disappear", InspectorField::FieldType::Float, &dashDecalTimer, 0.0f, 20.0f});
     fields.push_back({"Heal visual object", InspectorField::FieldType::InputText, &healVisualName});
+    fields.push_back({"Riastrad VFX object", InspectorField::FieldType::InputText, &riastradVfxName});
 
     fields.push_back({InspectorField::FieldType::Text, (void*)"HUD textures"});
     fields.push_back({"Dash filled icon", InspectorField::FieldType::Resource, &dashFillImage});
@@ -202,6 +203,10 @@ bool CuChulainn::Init()
     healVisual = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(healVisualName);
     if (!healVisual) GLOG("[WARNING] No heal visual found for CuChulain")
     else healVisual->SetEnabled(false);
+
+    riastradVfx = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(riastradVfxName);
+    if (!riastradVfx) GLOG("[WARNING] No riastrad VFX found for CuChulain")
+    else riastradVfx->SetEnabled(false);
 
     audio = parent->GetComponent<AudioSourceComponent*>();
     if (!audio) GLOG("[WARNING] CuChulainn: No audio component found");
@@ -318,7 +323,7 @@ void CuChulainn::HandleState(float deltaTime)
     else if (state != CharacterStates::BASIC_ATTACK && !character->IsDashing() && state != CharacterStates::RESPAWN &&
              state != CharacterStates::AIM && state != CharacterStates::FALL && state != CharacterStates::ULTIMATE &&
              state != CharacterStates::CHARGED_ATTACK && state != CharacterStates::CHARGING &&
-             state != CharacterStates::HEAL)
+             state != CharacterStates::HEAL && state != CharacterStates::TRANSFORM)
         Move();
 
     // When finished animation, go back to idle state
@@ -341,6 +346,11 @@ void CuChulainn::HandleState(float deltaTime)
                 return;
             if (state == CharacterStates::CHARGED_ATTACK && meleeTrailObject) meleeTrailObject->SetEnabled(false);
             if (state == CharacterStates::HEAL) healKnockback->SetEnabled(false);
+            if (state == CharacterStates::TRANSFORM)
+            {
+                riastradVfx->GetComponent<AnimationComponent*>()->OnStop();
+                riastradVfx->SetEnabled(false);
+            }
             state = CharacterStates::IDLE;
             animComponent->UseTrigger("Idle");
         }
@@ -485,7 +495,7 @@ bool CuChulainn::CanDash() const
     bool canDash = dashTimer <= 0 && state != CharacterStates::AIM && !isAttacking && state != CharacterStates::FALL &&
                    state != CharacterStates::RESPAWN && state != CharacterStates::ULTIMATE &&
                    state != CharacterStates::CHARGED_ATTACK && state != CharacterStates::TAKE_MUSHROOM &&
-                   state != CharacterStates::HEAL && !isCursed;
+                   state != CharacterStates::HEAL && !isCursed && state != CharacterStates::TRANSFORM;
 
     if (canDash && state == CharacterStates::BASIC_ATTACK) canDash = comboBufferTimer > 0.0f;
 
@@ -498,7 +508,7 @@ bool CuChulainn::CanAttack() const
            state != CharacterStates::RESPAWN && comboCounter <= 1 && attackCdTimer <= 0.0f &&
            state != CharacterStates::ULTIMATE && state != CharacterStates::CHARGED_ATTACK &&
            state != CharacterStates::CHARGING && state != CharacterStates::TAKE_MUSHROOM &&
-           state != CharacterStates::HEAL;
+           state != CharacterStates::HEAL && state != CharacterStates::TRANSFORM;
 }
 
 bool CuChulainn::CanUltimate() const
@@ -506,7 +516,7 @@ bool CuChulainn::CanUltimate() const
     bool canUltimate = state != CharacterStates::DASH && !isAttacking && state != CharacterStates::FALL &&
                        state != CharacterStates::RESPAWN && ultimateCdTimer <= 0.0f &&
                        state != CharacterStates::CHARGED_ATTACK && state != CharacterStates::TAKE_MUSHROOM &&
-                       state != CharacterStates::HEAL;
+                       state != CharacterStates::HEAL && state != CharacterStates::TRANSFORM;
 
     if (canUltimate && state == CharacterStates::BASIC_ATTACK) canUltimate = comboBufferTimer > 0.0f;
 
@@ -517,7 +527,7 @@ bool CuChulainn::CanTakeMushroom() const
 {
     return state != CharacterStates::DASH && !isAttacking && state != CharacterStates::AIM &&
            state != CharacterStates::RESPAWN && state != CharacterStates::DEATH && state != CharacterStates::FALL &&
-           state != CharacterStates::ULTIMATE && state != CharacterStates::HEAL;
+           state != CharacterStates::ULTIMATE && state != CharacterStates::HEAL && state != CharacterStates::TRANSFORM;
 }
 
 bool CuChulainn::CanHeal() const
@@ -526,7 +536,7 @@ bool CuChulainn::CanHeal() const
            state != CharacterStates::RESPAWN && state != CharacterStates::DEATH && state != CharacterStates::FALL &&
            state != CharacterStates::ULTIMATE && state != CharacterStates::TAKE_MUSHROOM &&
            state != CharacterStates::CHARGED_ATTACK && state != CharacterStates::CHARGING && mushrooms > 0 &&
-           !isHealing;
+           !isHealing && state != CharacterStates::TRANSFORM;
 }
 
 bool CuChulainn::CanAim() const
@@ -534,7 +544,8 @@ bool CuChulainn::CanAim() const
     return state != CharacterStates::DASH && state != CharacterStates::BASIC_ATTACK && throwTimer <= 0 &&
            state != CharacterStates::FALL && state != CharacterStates::RESPAWN && state != CharacterStates::ULTIMATE &&
            state != CharacterStates::CHARGED_ATTACK && state != CharacterStates::CHARGING &&
-           state != CharacterStates::TAKE_MUSHROOM && state != CharacterStates::HEAL;
+           state != CharacterStates::TAKE_MUSHROOM && state != CharacterStates::HEAL &&
+           state != CharacterStates::TRANSFORM;
 }
 
 bool CuChulainn::CanChargeAttack() const
@@ -542,7 +553,8 @@ bool CuChulainn::CanChargeAttack() const
     bool canChargeAttack = state != CharacterStates::DASH && !isAttacking && state != CharacterStates::FALL &&
                            state != CharacterStates::RESPAWN && state != CharacterStates::ULTIMATE &&
                            state != CharacterStates::AIM && state != CharacterStates::CHARGED_ATTACK &&
-                           state != CharacterStates::TAKE_MUSHROOM && state != CharacterStates::HEAL;
+                           state != CharacterStates::TAKE_MUSHROOM && state != CharacterStates::HEAL &&
+                           state != CharacterStates::TRANSFORM;
 
     if (canChargeAttack && state == CharacterStates::BASIC_ATTACK) canChargeAttack = comboBufferTimer > 0.0f;
 
@@ -558,7 +570,7 @@ bool CuChulainn::CanTransform() const
                        state != CharacterStates::FALL && state != CharacterStates::RESPAWN &&
                        state != CharacterStates::ULTIMATE && state != CharacterStates::AIM &&
                        state != CharacterStates::CHARGED_ATTACK && state != CharacterStates::TAKE_MUSHROOM &&
-                       state != CharacterStates::HEAL;
+                       state != CharacterStates::HEAL && state != CharacterStates::TRANSFORM;
 
         if (canTransform && state == CharacterStates::BASIC_ATTACK) canTransform = comboBufferTimer > 0.0f;
     }
@@ -568,7 +580,7 @@ bool CuChulainn::CanTransform() const
                        state != CharacterStates::FALL && state != CharacterStates::RESPAWN &&
                        state != CharacterStates::ULTIMATE && state != CharacterStates::AIM &&
                        state != CharacterStates::CHARGED_ATTACK && state != CharacterStates::TAKE_MUSHROOM &&
-                       state != CharacterStates::HEAL;
+                       state != CharacterStates::HEAL && state != CharacterStates::TRANSFORM;
     }
 
     return canTransform;
@@ -1115,6 +1127,13 @@ void CuChulainn::ToggleRiastrad()
         character->SetMaxSpeed(riastradMovementSpeed);
         Heal(maxHealth);
 
+        riastradVfx->SetEnabled(true);
+        riastradVfx->GetComponent<AnimationComponent*>()->OnPlay(false);
+        state          = CharacterStates::TRANSFORM;
+        character->EnableMovement(false);
+
+        if (animComponent) animComponent->UseTrigger("Transform");
+
         for (Clip& clip : animComponent->GetResourceStateMachine()->clips)
         {
             clip.animationSpeed *= riastradAnimationsSpeedRatio;
@@ -1248,6 +1267,9 @@ const std::string CuChulainn::GetLogicStateName()
         break;
     case CharacterStates::HEAL:
         return "Healing";
+        break;
+    case CharacterStates::TRANSFORM:
+        return "Transform";
         break;
     default:
         return "MISSING!";

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -350,7 +350,7 @@ void CuChulainn::HandleState(float deltaTime)
             if (state == CharacterStates::ULTIMATE && ultimateObject->GetComponent<AnimationComponent*>()->IsPlaying())
                 return;
             if (state == CharacterStates::CHARGED_ATTACK && meleeTrailObject) meleeTrailObject->SetEnabled(false);
-            if (state == CharacterStates::HEAL) healKnockback->SetEnabled(false);
+            if (state == CharacterStates::HEAL && healKnockback) healKnockback->SetEnabled(false);
             if (state == CharacterStates::TRANSFORM)
             {
                 riastradVfx->GetComponent<AnimationComponent*>()->OnStop();
@@ -1101,7 +1101,7 @@ void CuChulainn::UseMushroom()
     if (healVisual) healVisual->SetEnabled(true);
 
     Heal(mushroomHeal);
-    healKnockback->SetEnabled(true);
+    if (healKnockback) healKnockback->SetEnabled(true);
 
     // UpdateMushroomsUI();
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -229,7 +229,7 @@ bool CuChulainn::Init()
     else riastradBurst->SetEnabled(false);
 
     riastradBlur = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(riastradBlurName);
-    if (!riastradBlur) GLOG("[WARNING] No riastrad Bñur VFX found for CuChulain")
+    if (!riastradBlur) GLOG("[WARNING] No riastrad Blur VFX found for CuChulain")
     else riastradBlur->SetEnabled(false);
 
     riastradHalo = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(riastradHaloName);
@@ -241,11 +241,11 @@ bool CuChulainn::Init()
     else riastradSphere->SetEnabled(false);
 
     riastradCrack = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(riastradCrackName);
-    if (!riastradCrack) GLOG("[WARNING] No riastrad Sphere VFX found for CuChulain")
+    if (!riastradCrack) GLOG("[WARNING] No riastrad Crack VFX found for CuChulain")
     else riastradCrack->SetEnabled(false);
 
     riastradWaring = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(riastradWaringName);
-    if (!riastradWaring) GLOG("[WARNING] No riastrad Sphere VFX found for CuChulain")
+    if (!riastradWaring) GLOG("[WARNING] No riastrad Warning VFX found for CuChulain")
     else riastradWaring->SetEnabled(false);
 
     riastradSmoke1 = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(riastradSmoke1Name);
@@ -1262,42 +1262,6 @@ void CuChulainn::ToggleRiastrad()
         {
             clip.animationSpeed *= riastradAnimationsSpeedRatio;
         }
-
-        // Starting VFX
-        if (riastradVfx)
-        {
-            riastradVfx->GetComponent<AnimationComponent*>()->OnPlay(true);
-        }
-        if (riastradSmoke1)
-        {
-            riastradSmoke1->SetEnabled(true);
-            riastradSmoke1->GetComponent<MeshComponent*>()->SetEnabled(false);
-            riastradSmoke1->GetComponent<ShaderScriptComponent*>()->GetScriptByType<MovingUVTransparent>()->Reset();
-        }
-        if (riastradSmoke2)
-        {
-            riastradSmoke2->SetEnabled(true);
-            riastradSmoke2->GetComponent<MeshComponent*>()->SetEnabled(false);
-            riastradSmoke2->GetComponent<ShaderScriptComponent*>()->GetScriptByType<MovingUVTransparent>()->Reset();
-        }
-        if (riastradSmoke3)
-        {
-            riastradSmoke3->SetEnabled(true);
-            riastradSmoke3->GetComponent<MeshComponent*>()->SetEnabled(false);
-            riastradSmoke3->GetComponent<ShaderScriptComponent*>()->GetScriptByType<MovingUVTransparent>()->Reset();
-        }
-        if (riastradSphere)
-        {
-            riastradSphere->SetEnabled(true);
-            riastradSphere->GetComponent<MeshComponent*>()->SetEnabled(false);
-            riastradSphere->GetComponent<ShaderScriptComponent*>()->GetScriptByType<MovingUVTransparent>()->Reset();
-        }
-        if (riastradHalo)
-        {
-            riastradHalo->SetEnabled(true);
-            riastradHalo->GetComponent<MeshComponent*>()->SetEnabled(false);
-            riastradHalo->GetComponent<ShaderScriptComponent*>()->GetScriptByType<MovingUVTransparent>()->Reset();
-        }
     }
     else
     {
@@ -1337,6 +1301,40 @@ void CuChulainn::EnableRiastradVfx()
     }
 
     // Stomp VFX
+    if (riastradVfx)
+    {
+        riastradVfx->GetComponent<AnimationComponent*>()->OnPlay(true);
+    }
+    if (riastradSmoke1)
+    {
+        riastradSmoke1->SetEnabled(true);
+        riastradSmoke1->GetComponent<MeshComponent*>()->SetEnabled(false);
+        riastradSmoke1->GetComponent<ShaderScriptComponent*>()->GetScriptByType<MovingUVTransparent>()->Reset();
+    }
+    if (riastradSmoke2)
+    {
+        riastradSmoke2->SetEnabled(true);
+        riastradSmoke2->GetComponent<MeshComponent*>()->SetEnabled(false);
+        riastradSmoke2->GetComponent<ShaderScriptComponent*>()->GetScriptByType<MovingUVTransparent>()->Reset();
+    }
+    if (riastradSmoke3)
+    {
+        riastradSmoke3->SetEnabled(true);
+        riastradSmoke3->GetComponent<MeshComponent*>()->SetEnabled(false);
+        riastradSmoke3->GetComponent<ShaderScriptComponent*>()->GetScriptByType<MovingUVTransparent>()->Reset();
+    }
+    if (riastradSphere)
+    {
+        riastradSphere->SetEnabled(true);
+        riastradSphere->GetComponent<MeshComponent*>()->SetEnabled(false);
+        riastradSphere->GetComponent<ShaderScriptComponent*>()->GetScriptByType<MovingUVTransparent>()->Reset();
+    }
+    if (riastradHalo)
+    {
+        riastradHalo->SetEnabled(true);
+        riastradHalo->GetComponent<MeshComponent*>()->SetEnabled(false);
+        riastradHalo->GetComponent<ShaderScriptComponent*>()->GetScriptByType<MovingUVTransparent>()->Reset();
+    }
     if (riastradCrack) riastradCrack->SetEnabled(true);
     if (riastradWaring) riastradWaring->SetEnabled(true);
     if (riastradBurst)

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -10,7 +10,9 @@
 #include "GameTimer.h"
 #include "InputModule.h"
 #include "Projectile.h"
+#include "ResourceMaterial.h"
 #include "ResourceStateMachine.h"
+#include "ResourcesModule.h"
 #include "Scene.h"
 #include "SceneModule.h"
 #include "ScriptComponent.h"
@@ -80,6 +82,11 @@ CuChulainn::CuChulainn(GameObject* parent)
     fields.push_back({"Riastrad on damage taken", InspectorField::FieldType::Int, &riastradOnDamageTaken, 0, 100});
     fields.push_back({"Riastrad on enemy hit", InspectorField::FieldType::Int, &riastradOnHit, 0, 100});
     fields.push_back({"Riastrad on enemy defeated", InspectorField::FieldType::Int, &riastradOnEnemyDeath, 0, 100});
+
+    fields.push_back({InspectorField::FieldType::Text, (void*)"Curse parameters"});
+    fields.push_back({"Curse duration", InspectorField::FieldType::Float, &curseDuration, 0.0f, 100.0f});
+    fields.push_back({"Curse speed", InspectorField::FieldType::Float, &curseSpeed, 0.0f, 100.0f});
+    fields.push_back({"Player material", InspectorField::FieldType::Resource, &playerMaterial});
 
     fields.push_back({InspectorField::FieldType::Text, (void*)"VFX"});
     fields.push_back({"Aim shadow object", InspectorField::FieldType::InputText, &aimShadowName});
@@ -394,7 +401,7 @@ void CuChulainn::GetInputs()
         {
             desiredTransform     = true;
             transformBufferTimer = inputBuffer;
-        } 
+        }
     }
 
     // Dash
@@ -463,6 +470,10 @@ void CuChulainn::GetInputs()
         AddRiastrad(100);
         GLOG("Fill riastrad")
     }
+    if (keyboard[SDL_SCANCODE_F9] == KEY_DOWN)
+    {
+        StartCurse();
+    }
 }
 
 bool CuChulainn::CanDash() const
@@ -470,7 +481,7 @@ bool CuChulainn::CanDash() const
     bool canDash = dashTimer <= 0 && state != CharacterStates::AIM && !isAttacking && state != CharacterStates::FALL &&
                    state != CharacterStates::RESPAWN && state != CharacterStates::ULTIMATE &&
                    state != CharacterStates::CHARGED_ATTACK && state != CharacterStates::TAKE_MUSHROOM &&
-                   state != CharacterStates::HEAL;
+                   state != CharacterStates::HEAL && !isCursed;
 
     if (canDash && state == CharacterStates::BASIC_ATTACK) canDash = comboBufferTimer > 0.0f;
 
@@ -666,6 +677,12 @@ void CuChulainn::UpdateTimers(float deltaTime)
     {
         riastradTimer -= deltaTime;
         if (riastradTimer <= 0.0f) desiredTransform = true;
+    }
+
+    if (isCursed)
+    {
+        curseTimer -= deltaTime;
+        if (curseTimer <= 0) EndCurse();
     }
 
     if (state == CharacterStates::ULTIMATE) ultimateTimer += deltaTime;
@@ -1083,6 +1100,8 @@ void CuChulainn::ToggleRiastrad()
 
     if (!isRiastrad)
     {
+        EndCurse();
+
         // Start Riastrad
         AddRiastrad(-100);
         isRiastrad    = true;
@@ -1095,6 +1114,18 @@ void CuChulainn::ToggleRiastrad()
         {
             clip.animationSpeed *= riastradAnimationsSpeedRatio;
         }
+
+
+        // TODO: Remove when VFX
+        Resource* res = AppEngine->GetResourcesModule()->RequestResource(playerMaterial);
+        if (res)
+        {
+            ResourceMaterial* mat = static_cast<ResourceMaterial*>(res);
+            float4 newColor       = mat->GetMaterial().diffColor;
+            newColor.y            = 0.0f;
+            newColor.x            = 0.0f;
+            mat->SetDiffColor(newColor);
+        }
     }
     else
     {
@@ -1102,6 +1133,16 @@ void CuChulainn::ToggleRiastrad()
         isRiastrad = false;
         animComponent->GetResourceStateMachine()->ResetClipsSpeed();
         character->SetMaxSpeed(defaultSpeed);
+
+        // TODO: Remove when VFX
+        Resource* res = AppEngine->GetResourcesModule()->RequestResource(playerMaterial);
+        if (res)
+        {
+            ResourceMaterial* mat = static_cast<ResourceMaterial*>(res);
+            float4 newColor       = mat->GetMaterial().diffColor;
+            newColor              = float4::one;
+            mat->SetDiffColor(newColor);
+        }
     }
 }
 
@@ -1125,6 +1166,40 @@ void CuChulainn::OnEnemyHit()
 void CuChulainn::OnEnemyDefeated()
 {
     AddRiastrad(riastradOnEnemyDeath);
+}
+
+void CuChulainn::StartCurse()
+{
+    // TODO: Remove when VFX
+    Resource* res = AppEngine->GetResourcesModule()->RequestResource(playerMaterial);
+    if (res)
+    {
+        ResourceMaterial* mat = static_cast<ResourceMaterial*>(res);
+        float4 newColor       = mat->GetMaterial().diffColor;
+        newColor.y            = 0.0f;
+        newColor.x            = 0.6f;
+        mat->SetDiffColor(newColor);
+    }
+
+    isCursed = true;
+    character->SetMaxSpeed(curseSpeed);
+    curseTimer = curseDuration;
+}
+
+void CuChulainn::EndCurse()
+{
+    // TODO: Remove when VFX
+    Resource* res = AppEngine->GetResourcesModule()->RequestResource(playerMaterial);
+    if (res)
+    {
+        ResourceMaterial* mat = static_cast<ResourceMaterial*>(res);
+        float4 newColor       = mat->GetMaterial().diffColor;
+        newColor              = float4::one;
+        mat->SetDiffColor(newColor);
+    }
+
+    isCursed = false;
+    character->SetMaxSpeed(defaultSpeed);
 }
 
 const std::string CuChulainn::GetLogicStateName()

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -24,6 +24,7 @@
 #include "Standalone/Physics/SphereColliderComponent.h"
 #include "Standalone/UI/ImageComponent.h"
 #include "Standalone/UI/Transform2DComponent.h"
+#include "GameTimer.h"
 
 #include "Math/Quat.h"
 #include "SDL.h"
@@ -289,8 +290,9 @@ void CuChulainn::OnDamageTaken(int amount)
         state = CharacterStates::IDLE;
         if (animComponent) animComponent->UseTrigger("Idle");
     }
-    // TODO: play CuChulainn take damage sound
-    // TODO: fill riastrad bar dinamically
+
+    // TODO: Test if hitstop when hit feels nice
+    //AppEngine->GetGameTimer()->SetTimeScale(0.0f);
 }
 
 void CuChulainn::OnHealed(int amount)
@@ -353,6 +355,7 @@ void CuChulainn::HandleState(float deltaTime)
             {
                 riastradVfx->GetComponent<AnimationComponent*>()->OnStop();
                 riastradVfx->SetEnabled(false);
+                AppEngine->GetGameTimer()->SetTimeScale(1.0f);
             }
             state = CharacterStates::IDLE;
             animComponent->UseTrigger("Idle");
@@ -593,6 +596,16 @@ void CuChulainn::UpdateTimers(float deltaTime)
 {
     weaponCollider->SetEnabled(false);
     Character::UpdateTimers(deltaTime);
+
+    if (AppEngine->GetGameTimer()->GetTimeScale() == 0.0f)
+    {
+        epicTimer += AppEngine->GetGameTimer()->GetUnscaledDeltaTime() / 1000.0f;
+        if (epicTimer > 0.1f)
+        {
+            epicTimer = 0.0f;
+            AppEngine->GetGameTimer()->SetTimeScale(1.0f);
+        }
+    }
 
     // Dash
     dashTimer -= deltaTime;
@@ -1167,6 +1180,7 @@ void CuChulainn::ToggleRiastrad()
         riastradVfx->GetComponent<AnimationComponent*>()->OnPlay(false);
         state          = CharacterStates::TRANSFORM;
         character->EnableMovement(false);
+        AppEngine->GetGameTimer()->SetTimeScale(0.5f);
 
         if (animComponent) animComponent->UseTrigger("Transform");
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -36,7 +36,6 @@ CuChulainn::CuChulainn(GameObject* parent)
 {
     currentHealth = 3; // mainChar starts low hp
 
-    // TODO: Replace target names by gameObjects when overriding prefabs doesn't break the link
     fields.push_back({InspectorField::FieldType::Spacing, nullptr});
     fields.push_back({InspectorField::FieldType::Text, (void*)"CuChulainn parameters"});
     fields.push_back({"God Mode", InspectorField::FieldType::Bool, &godMode});
@@ -67,12 +66,18 @@ CuChulainn::CuChulainn(GameObject* parent)
         {"Charged Attack hitbox duration", InspectorField::FieldType::Float, &chargedAttackHitboxDuration, 0.0f, 5.0f}
     );
 
+    fields.push_back({InspectorField::FieldType::Text, (void*)"Curse parameters"});
+    fields.push_back({"Curse duration", InspectorField::FieldType::Float, &curseDuration, 0.0f, 100.0f});
+    fields.push_back({"Curse speed", InspectorField::FieldType::Float, &curseSpeed, 0.0f, 100.0f});
+    fields.push_back({"Player material", InspectorField::FieldType::Resource, &playerMaterial});
+
     fields.push_back({InspectorField::FieldType::Text, (void*)"Healing"});
     fields.push_back({"Take mushroom cooldown", InspectorField::FieldType::Float, &takeMushroomCd, 0.0f, 5.0f});
     fields.push_back({"Mushroom healing", InspectorField::FieldType::Int, &mushroomHeal, 0.0f, 5.0f});
+    fields.push_back({"Heal knockback object", InspectorField::FieldType::InputText, &healKnockbackName});
 
     fields.push_back({InspectorField::FieldType::Text, (void*)"Riastrad parameters"});
-    fields.push_back({"Riastrad Bar object", InspectorField::FieldType::GameObject, &riastradBar});
+    //fields.push_back({"Riastrad Bar object", InspectorField::FieldType::GameObject, &riastradBar}); // TODO: Fix GameObject field breaks the loading of the ones after
     fields.push_back({"Riastrad duration", InspectorField::FieldType::Float, &riastradDuration, 0.0f, 100.0f});
     fields.push_back({"Riastrad movement speed", InspectorField::FieldType::Float, &riastradMovementSpeed, 0.0f, 20.0f}
     );
@@ -83,16 +88,10 @@ CuChulainn::CuChulainn(GameObject* parent)
     fields.push_back({"Riastrad on enemy hit", InspectorField::FieldType::Int, &riastradOnHit, 0, 100});
     fields.push_back({"Riastrad on enemy defeated", InspectorField::FieldType::Int, &riastradOnEnemyDeath, 0, 100});
 
-    fields.push_back({InspectorField::FieldType::Text, (void*)"Curse parameters"});
-    fields.push_back({"Curse duration", InspectorField::FieldType::Float, &curseDuration, 0.0f, 100.0f});
-    fields.push_back({"Curse speed", InspectorField::FieldType::Float, &curseSpeed, 0.0f, 100.0f});
-    fields.push_back({"Player material", InspectorField::FieldType::Resource, &playerMaterial});
-
     fields.push_back({InspectorField::FieldType::Text, (void*)"VFX"});
     fields.push_back({"Aim shadow object", InspectorField::FieldType::InputText, &aimShadowName});
     fields.push_back({"Melee trail object", InspectorField::FieldType::InputText, &meleeTrailName});
     fields.push_back({"Melee VFX object", InspectorField::FieldType::InputText, &meleeVfxName});
-
     fields.push_back({"Dash Trail object", InspectorField::FieldType::InputText, &dashTrailName});
     fields.push_back({"Dash decal object", InspectorField::FieldType::InputText, &dashDecalName});
     fields.push_back({"Dash decal disappear", InspectorField::FieldType::Float, &dashDecalTimer, 0.0f, 20.0f});
@@ -169,8 +168,12 @@ bool CuChulainn::Init()
     }
 
     chargedAttackCollider = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(chargedAttackName);
-    if (!chargedAttackCollider) GLOG("[WARNING] No ultimate found for CuChualin")
+    if (!chargedAttackCollider) GLOG("[WARNING] No charge attack found for CuChualin")
     else chargedAttackCollider->SetEnabled(false);
+
+    healKnockback = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(healKnockbackName);
+    if (!healKnockback) GLOG("[WARNING] No heal knockback found for CuChualin")
+    else healKnockback->SetEnabled(false);
 
     ultimateObject = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(ultimateName);
     if (!ultimateObject) GLOG("[WARNING] No ultimate found for CuChulain")
@@ -337,6 +340,7 @@ void CuChulainn::HandleState(float deltaTime)
             if (state == CharacterStates::ULTIMATE && ultimateObject->GetComponent<AnimationComponent*>()->IsPlaying())
                 return;
             if (state == CharacterStates::CHARGED_ATTACK && meleeTrailObject) meleeTrailObject->SetEnabled(false);
+            if (state == CharacterStates::HEAL) healKnockback->SetEnabled(false);
             state = CharacterStates::IDLE;
             animComponent->UseTrigger("Idle");
         }
@@ -1036,6 +1040,7 @@ void CuChulainn::UseMushroom()
     if (healVisual) healVisual->SetEnabled(true);
 
     Heal(mushroomHeal);
+    healKnockback->SetEnabled(true);
 
     // UpdateMushroomsUI();
 }
@@ -1115,7 +1120,6 @@ void CuChulainn::ToggleRiastrad()
             clip.animationSpeed *= riastradAnimationsSpeedRatio;
         }
 
-
         // TODO: Remove when VFX
         Resource* res = AppEngine->GetResourcesModule()->RequestResource(playerMaterial);
         if (res)
@@ -1123,7 +1127,7 @@ void CuChulainn::ToggleRiastrad()
             ResourceMaterial* mat = static_cast<ResourceMaterial*>(res);
             float4 newColor       = mat->GetMaterial().diffColor;
             newColor.y            = 0.0f;
-            newColor.x            = 0.0f;
+            newColor.z            = 0.0f;
             mat->SetDiffColor(newColor);
         }
     }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -78,6 +78,7 @@ CuChulainn::CuChulainn(GameObject* parent)
     fields.push_back({"Take mushroom cooldown", InspectorField::FieldType::Float, &takeMushroomCd, 0.0f, 5.0f});
     fields.push_back({"Mushroom healing", InspectorField::FieldType::Int, &mushroomHeal, 0.0f, 5.0f});
     fields.push_back({"Heal knockback object", InspectorField::FieldType::InputText, &healKnockbackName});
+    fields.push_back({"Heal knockback delay", InspectorField::FieldType::Float, &healKnockbackDelay});
 
     fields.push_back({InspectorField::FieldType::Text, (void*)"Riastrad parameters"});
     //fields.push_back({"Riastrad Bar object", InspectorField::FieldType::GameObject, &riastradBar}); // TODO: Fix GameObject field breaks the loading of the ones after
@@ -234,6 +235,7 @@ void CuChulainn::Update(float deltaTime)
     if (character->GetInputDown()) GetInputs();
     Character::Update(deltaTime);
     PerformAttack();
+    if (state == CharacterStates::HEAL) HealKnockback();
     CheckIsFalling();
 
     if (AppEngine->GetDebugDrawModule()->GetDebugOptionValue((int)DebugOptions::RENDER_DEBUG_VISUALS))
@@ -284,11 +286,15 @@ void CuChulainn::OnDamageTaken(int amount)
     if (audio) audio->EmitEvent(AK::EVENTS::PLAY_SFX_MC_HURT);
     AddRiastrad(riastradOnDamageTaken);
 
-    if (state == CharacterStates::CHARGING)
+    if (state == CharacterStates::CHARGING || state == CharacterStates::IDLE ||
+        state == CharacterStates::RUN)
     {
-        character->EnableMovement(true);
-        state = CharacterStates::IDLE;
-        if (animComponent) animComponent->UseTrigger("Idle");
+        state = CharacterStates::HURT;
+        if (animComponent)
+        {
+            animComponent->UseTrigger("Hurt");
+            character->EnableMovement(false);
+        }
     }
 
     // TODO: Test if hitstop when hit feels nice
@@ -328,7 +334,7 @@ void CuChulainn::HandleState(float deltaTime)
     else if (state != CharacterStates::BASIC_ATTACK && !character->IsDashing() && state != CharacterStates::RESPAWN &&
              state != CharacterStates::AIM && state != CharacterStates::FALL && state != CharacterStates::ULTIMATE &&
              state != CharacterStates::CHARGED_ATTACK && state != CharacterStates::CHARGING &&
-             state != CharacterStates::HEAL && state != CharacterStates::TRANSFORM)
+             state != CharacterStates::HEAL && state != CharacterStates::TRANSFORM && state != CharacterStates::HURT)
         Move();
 
     // When finished animation, go back to idle state
@@ -501,7 +507,8 @@ bool CuChulainn::CanDash() const
     bool canDash = dashTimer <= 0 && state != CharacterStates::AIM && !isAttacking && state != CharacterStates::FALL &&
                    state != CharacterStates::RESPAWN && state != CharacterStates::ULTIMATE &&
                    state != CharacterStates::CHARGED_ATTACK && state != CharacterStates::TAKE_MUSHROOM &&
-                   state != CharacterStates::HEAL && !isCursed && state != CharacterStates::TRANSFORM;
+                   state != CharacterStates::HEAL && !isCursed && state != CharacterStates::TRANSFORM &&
+                   state != CharacterStates::HURT;
 
     if (canDash && state == CharacterStates::BASIC_ATTACK) canDash = comboBufferTimer > 0.0f;
 
@@ -514,7 +521,7 @@ bool CuChulainn::CanAttack() const
            state != CharacterStates::RESPAWN && comboCounter <= 1 && attackCdTimer <= 0.0f &&
            state != CharacterStates::ULTIMATE && state != CharacterStates::CHARGED_ATTACK &&
            state != CharacterStates::CHARGING && state != CharacterStates::TAKE_MUSHROOM &&
-           state != CharacterStates::HEAL && state != CharacterStates::TRANSFORM;
+           state != CharacterStates::HEAL && state != CharacterStates::TRANSFORM && state != CharacterStates::HURT;
 }
 
 bool CuChulainn::CanUltimate() const
@@ -522,7 +529,8 @@ bool CuChulainn::CanUltimate() const
     bool canUltimate = state != CharacterStates::DASH && !isAttacking && state != CharacterStates::FALL &&
                        state != CharacterStates::RESPAWN && ultimateCdTimer <= 0.0f &&
                        state != CharacterStates::CHARGED_ATTACK && state != CharacterStates::TAKE_MUSHROOM &&
-                       state != CharacterStates::HEAL && state != CharacterStates::TRANSFORM;
+                       state != CharacterStates::HEAL && state != CharacterStates::TRANSFORM &&
+                       state != CharacterStates::HURT;
 
     if (canUltimate && state == CharacterStates::BASIC_ATTACK) canUltimate = comboBufferTimer > 0.0f;
 
@@ -533,7 +541,8 @@ bool CuChulainn::CanTakeMushroom() const
 {
     return state != CharacterStates::DASH && !isAttacking && state != CharacterStates::AIM &&
            state != CharacterStates::RESPAWN && state != CharacterStates::DEATH && state != CharacterStates::FALL &&
-           state != CharacterStates::ULTIMATE && state != CharacterStates::HEAL && state != CharacterStates::TRANSFORM;
+           state != CharacterStates::ULTIMATE && state != CharacterStates::HEAL &&
+           state != CharacterStates::TRANSFORM && state != CharacterStates::HURT;
 }
 
 bool CuChulainn::CanHeal() const
@@ -542,7 +551,7 @@ bool CuChulainn::CanHeal() const
            state != CharacterStates::RESPAWN && state != CharacterStates::DEATH && state != CharacterStates::FALL &&
            state != CharacterStates::ULTIMATE && state != CharacterStates::TAKE_MUSHROOM &&
            state != CharacterStates::CHARGED_ATTACK && state != CharacterStates::CHARGING && mushrooms > 0 &&
-           !isHealing && state != CharacterStates::TRANSFORM;
+           !isHealing && state != CharacterStates::TRANSFORM && state != CharacterStates::HURT;
 }
 
 bool CuChulainn::CanAim() const
@@ -551,7 +560,7 @@ bool CuChulainn::CanAim() const
            state != CharacterStates::FALL && state != CharacterStates::RESPAWN && state != CharacterStates::ULTIMATE &&
            state != CharacterStates::CHARGED_ATTACK && state != CharacterStates::CHARGING &&
            state != CharacterStates::TAKE_MUSHROOM && state != CharacterStates::HEAL &&
-           state != CharacterStates::TRANSFORM;
+           state != CharacterStates::TRANSFORM && state != CharacterStates::HURT;
 }
 
 bool CuChulainn::CanChargeAttack() const
@@ -560,7 +569,7 @@ bool CuChulainn::CanChargeAttack() const
                            state != CharacterStates::RESPAWN && state != CharacterStates::ULTIMATE &&
                            state != CharacterStates::AIM && state != CharacterStates::CHARGED_ATTACK &&
                            state != CharacterStates::TAKE_MUSHROOM && state != CharacterStates::HEAL &&
-                           state != CharacterStates::TRANSFORM;
+                           state != CharacterStates::TRANSFORM && state != CharacterStates::HURT;
 
     if (canChargeAttack && state == CharacterStates::BASIC_ATTACK) canChargeAttack = comboBufferTimer > 0.0f;
 
@@ -576,7 +585,7 @@ bool CuChulainn::CanTransform() const
                        state != CharacterStates::FALL && state != CharacterStates::RESPAWN &&
                        state != CharacterStates::ULTIMATE && state != CharacterStates::AIM &&
                        state != CharacterStates::CHARGED_ATTACK && state != CharacterStates::TAKE_MUSHROOM &&
-                       state != CharacterStates::HEAL && state != CharacterStates::TRANSFORM;
+            state != CharacterStates::HEAL && state != CharacterStates::TRANSFORM && state != CharacterStates::HURT;
 
         if (canTransform && state == CharacterStates::BASIC_ATTACK) canTransform = comboBufferTimer > 0.0f;
     }
@@ -721,6 +730,7 @@ void CuChulainn::UpdateTimers(float deltaTime)
     if (state == CharacterStates::CHARGED_ATTACK) chargedAttackTimer += deltaTime;
     if (state == CharacterStates::IDLE) idleTimer += deltaTime;
     if (state == CharacterStates::RUN) runTimer += deltaTime;
+    if (state == CharacterStates::HEAL) healTimer += deltaTime;
 
     if (state == CharacterStates::DASH) isInvulnerable = true;
 
@@ -1101,9 +1111,17 @@ void CuChulainn::UseMushroom()
     if (healVisual) healVisual->SetEnabled(true);
 
     Heal(mushroomHeal);
-    if (healKnockback) healKnockback->SetEnabled(true);
+    healTimer = 0.0f;
 
     // UpdateMushroomsUI();
+}
+
+void CuChulainn::HealKnockback()
+{
+    if (healTimer > healKnockbackDelay && !healKnockback->IsEnabled())
+    {
+        healKnockback->SetEnabled(true);
+    }
 }
 
 void CuChulainn::UpdateHealthBarUI()

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -9,22 +9,24 @@
 #include "GameObject.h"
 #include "GameTimer.h"
 #include "InputModule.h"
+#include "MovingUVTransparent.h"
 #include "Projectile.h"
-#include "ResourceMaterial.h"
 #include "RaycastController.h"
+#include "ResourceMaterial.h"
 #include "ResourceStateMachine.h"
 #include "ResourcesModule.h"
 #include "Scene.h"
 #include "SceneModule.h"
 #include "ScriptComponent.h"
+#include "ShaderScriptComponent.h"
 #include "Standalone/AnimationComponent.h"
 #include "Standalone/Audio/AudioSourceComponent.h"
 #include "Standalone/CharacterControllerComponent.h"
+#include "Standalone/MeshComponent.h"
 #include "Standalone/Physics/CapsuleColliderComponent.h"
 #include "Standalone/Physics/SphereColliderComponent.h"
 #include "Standalone/UI/ImageComponent.h"
 #include "Standalone/UI/Transform2DComponent.h"
-#include "GameTimer.h"
 
 #include "Math/Quat.h"
 #include "SDL.h"
@@ -81,7 +83,8 @@ CuChulainn::CuChulainn(GameObject* parent)
     fields.push_back({"Heal knockback delay", InspectorField::FieldType::Float, &healKnockbackDelay});
 
     fields.push_back({InspectorField::FieldType::Text, (void*)"Riastrad parameters"});
-    //fields.push_back({"Riastrad Bar object", InspectorField::FieldType::GameObject, &riastradBar}); // TODO: Fix GameObject field breaks the loading of the ones after
+    // fields.push_back({"Riastrad Bar object", InspectorField::FieldType::GameObject, &riastradBar}); // TODO: Fix
+    // GameObject field breaks the loading of the ones after
     fields.push_back({"Riastrad duration", InspectorField::FieldType::Float, &riastradDuration, 0.0f, 100.0f});
     fields.push_back({"Riastrad movement speed", InspectorField::FieldType::Float, &riastradMovementSpeed, 0.0f, 20.0f}
     );
@@ -91,6 +94,16 @@ CuChulainn::CuChulainn(GameObject* parent)
     fields.push_back({"Riastrad on damage taken", InspectorField::FieldType::Int, &riastradOnDamageTaken, 0, 100});
     fields.push_back({"Riastrad on enemy hit", InspectorField::FieldType::Int, &riastradOnHit, 0, 100});
     fields.push_back({"Riastrad on enemy defeated", InspectorField::FieldType::Int, &riastradOnEnemyDeath, 0, 100});
+    fields.push_back({"Transform VFX Delay", InspectorField::FieldType::Float, &transformVfxDelay, 0.0f, 20.0f});
+    fields.push_back({"Riastrad VFX burst", InspectorField::FieldType::InputText, &riastradBurstName});
+    fields.push_back({"Riastrad VFX blur", InspectorField::FieldType::InputText, &riastradBlurName});
+    fields.push_back({"Riastrad VFX halo", InspectorField::FieldType::InputText, &riastradHaloName});
+    fields.push_back({"Riastrad VFX sphere", InspectorField::FieldType::InputText, &riastradSphereName});
+    fields.push_back({"Riastrad VFX crack", InspectorField::FieldType::InputText, &riastradCrackName});
+    fields.push_back({"Riastrad VFX waring", InspectorField::FieldType::InputText, &riastradWaringName});
+    fields.push_back({"Riastrad VFX smoke 1", InspectorField::FieldType::InputText, &riastradSmoke1Name});
+    fields.push_back({"Riastrad VFX smoke 2", InspectorField::FieldType::InputText, &riastradSmoke2Name});
+    fields.push_back({"Riastrad VFX smoke 3", InspectorField::FieldType::InputText, &riastradSmoke3Name});
 
     fields.push_back({InspectorField::FieldType::Text, (void*)"VFX"});
     fields.push_back({"Aim shadow object", InspectorField::FieldType::InputText, &aimShadowName});
@@ -210,7 +223,42 @@ bool CuChulainn::Init()
 
     riastradVfx = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(riastradVfxName);
     if (!riastradVfx) GLOG("[WARNING] No riastrad VFX found for CuChulain")
-    else riastradVfx->SetEnabled(false);
+
+    riastradBurst = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(riastradBurstName);
+    if (!riastradBurst) GLOG("[WARNING] No riastrad Burst VFX found for CuChulain")
+    else riastradBurst->SetEnabled(false);
+
+    riastradBlur = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(riastradBlurName);
+    if (!riastradBlur) GLOG("[WARNING] No riastrad Bñur VFX found for CuChulain")
+    else riastradBlur->SetEnabled(false);
+
+    riastradHalo = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(riastradHaloName);
+    if (!riastradHalo) GLOG("[WARNING] No riastrad Halo VFX found for CuChulain")
+    else riastradHalo->SetEnabled(false);
+
+    riastradSphere = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(riastradSphereName);
+    if (!riastradSphere) GLOG("[WARNING] No riastrad Sphere VFX found for CuChulain")
+    else riastradSphere->SetEnabled(false);
+
+    riastradCrack = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(riastradCrackName);
+    if (!riastradCrack) GLOG("[WARNING] No riastrad Sphere VFX found for CuChulain")
+    else riastradCrack->SetEnabled(false);
+
+    riastradWaring = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(riastradWaringName);
+    if (!riastradWaring) GLOG("[WARNING] No riastrad Sphere VFX found for CuChulain")
+    else riastradWaring->SetEnabled(false);
+
+    riastradSmoke1 = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(riastradSmoke1Name);
+    if (!riastradSmoke1) GLOG("[WARNING] No riastrad Smoke 1 VFX found for CuChulain")
+    else riastradSmoke1->SetEnabled(false);
+
+    riastradSmoke2 = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(riastradSmoke2Name);
+    if (!riastradSmoke2) GLOG("[WARNING] No riastrad Smoke 2 VFX found for CuChulain")
+    else riastradSmoke2->SetEnabled(false);
+
+    riastradSmoke3 = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(riastradSmoke3Name);
+    if (!riastradSmoke3) GLOG("[WARNING] No riastrad Smoke 3 VFX found for CuChulain")
+    else riastradSmoke3->SetEnabled(false);
 
     audio = parent->GetComponent<AudioSourceComponent*>();
     if (!audio) GLOG("[WARNING] CuChulainn: No audio component found");
@@ -235,7 +283,14 @@ void CuChulainn::Update(float deltaTime)
     if (character->GetInputDown()) GetInputs();
     Character::Update(deltaTime);
     PerformAttack();
-    if (state == CharacterStates::HEAL) HealKnockback();
+    if (state == CharacterStates::HEAL && healTimer > healKnockbackDelay && !healKnockback->IsEnabled())
+    {
+        healKnockback->SetEnabled(true);
+    }
+    if (state == CharacterStates::TRANSFORM && transformTimer > transformVfxDelay && !riastradCrack->IsEnabled())
+    {
+        EnableRiastradVfx();
+    }
     CheckIsFalling();
 
     if (AppEngine->GetDebugDrawModule()->GetDebugOptionValue((int)DebugOptions::RENDER_DEBUG_VISUALS))
@@ -286,8 +341,7 @@ void CuChulainn::OnDamageTaken(int amount)
     if (audio) audio->EmitEvent(AK::EVENTS::PLAY_SFX_MC_HURT);
     AddRiastrad(riastradOnDamageTaken);
 
-    if (state == CharacterStates::CHARGING || state == CharacterStates::IDLE ||
-        state == CharacterStates::RUN)
+    if (state == CharacterStates::CHARGING || state == CharacterStates::IDLE || state == CharacterStates::RUN)
     {
         state = CharacterStates::HURT;
         if (animComponent)
@@ -298,7 +352,7 @@ void CuChulainn::OnDamageTaken(int amount)
     }
 
     // TODO: Test if hitstop when hit feels nice
-    //AppEngine->GetGameTimer()->SetTimeScale(0.0f);
+    // AppEngine->GetGameTimer()->SetTimeScale(0.0f);
 }
 
 void CuChulainn::OnHealed(int amount)
@@ -359,9 +413,21 @@ void CuChulainn::HandleState(float deltaTime)
             if (state == CharacterStates::HEAL && healKnockback) healKnockback->SetEnabled(false);
             if (state == CharacterStates::TRANSFORM)
             {
+                transformTimer = 0.0f;
+                chargedAttackCollider->SetEnabled(false);
                 riastradVfx->GetComponent<AnimationComponent*>()->OnStop();
-                riastradVfx->SetEnabled(false);
                 AppEngine->GetGameTimer()->SetTimeScale(1.0f);
+
+                // StopVFX
+                if (riastradBlur) riastradBlur->SetEnabled(false);
+                if (riastradBurst) riastradBurst->SetEnabled(false);
+                if (riastradHalo) riastradHalo->SetEnabled(false);
+                if (riastradSphere) riastradSphere->SetEnabled(false);
+                if (riastradCrack) riastradCrack->SetEnabled(false);
+                if (riastradWaring) riastradWaring->SetEnabled(false);
+                if (riastradSmoke1) riastradSmoke1->SetEnabled(false);
+                if (riastradSmoke2) riastradSmoke2->SetEnabled(false);
+                if (riastradSmoke3) riastradSmoke3->SetEnabled(false);
             }
             state = CharacterStates::IDLE;
             animComponent->UseTrigger("Idle");
@@ -581,10 +647,10 @@ bool CuChulainn::CanTransform() const
     bool canTransform = false;
     if (!isRiastrad)
     {
-        canTransform = riastradMeter == 100 && state != CharacterStates::DASH && !isAttacking &&
-                       state != CharacterStates::FALL && state != CharacterStates::RESPAWN &&
-                       state != CharacterStates::ULTIMATE && state != CharacterStates::AIM &&
-                       state != CharacterStates::CHARGED_ATTACK && state != CharacterStates::TAKE_MUSHROOM &&
+        canTransform =
+            riastradMeter == 100 && state != CharacterStates::DASH && !isAttacking && state != CharacterStates::FALL &&
+            state != CharacterStates::RESPAWN && state != CharacterStates::ULTIMATE && state != CharacterStates::AIM &&
+            state != CharacterStates::CHARGED_ATTACK && state != CharacterStates::TAKE_MUSHROOM &&
             state != CharacterStates::HEAL && state != CharacterStates::TRANSFORM && state != CharacterStates::HURT;
 
         if (canTransform && state == CharacterStates::BASIC_ATTACK) canTransform = comboBufferTimer > 0.0f;
@@ -731,6 +797,7 @@ void CuChulainn::UpdateTimers(float deltaTime)
     if (state == CharacterStates::IDLE) idleTimer += deltaTime;
     if (state == CharacterStates::RUN) runTimer += deltaTime;
     if (state == CharacterStates::HEAL) healTimer += deltaTime;
+    if (state == CharacterStates::TRANSFORM) transformTimer += deltaTime;
 
     if (state == CharacterStates::DASH) isInvulnerable = true;
 
@@ -1116,14 +1183,6 @@ void CuChulainn::UseMushroom()
     // UpdateMushroomsUI();
 }
 
-void CuChulainn::HealKnockback()
-{
-    if (healTimer > healKnockbackDelay && !healKnockback->IsEnabled())
-    {
-        healKnockback->SetEnabled(true);
-    }
-}
-
 void CuChulainn::UpdateHealthBarUI()
 {
     if (!healthImageComponent || healthBarTextures.empty()) return;
@@ -1194,28 +1253,50 @@ void CuChulainn::ToggleRiastrad()
         character->SetMaxSpeed(riastradMovementSpeed);
         Heal(maxHealth);
 
-        riastradVfx->SetEnabled(true);
-        riastradVfx->GetComponent<AnimationComponent*>()->OnPlay(false);
-        state          = CharacterStates::TRANSFORM;
+        state = CharacterStates::TRANSFORM;
         character->EnableMovement(false);
-        AppEngine->GetGameTimer()->SetTimeScale(0.5f);
+        // AppEngine->GetGameTimer()->SetTimeScale(0.5f);
 
         if (animComponent) animComponent->UseTrigger("Transform");
-
         for (Clip& clip : animComponent->GetResourceStateMachine()->clips)
         {
             clip.animationSpeed *= riastradAnimationsSpeedRatio;
         }
 
-        // TODO: Remove when VFX
-        Resource* res = AppEngine->GetResourcesModule()->RequestResource(playerMaterial);
-        if (res)
+        // Starting VFX
+        if (riastradVfx)
         {
-            ResourceMaterial* mat = static_cast<ResourceMaterial*>(res);
-            float4 newColor       = mat->GetMaterial().diffColor;
-            newColor.y            = 0.0f;
-            newColor.z            = 0.0f;
-            mat->SetDiffColor(newColor);
+            riastradVfx->GetComponent<AnimationComponent*>()->OnPlay(true);
+        }
+        if (riastradSmoke1)
+        {
+            riastradSmoke1->SetEnabled(true);
+            riastradSmoke1->GetComponent<MeshComponent*>()->SetEnabled(false);
+            riastradSmoke1->GetComponent<ShaderScriptComponent*>()->GetScriptByType<MovingUVTransparent>()->Reset();
+        }
+        if (riastradSmoke2)
+        {
+            riastradSmoke2->SetEnabled(true);
+            riastradSmoke2->GetComponent<MeshComponent*>()->SetEnabled(false);
+            riastradSmoke2->GetComponent<ShaderScriptComponent*>()->GetScriptByType<MovingUVTransparent>()->Reset();
+        }
+        if (riastradSmoke3)
+        {
+            riastradSmoke3->SetEnabled(true);
+            riastradSmoke3->GetComponent<MeshComponent*>()->SetEnabled(false);
+            riastradSmoke3->GetComponent<ShaderScriptComponent*>()->GetScriptByType<MovingUVTransparent>()->Reset();
+        }
+        if (riastradSphere)
+        {
+            riastradSphere->SetEnabled(true);
+            riastradSphere->GetComponent<MeshComponent*>()->SetEnabled(false);
+            riastradSphere->GetComponent<ShaderScriptComponent*>()->GetScriptByType<MovingUVTransparent>()->Reset();
+        }
+        if (riastradHalo)
+        {
+            riastradHalo->SetEnabled(true);
+            riastradHalo->GetComponent<MeshComponent*>()->SetEnabled(false);
+            riastradHalo->GetComponent<ShaderScriptComponent*>()->GetScriptByType<MovingUVTransparent>()->Reset();
         }
     }
     else
@@ -1234,6 +1315,41 @@ void CuChulainn::ToggleRiastrad()
             newColor              = float4::one;
             mat->SetDiffColor(newColor);
         }
+    }
+}
+
+void CuChulainn::EnableRiastradVfx()
+{
+    AppEngine->GetGameTimer()->SetTimeScale(0.5f);
+
+    // Reuse charge attack collider (If needed different size, create another)
+    chargedAttackCollider->SetEnabled(true);
+
+    // TODO: Remove when VFX. For now it turns red
+    Resource* res = AppEngine->GetResourcesModule()->RequestResource(playerMaterial);
+    if (res)
+    {
+        ResourceMaterial* mat = static_cast<ResourceMaterial*>(res);
+        float4 newColor       = mat->GetMaterial().diffColor;
+        newColor.y            = 0.0f;
+        newColor.z            = 0.0f;
+        mat->SetDiffColor(newColor);
+    }
+
+    // Stomp VFX
+    if (riastradCrack) riastradCrack->SetEnabled(true);
+    if (riastradWaring) riastradWaring->SetEnabled(true);
+    if (riastradBurst)
+    {
+        riastradBurst->SetEnabled(true);
+        riastradBurst->GetComponent<MeshComponent*>()->SetEnabled(false);
+        riastradBurst->GetComponent<ShaderScriptComponent*>()->GetScriptByType<MovingUVTransparent>()->Reset();
+    }
+    if (riastradBlur)
+    {
+        riastradBlur->SetEnabled(true);
+        riastradBlur->GetComponent<MeshComponent*>()->SetEnabled(false);
+        riastradBlur->GetComponent<ShaderScriptComponent*>()->GetScriptByType<MovingUVTransparent>()->Reset();
     }
 }
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
@@ -102,11 +102,11 @@ class CuChulainn : public Character
   private:
     CharacterStates state              = CharacterStates::IDLE;
 
-    std::string cameraName             = "";
+    std::string cameraName             = "Camera Pivot";
     GameObject* cameraObject           = nullptr;
     CameraMovement* camera             = nullptr;
 
-    std::string spearName              = "";
+    std::string spearName              = "SpearProjectile";
     Projectile* spear                  = nullptr;
 
     float defaultSpeed                 = 7.0f;
@@ -122,8 +122,8 @@ class CuChulainn : public Character
     float dashBufferTimer              = 0.0f;
 
     // Basic attack
-    std::string meleeVfxName           = "";
-    std::string meleeTrailName         = "";
+    std::string meleeVfxName           = "SpearVFX";
+    std::string meleeTrailName         = "SpearMeleeTrail";
     GameObject* meleeVfxObject         = nullptr;
     GameObject* meleeTrailObject       = nullptr;
     bool desiredAttack                 = false;
@@ -132,7 +132,7 @@ class CuChulainn : public Character
     float comboBufferTimer             = 0.0f;
 
     // CHarged attack
-    std::string chargedAttackName      = "";
+    std::string chargedAttackName      = "Charged";
     GameObject* chargedAttackCollider  = nullptr;
     bool isChargingAttack              = false;
     float chargeTimer                  = 0.0f;
@@ -153,11 +153,11 @@ class CuChulainn : public Character
     float deathTimer                   = 0.5f;
     float aimTimer                     = 0.0f;
 
-    std::string aimShadowName          = "";
+    std::string aimShadowName          = "AimShadow";
     GameObject* aimShadowObject        = nullptr;
 
     // Ultimate
-    std::string ultimateName           = "";
+    std::string ultimateName           = "Ultimate";
     GameObject* ultimateObject         = nullptr;
     bool desiredUltimate               = false;
     int ultimateDamage                 = 0;
@@ -182,7 +182,7 @@ class CuChulainn : public Character
     int riastradOnDamageTaken          = 2;
     int riastradOnHit                  = 5;
     int riastradOnEnemyDeath           = 5;
-    std::string riastradVfxName        = "";
+    std::string riastradVfxName        = "riastrad_all";
     GameObject* riastradVfx            = nullptr;
 
     float3 spawnPos                    = float3::zero;
@@ -207,9 +207,9 @@ class CuChulainn : public Character
     float takeMushroomCdTimer              = 0.0f;
     float takeMushroomCd                   = 0.0f;
 
-    std::string dashTrailName              = "";
+    std::string dashTrailName              = "DashTrail";
     GameObject* dashTrail                  = nullptr;
-    std::string dashDecalName              = "";
+    std::string dashDecalName              = "DashDecal";
     GameObject* dashDecal                  = nullptr;
 
     float dashDecalTimer                   = 5.0f;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
@@ -208,6 +208,8 @@ class CuChulainn : public Character
     bool isHealing                         = false;
     std::string healVisualName             = "";
     GameObject* healVisual                 = nullptr;
+    std::string healKnockbackName          = "";
+    GameObject* healKnockback              = nullptr;
 
     bool isCursed                          = false;
     float curseSpeed                       = 4.0f;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
@@ -232,6 +232,8 @@ class CuChulainn : public Character
     UID dashEmptyImage                     = 0;
     UID ultimateFillImage                  = 0;
     UID ultimateEmptyImage                 = 0;
+
+    float epicTimer                        = 0.0f;
 };
 
 extern CharacterControllerComponent* character;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
@@ -27,6 +27,7 @@ enum class CharacterStates
     TAKE_MUSHROOM,
     HEAL,
     TRANSFORM,
+    HURT
 };
 
 class CuChulainn : public Character
@@ -85,6 +86,7 @@ class CuChulainn : public Character
     void CheckIsFalling();
 
     void UseMushroom();
+    void HealKnockback();
     void ThrowSpear();
     void UltimateAttack();
     void Dash();
@@ -215,12 +217,16 @@ class CuChulainn : public Character
     float dashDecalTimer                   = 5.0f;
     float dashDecalBufferTimer             = 0.0f;
 
+    // Heal
     bool isHealing                         = false;
     std::string healVisualName             = "";
     GameObject* healVisual                 = nullptr;
     std::string healKnockbackName          = "";
     GameObject* healKnockback              = nullptr;
+    float healTimer                        = 0.0f;
+    float healKnockbackDelay               = 0.0f;
 
+    // Curse
     bool isCursed                          = false;
     float curseSpeed                       = 4.0f;
     float curseDuration                    = 5.0f;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
@@ -191,8 +191,8 @@ class CuChulainn : public Character
     std::string riastradBlurName       = "mesh_blur";
     std::string riastradHaloName       = "mesh_halo";
     std::string riastradSphereName     = "mesh_sphere_glow";
-    std::string riastradCrackName      = "mesh_sphere_glow";
-    std::string riastradWaringName     = "mesh_sphere_glow";
+    std::string riastradCrackName      = "mesh_crack";
+    std::string riastradWaringName     = "mesh_warning";
     std::string riastradSmoke1Name     = "mesh_smoke_a";
     std::string riastradSmoke2Name     = "mesh_smoke_a.001";
     std::string riastradSmoke3Name     = "mesh_smoke_a.002";

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
@@ -92,6 +92,8 @@ class CuChulainn : public Character
     void ChargeAttack();
     void ToggleRiastrad();
     void AddRiastrad(int amount);
+    void StartCurse();
+    void EndCurse();
 
     void SetPosition(const float3& position);
     const std::string GetLogicStateName();
@@ -206,6 +208,12 @@ class CuChulainn : public Character
     bool isHealing                         = false;
     std::string healVisualName             = "";
     GameObject* healVisual                 = nullptr;
+
+    bool isCursed                          = false;
+    float curseSpeed                       = 4.0f;
+    float curseDuration                    = 5.0f;
+    float curseTimer                       = 0.0f;
+    UID playerMaterial                     = 0;
 
     // Images UIDs
     UID dashFillImage                      = 0;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
@@ -85,8 +85,8 @@ class CuChulainn : public Character
     void LookAtLeftStick();
     void CheckIsFalling();
 
+    void EnableRiastradVfx();
     void UseMushroom();
-    void HealKnockback();
     void ThrowSpear();
     void UltimateAttack();
     void Dash();
@@ -177,6 +177,8 @@ class CuChulainn : public Character
     bool isRiastrad                    = false;
     bool desiredTransform              = false;
     float transformBufferTimer         = 0.0f;
+    float transformTimer               = 0.0f;
+    float transformVfxDelay            = 0.35f;
     float riastradTimer                = 0.0f;
     float riastradDuration             = 5.0f;
     float riastradMovementSpeed        = 12.0f;
@@ -185,7 +187,25 @@ class CuChulainn : public Character
     int riastradOnHit                  = 5;
     int riastradOnEnemyDeath           = 5;
     std::string riastradVfxName        = "riastrad_all";
+    std::string riastradBurstName      = "mesh_brust";
+    std::string riastradBlurName       = "mesh_blur";
+    std::string riastradHaloName       = "mesh_halo";
+    std::string riastradSphereName     = "mesh_sphere_glow";
+    std::string riastradCrackName      = "mesh_sphere_glow";
+    std::string riastradWaringName     = "mesh_sphere_glow";
+    std::string riastradSmoke1Name     = "mesh_smoke_a";
+    std::string riastradSmoke2Name     = "mesh_smoke_a.001";
+    std::string riastradSmoke3Name     = "mesh_smoke_a.002";
     GameObject* riastradVfx            = nullptr;
+    GameObject* riastradBurst          = nullptr;
+    GameObject* riastradBlur           = nullptr;
+    GameObject* riastradHalo           = nullptr;
+    GameObject* riastradSphere         = nullptr;
+    GameObject* riastradCrack         = nullptr;
+    GameObject* riastradWaring         = nullptr;
+    GameObject* riastradSmoke1         = nullptr;
+    GameObject* riastradSmoke2         = nullptr;
+    GameObject* riastradSmoke3         = nullptr;
 
     float3 spawnPos                    = float3::zero;
     AudioSourceComponent* audio        = nullptr;
@@ -221,7 +241,7 @@ class CuChulainn : public Character
     bool isHealing                         = false;
     std::string healVisualName             = "";
     GameObject* healVisual                 = nullptr;
-    std::string healKnockbackName          = "";
+    std::string healKnockbackName          = "Heal Knockback";
     GameObject* healKnockback              = nullptr;
     float healTimer                        = 0.0f;
     float healKnockbackDelay               = 0.0f;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
@@ -26,6 +26,7 @@ enum class CharacterStates
     CHARGED_ATTACK,
     TAKE_MUSHROOM,
     HEAL,
+    TRANSFORM,
 };
 
 class CuChulainn : public Character
@@ -111,6 +112,7 @@ class CuChulainn : public Character
     float defaultSpeed                 = 7.0f;
     float inputBuffer                  = 0.5f;
 
+    // Dash
     float3 lastDashStartPos            = float3::zero;
     bool isDashing                     = false;
     bool wasDashing                    = false;
@@ -119,6 +121,7 @@ class CuChulainn : public Character
     bool desiredDash                   = false;
     float dashBufferTimer              = 0.0f;
 
+    // Basic attack
     std::string meleeVfxName           = "";
     std::string meleeTrailName         = "";
     GameObject* meleeVfxObject         = nullptr;
@@ -128,6 +131,7 @@ class CuChulainn : public Character
     int comboCounter                   = -1;
     float comboBufferTimer             = 0.0f;
 
+    // CHarged attack
     std::string chargedAttackName      = "";
     GameObject* chargedAttackCollider  = nullptr;
     bool isChargingAttack              = false;
@@ -152,6 +156,7 @@ class CuChulainn : public Character
     std::string aimShadowName          = "";
     GameObject* aimShadowObject        = nullptr;
 
+    // Ultimate
     std::string ultimateName           = "";
     GameObject* ultimateObject         = nullptr;
     bool desiredUltimate               = false;
@@ -164,6 +169,7 @@ class CuChulainn : public Character
     float ultimateHitboxDuration       = 0.0f;
     float ultimateAnimationDelay       = 0.0f;
 
+    // Riastrad
     GameObject* riastradBar            = nullptr;
     int riastradMeter                  = 0;
     bool isRiastrad                    = false;
@@ -176,6 +182,8 @@ class CuChulainn : public Character
     int riastradOnDamageTaken          = 2;
     int riastradOnHit                  = 5;
     int riastradOnEnemyDeath           = 5;
+    std::string riastradVfxName        = "";
+    GameObject* riastradVfx            = nullptr;
 
     float3 spawnPos                    = float3::zero;
     AudioSourceComponent* audio        = nullptr;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MovingUVTransparent.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MovingUVTransparent.cpp
@@ -24,6 +24,7 @@ MovingUVTransparent::MovingUVTransparent(GameObject* parent) : Script(parent)
 {
     fields.push_back({"Animation Speed", InspectorField::FieldType::Float, &animationSpeed});
     fields.push_back({"Moving UV Direction", InspectorField::FieldType::Vec2, &uvOffsetDirection, -1.f, 1.f});
+    fields.push_back({"Double sided", InspectorField::FieldType::Bool, &isDoubleSided});
 }
 
 MovingUVTransparent::~MovingUVTransparent()
@@ -150,7 +151,9 @@ void MovingUVTransparent::Render(float deltaTime, CameraComponent* cameraComp)
 
         glBindVertexArray(vao);
 
+        if (isDoubleSided) glDisable(GL_CULL_FACE);
         glDrawElements(GL_TRIANGLES, indexCount, GL_UNSIGNED_INT, 0);
+        if (isDoubleSided) glEnable(GL_CULL_FACE);
 
         glBindVertexArray(0);
     }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MovingUVTransparent.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MovingUVTransparent.cpp
@@ -154,6 +154,7 @@ void MovingUVTransparent::Render(float deltaTime, CameraComponent* cameraComp)
 
         glBindVertexArray(vao);
 
+
         if (isDoubleSided) glDisable(GL_CULL_FACE);
         glDrawElements(GL_TRIANGLES, indexCount, GL_UNSIGNED_INT, 0);
         if (isDoubleSided) glEnable(GL_CULL_FACE);

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MovingUVTransparent.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MovingUVTransparent.h
@@ -25,6 +25,7 @@ class MovingUVTransparent : public Script
     unsigned int materialBuffer  = 0;
 
     bool isAlphaDiscard          = false;
+    bool isDoubleSided           = false;
 
     unsigned int indexCount      = 0;
 

--- a/SobrassadaEngine/UI/EngineEditors/Editor/StateMachineEditor.cpp
+++ b/SobrassadaEngine/UI/EngineEditors/Editor/StateMachineEditor.cpp
@@ -71,6 +71,11 @@ bool StateMachineEditor::RenderEditor()
         ShowTriggers();
     }
     ShowTriggersPopup();
+    ImGui::SameLine();
+    if (ImGui::Button("DELETE ALL CLIPS"))
+    {
+        resource->RemoveAllClips();
+    }
 
     const State* activeState = resource->GetDefaultState();
     for (const auto& pair : graph->getNodes())


### PR DESCRIPTION
This PR adds various features, most of them for the player:

- The player has new animations: heal, hurt and transform, as well as some other have been updated like the running one.
- Added vfx when transforming to riastrad. The player also turns red (this is provisional, to have visual feedback). I also added a little slow-motion in a part of the animation, if you don't like it tell me and I can remove it.
- Also added the "cursed" state, where the player moves slower and cannot dash. This will be triggered by the changeling, for now it's triggered pressing the F9 key. It also changes the color of the character for now.
- Added a knockback area when healing and transforming.

Some other new things:
- Now the MovingUVTransparent has a double-sided check in the inspector.
- Added a button to remove all clips from a state machine, because old ones were never deleted even if their clips no longer existed.
- Now animations get the GameTimer deltaTime if the engine is in play mode, so animations are affected by pausing / scaling the time.

TO TEST: Go to the new-player-vfx branch of the game repo, and chec kthe things listed above work properly. To get full riastrad bar press F8

The healing VFX will be added in a separate PR, because they will need new custom shaders.