### PR TITLE
Player progression (lock & unlock skills) final Player THO-777

### DIFF
--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -1129,6 +1129,14 @@ void CuChulainn::OnEnemyDefeated()
     AddRiastrad(riastradOnEnemyDeath);
 }
 
+void CuChulainn::ActivateAbility(std::string& abilityName)
+{
+    std::transform(abilityName.begin(), abilityName.end(), abilityName.begin(), ::tolower);
+
+    if (abilityName == "dash") dashUnlocked = true;
+    else if (abilityName == "ultimate") unlockUltimate = true;
+}
+
 const std::string CuChulainn::GetLogicStateName()
 {
     switch (state)

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -96,6 +96,9 @@ CuChulainn::CuChulainn(GameObject* parent)
     fields.push_back({"Dash empty icon", InspectorField::FieldType::Resource, &dashEmptyImage});
     fields.push_back({"Ultimate filled icon", InspectorField::FieldType::Resource, &ultimateFillImage});
     fields.push_back({"Ultimate empty icon", InspectorField::FieldType::Resource, &ultimateEmptyImage});
+
+    //Unlocked abilities
+    fields.push_back({"Dash Activated", InspectorField::FieldType::Bool, &dashUnlocked});
 }
 
 bool CuChulainn::Init()

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -467,7 +467,7 @@ void CuChulainn::GetInputs()
 
 bool CuChulainn::CanDash() const
 {
-    //if (!dashUnlocked) return false; //When tutorial map is correctly fixed, put this to make progression
+    if (!dashUnlocked) return false; //When tutorial map is correctly fixed, put this to make progression
 
     bool canDash = dashTimer <= 0 && state != CharacterStates::AIM && !isAttacking && state != CharacterStates::FALL &&
                    state != CharacterStates::RESPAWN && state != CharacterStates::ULTIMATE &&

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -44,6 +44,11 @@ CuChulainn::CuChulainn(GameObject* parent)
     fields.push_back({"Range attack cooldown", InspectorField::FieldType::Float, &throwCooldown, 0.0f, 2.0f});
     fields.push_back({"Dash cooldown", InspectorField::FieldType::Float, &dashCooldown, 0.0f, 5.0f});
 
+    // Unlocked abilities
+    fields.push_back({InspectorField::FieldType::Text, (void*)"Unlocked Abilities from Start"});
+    fields.push_back({"Dash unlocked", InspectorField::FieldType::Bool, &dashUnlocked});
+    fields.push_back({"Ultimate unlocked", InspectorField::FieldType::Bool, &unlockUltimate});
+
     fields.push_back({InspectorField::FieldType::Text, (void*)"Ultimate parameters"});
     fields.push_back({"Ultimate object", InspectorField::FieldType::InputText, &ultimateName});
     fields.push_back({"Ultimate damage", InspectorField::FieldType::Int, &ultimateDamage, 0.0f, 5.0f});
@@ -97,8 +102,6 @@ CuChulainn::CuChulainn(GameObject* parent)
     fields.push_back({"Ultimate filled icon", InspectorField::FieldType::Resource, &ultimateFillImage});
     fields.push_back({"Ultimate empty icon", InspectorField::FieldType::Resource, &ultimateEmptyImage});
 
-    //Unlocked abilities
-    fields.push_back({"Dash Activated", InspectorField::FieldType::Bool, &dashUnlocked});
 }
 
 bool CuChulainn::Init()

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -467,6 +467,8 @@ void CuChulainn::GetInputs()
 
 bool CuChulainn::CanDash() const
 {
+    //if (!dashUnlocked) return false; //When tutorial map is correctly fixed, put this to make progression
+
     bool canDash = dashTimer <= 0 && state != CharacterStates::AIM && !isAttacking && state != CharacterStates::FALL &&
                    state != CharacterStates::RESPAWN && state != CharacterStates::ULTIMATE &&
                    state != CharacterStates::CHARGED_ATTACK && state != CharacterStates::TAKE_MUSHROOM &&

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -49,7 +49,7 @@ CuChulainn::CuChulainn(GameObject* parent)
     // Unlocked abilities
     fields.push_back({InspectorField::FieldType::Text, (void*)"Unlocked Abilities from Start"});
     fields.push_back({"Dash unlocked", InspectorField::FieldType::Bool, &dashUnlocked});
-    fields.push_back({"Ultimate unlocked", InspectorField::FieldType::Bool, &unlockUltimate});
+    fields.push_back({"Ultimate unlocked", InspectorField::FieldType::Bool, &ultimateUnlocked});
 
     fields.push_back({InspectorField::FieldType::Text, (void*)"Ultimate parameters"});
     fields.push_back({"Ultimate object", InspectorField::FieldType::InputText, &ultimateName});
@@ -1176,7 +1176,7 @@ void CuChulainn::ActivateAbility(std::string& abilityName)
     std::transform(abilityName.begin(), abilityName.end(), abilityName.begin(), ::tolower);
 
     if (abilityName == "dash") dashUnlocked = true;
-    else if (abilityName == "ultimate") unlockUltimate = true;
+    else if (abilityName == "ultimate") ultimateUnlocked = true;
 }
 
 const std::string CuChulainn::GetLogicStateName()

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
@@ -59,6 +59,8 @@ class CuChulainn : public Character
     void OnEnemyHit();
     void OnEnemyDefeated();
 
+    void ActivateAbility(std::string& abilityName);
+
   private:
     void OnDeath() override;
     void OnDamageTaken(int amount) override;
@@ -162,6 +164,7 @@ class CuChulainn : public Character
     float ultimateHitboxDelay          = 0.0f;
     float ultimateHitboxDuration       = 0.0f;
     float ultimateAnimationDelay       = 0.0f;
+    bool unlockUltimate                = false;
 
     GameObject* riastradBar            = nullptr;
     int riastradMeter                  = 0;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
@@ -116,6 +116,7 @@ class CuChulainn : public Character
     float dashTimer                    = 0.0f;
     bool desiredDash                   = false;
     float dashBufferTimer              = 0.0f;
+    bool dashUnlocked = false;
 
     std::string meleeVfxName           = "";
     std::string meleeTrailName         = "";

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
@@ -164,7 +164,7 @@ class CuChulainn : public Character
     float ultimateHitboxDelay          = 0.0f;
     float ultimateHitboxDuration       = 0.0f;
     float ultimateAnimationDelay       = 0.0f;
-    bool unlockUltimate                = false;
+    bool ultimateUnlocked              = false;
 
     GameObject* riastradBar            = nullptr;
     int riastradMeter                  = 0;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SpawnUI.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SpawnUI.cpp
@@ -10,7 +10,7 @@
 SpawnUI::SpawnUI(GameObject* parent) : Script(parent)
 {
     fields.push_back({"Object UI Name", InspectorField::FieldType::InputText, &objectUIName});
-    fields.push_back({"Unlocks Ability", InspectorField::FieldType::Bool, &unlockAbility});
+    fields.push_back({"Unlock Ability", InspectorField::FieldType::Bool, &unlockAbility});
     fields.push_back({"Ability Name", InspectorField::FieldType::InputText, &nameAbility});
 }
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SpawnUI.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SpawnUI.cpp
@@ -4,11 +4,14 @@
 #include "SpawnUI.h"
 #include "Standalone/Physics/SphereColliderComponent.h"
 #include "Standalone/UI/ImageComponent.h"
+#include "ScriptComponent.h"
+#include "CuChulainn.h"
 
 SpawnUI::SpawnUI(GameObject* parent) : Script(parent)
 {
     fields.push_back({"Object UI Name", InspectorField::FieldType::InputText, &objectUIName});
     fields.push_back({"Unlocks Ability", InspectorField::FieldType::Bool, &unlockAbility});
+    fields.push_back({"Ability Name", InspectorField::FieldType::InputText, &nameAbility});
 }
 
 bool SpawnUI::Init()
@@ -42,6 +45,8 @@ void SpawnUI::OnCollision(GameObject* otherObject, const float3 collisionNormal,
     // triggers only collision with Player
     if (imageUI) imageUI->SetEnabled(true);
     onCollision = true;
-
+    GameObject* engineGO = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByUID(otherObject->GetUID());
+    
     if (unlockAbility) 
+        engineGO->GetComponent<ScriptComponent*>()->GetScriptByType<CuChulainn>()->ActivateAbility(nameAbility);
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SpawnUI.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SpawnUI.cpp
@@ -8,6 +8,7 @@
 SpawnUI::SpawnUI(GameObject* parent) : Script(parent)
 {
     fields.push_back({"Object UI Name", InspectorField::FieldType::InputText, &objectUIName});
+    fields.push_back({"Keep after collision", InspectorField::FieldType::Bool, &keepAfterCollision});
 }
 
 bool SpawnUI::Init()
@@ -31,7 +32,7 @@ void SpawnUI::Update(float deltaTime)
 {
     if (!trigger || !imageUI) return;
 
-    if (!onCollision) imageUI->SetEnabled(false);
+    if (!onCollision && !keepAfterCollision) imageUI->SetEnabled(false);
 
     onCollision = false;
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SpawnUI.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SpawnUI.cpp
@@ -8,7 +8,7 @@
 SpawnUI::SpawnUI(GameObject* parent) : Script(parent)
 {
     fields.push_back({"Object UI Name", InspectorField::FieldType::InputText, &objectUIName});
-    fields.push_back({"Keep after collision", InspectorField::FieldType::Bool, &keepAfterCollision});
+    fields.push_back({"Unlocks Ability", InspectorField::FieldType::Bool, &unlockAbility});
 }
 
 bool SpawnUI::Init()
@@ -32,7 +32,7 @@ void SpawnUI::Update(float deltaTime)
 {
     if (!trigger || !imageUI) return;
 
-    if (!onCollision && !keepAfterCollision) imageUI->SetEnabled(false);
+    if (!onCollision && !unlockAbility) imageUI->SetEnabled(false);
 
     onCollision = false;
 }
@@ -42,4 +42,6 @@ void SpawnUI::OnCollision(GameObject* otherObject, const float3 collisionNormal,
     // triggers only collision with Player
     if (imageUI) imageUI->SetEnabled(true);
     onCollision = true;
+
+    if (unlockAbility) 
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SpawnUI.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SpawnUI.h
@@ -19,6 +19,6 @@ class SpawnUI : public Script
     ImageComponent* imageUI             = nullptr;
     std::string objectUIName         = "";
     bool onCollision                 = false;
-    bool keepAfterCollision             = false;
     bool unlockAbility                  = false;
+    std::string nameAbility     = "";
 };

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SpawnUI.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SpawnUI.h
@@ -20,4 +20,5 @@ class SpawnUI : public Script
     std::string objectUIName         = "";
     bool onCollision                 = false;
     bool keepAfterCollision             = false;
+    bool unlockAbility                  = false;
 };

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SpawnUI.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SpawnUI.h
@@ -19,4 +19,5 @@ class SpawnUI : public Script
     ImageComponent* imageUI             = nullptr;
     std::string objectUIName         = "";
     bool onCollision                 = false;
+    bool keepAfterCollision             = false;
 };


### PR DESCRIPTION
In order to create some progression, player will have locked some skills from the start. In some specific conditions, player will unlock skills.

The code has been adapted to lock or unlock any skill. In this case only has been implemented dash mechanic with this feature.

To control which skills are unlocked in the level, properties in CuChulain script added to unlock abilities from start. In spawnUI has been added also some properties to activate the skill you want to activate (for UI purposes).

How to test it:
- In The Hound of Ulter repository, go to branch Player progression. Tutorial level and lvl 1 adapted to test this functionality.
- from start, dash UI and dash functionality are locked.
- go to Dash tutorial. This unlocks dash mechanic and UI.
- When changes from tutorial to lvl 1, dash mechanic still being unlocked.


NOTE: take into account that position of player in tutorial and lvl 1 are made to test functionality more easily. 