### PR TITLE
THO-879 Bones in moving uv shaders

### DIFF
--- a/Game/EngineDefaults/Shader/Custom/Fragment/MovingUV_PostL_Fragment.glsl
+++ b/Game/EngineDefaults/Shader/Custom/Fragment/MovingUV_PostL_Fragment.glsl
@@ -8,7 +8,7 @@ out vec4 fragColor;
 
 void main()
 {
-    vec4 texColor = texture2D(myTexture, vec2(uv.x, 1 - uv.y));
+    vec4 texColor = texture2D(myTexture, uv);
     // fragColor = vec4(0, 0, 1.0f, 1.0f);
     fragColor = texColor;
 }

--- a/Game/EngineDefaults/Shader/Custom/Vertex/MovingUV_Light_Vertex.glsl
+++ b/Game/EngineDefaults/Shader/Custom/Vertex/MovingUV_Light_Vertex.glsl
@@ -42,5 +42,5 @@ void main()
     } 
 
     uv = vertexUV + uvOffset;
-    gl_Position =  gl_Position = proj * view * vec4(pos, 1.0f);
+    gl_Position = proj * view * vec4(pos, 1.0f);
 }

--- a/Game/EngineDefaults/Shader/Custom/Vertex/MovingUV_Light_Vertex.glsl
+++ b/Game/EngineDefaults/Shader/Custom/Vertex/MovingUV_Light_Vertex.glsl
@@ -3,11 +3,20 @@ layout(location=0) in vec3 vertexPosition;
 layout(location=1) in vec4 vertexTangent;
 layout(location=2) in vec3 vertexNormal;
 layout(location=3) in vec2 vertexUV;
+layout(location=4) in ivec4 vertexJoint;
+layout(location=5) in vec4 vertexWeights;
 
 layout(location=0) uniform mat4 proj;
 layout(location=1) uniform mat4 view;
 layout(location=2) uniform mat4 model;
 layout(location=3) uniform vec2 uvOffset;
+layout(location=9) uniform bool hasBones;
+layout(location=10) uniform uint boneIndex;
+
+
+readonly layout(std430, row_major, binding = 12) buffer Bones {
+    mat4 palettes[];
+};
 
 out vec3 pos;
 out vec3 normal;
@@ -20,6 +29,17 @@ void main()
     normal = normalMatrix * vertexNormal;
     tangent = vec4(normalMatrix * vertexTangent.xyz, vertexTangent.w);
     pos = vec3(model * vec4(vertexPosition, 1.0));
+
+    if (hasBones) 
+    {
+        mat4 skin    = palettes[boneIndex + vertexJoint[0]] * vertexWeights[0] + palettes[boneIndex + vertexJoint[1]] * vertexWeights[1] +             
+                       palettes[boneIndex + vertexJoint[2]] * vertexWeights[2] + palettes[boneIndex + vertexJoint[3]] * vertexWeights[3];
+        pos          = (skin * vec4(vertexPosition, 1.0)).xyz;
+
+        mat3 skinRot = mat3(skin); // Skin matrix with rotation only
+        normal       = skinRot * vertexNormal;        
+        tangent      = vec4(skinRot * tangent.xyz, tangent.w); 
+    } 
 
     uv = vertexUV + uvOffset;
     gl_Position =  gl_Position = proj * view * vec4(pos, 1.0f);

--- a/Game/EngineDefaults/Shader/Custom/Vertex/MovingUV_PostL_Vertex.glsl
+++ b/Game/EngineDefaults/Shader/Custom/Vertex/MovingUV_PostL_Vertex.glsl
@@ -1,17 +1,37 @@
 #version 460
 
 layout(location=0) in vec3 vertexPosition;
-layout(location=1) in vec2 vertexUV;
+layout(location=1) in vec4 vertexTangent;
+layout(location=2) in vec3 vertexNormal;
+layout(location=3) in vec2 vertexUV;
+layout(location=4) in ivec4 vertexJoint;
+layout(location=5) in vec4 vertexWeights;
 
 layout(location=0) uniform mat4 proj;
 layout(location=1) uniform mat4 view;
 layout(location=2) uniform mat4 model;
 layout(location=3) uniform vec2 uvOffset;
 
+layout(location=9) uniform bool hasBones;
+layout(location=10) uniform uint boneIndex;
+
+readonly layout(std430, row_major, binding = 12) buffer Bones {
+    mat4 palettes[];
+};
+
 out vec2 uv;
 
 void main()
 {
     uv = vertexUV + uvOffset;
-    gl_Position =  gl_Position = proj * view * model * vec4(vertexPosition, 1.0f);
+    vec3 pos = vec3(model * vec4(vertexPosition, 1.0));
+
+    if (hasBones) 
+    {
+        mat4 skin    = palettes[boneIndex + vertexJoint[0]] * vertexWeights[0] + palettes[boneIndex + vertexJoint[1]] * vertexWeights[1] +             
+                       palettes[boneIndex + vertexJoint[2]] * vertexWeights[2] + palettes[boneIndex + vertexJoint[3]] * vertexWeights[3];
+        pos          = (skin * vec4(vertexPosition, 1.0)).xyz;
+    }
+
+    gl_Position = proj * view * vec4(pos, 1.0f);
 }

--- a/SobrassadaEngine/FileSystem/Batching/BatchManager.cpp
+++ b/SobrassadaEngine/FileSystem/Batching/BatchManager.cpp
@@ -15,9 +15,9 @@
 #include "Standalone/MeshComponent.h"
 #include "WindConfig.h"
 
+#include "Math/Quat.h"
 #include "Math/float3.h"
 #include "glew.h"
-#include "Math/Quat.h"
 #include <algorithm>
 #include <chrono>
 #ifdef OPTICK
@@ -97,7 +97,7 @@ void BatchManager::Render(const std::vector<MeshComponent*>& meshesToRender, Cam
         for (MeshComponent* mesh : meshesToRender)
         {
             GameObject* owner = mesh->GetParent();
-            if (!owner || !owner->IsGloballyEnabled()) continue;
+            if (!owner || (!owner->IsGloballyEnabled() && !mesh->GetUpdateShaderStorage())) continue;
 
             if (mesh->GetBatch() == it) batchMeshes.push_back(mesh);
         }
@@ -185,7 +185,7 @@ void BatchManager::RenderTransparent(
     for (MeshComponent* mesh : meshesToRender)
     {
         GameObject* owner = mesh->GetParent();
-        if (!owner || !owner->IsGloballyEnabled()) continue;
+        if (!owner || (!owner->IsGloballyEnabled() && !mesh->GetUpdateShaderStorage())) continue;
 
         batchMeshes.push_back(mesh);
     }
@@ -282,7 +282,7 @@ void BatchManager::RenderShadowMap(const std::vector<MeshComponent*>& meshesToRe
         for (MeshComponent* mesh : meshesToRender)
         {
             GameObject* owner = mesh->GetParent();
-            if (!owner || !owner->IsGloballyEnabled()) continue;
+            if (!owner || (!owner->IsGloballyEnabled() && !mesh->GetUpdateShaderStorage())) continue;
 
             if (mesh->GetBatch() == it) batchMeshes.push_back(mesh);
         }

--- a/SobrassadaEngine/FileSystem/Batching/GeometryBatch.cpp
+++ b/SobrassadaEngine/FileSystem/Batching/GeometryBatch.cpp
@@ -306,7 +306,7 @@ void GeometryBatch::UpdateBuffers(const std::vector<MeshComponent*>& meshesToRen
 
         glBindBuffer(GL_SHADER_STORAGE_BUFFER, nextBuffer);
 
-        for (const MeshComponent* component : meshesToRender)
+        for (MeshComponent* component : meshesToRender)
         {
             const std::size_t index                         = componentsMap[component];
             const std::size_t accBones                      = bonesCount[index];
@@ -316,6 +316,9 @@ void GeometryBatch::UpdateBuffers(const std::vector<MeshComponent*>& meshesToRen
             {
                 ptrBones[nextBufferIndex][accBones + i] = bonesGameObject[i]->GetGlobalTransform() * bindMatrices[i];
             }
+
+            // SETTING BONE INDEX FOR USE IN SHADER SCRIPTS
+            component->SetBoneIndexOffset((unsigned int)accBones);
         }
         glMemoryBarrier(GL_CLIENT_MAPPED_BUFFER_BARRIER_BIT);
 
@@ -345,6 +348,21 @@ void GeometryBatch::UpdateBuffers(const std::vector<MeshComponent*>& meshesToRen
     glBindBufferRange(GL_SHADER_STORAGE_BUFFER, 10, currentBuffer, 0, modelsSize);
 
     currentBufferIndex = nextBufferIndex;
+}
+
+void GeometryBatch::BindBonesBuffer()
+{
+    const GLuint currentBuffer = bones[currentBufferIndex];
+
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, currentBuffer);
+    glBindBufferRange(GL_SHADER_STORAGE_BUFFER, 12, currentBuffer, 0, bonesSize);
+}
+
+void GeometryBatch::UnbindBonesBuffer()
+{
+    const GLuint currentBuffer = bones[currentBufferIndex];
+
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 12, 0);
 }
 
 void GeometryBatch::LockBuffer()

--- a/SobrassadaEngine/FileSystem/Batching/GeometryBatch.cpp
+++ b/SobrassadaEngine/FileSystem/Batching/GeometryBatch.cpp
@@ -261,6 +261,9 @@ void GeometryBatch::GenerateCommands(const std::vector<MeshComponent*>& meshes, 
             continue;
         }
 
+        // CHECK AGAIN BECAUSE IF UPDATE_SHADERSTORAGE == TRUE WILL ARRIVE TO THIS POINT
+        if (!component->GetEnabled()) continue;
+
         const ResourceMesh* resource   = component->GetResourceMesh();
 
         const unsigned int vertexCount = static_cast<unsigned int>(resource->GetVertexCount());

--- a/SobrassadaEngine/FileSystem/Batching/GeometryBatch.h
+++ b/SobrassadaEngine/FileSystem/Batching/GeometryBatch.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Globals.h"
+
 #include "Math/float4x4.h"
 #include <unordered_map>
 #include <vector>
@@ -41,6 +43,9 @@ class GeometryBatch
     const unsigned int GetVertexCount() const { return totalVertexCount; }
     const unsigned int GetIndexCount() const { return totalIndexCount; }
     void ResetUpdatedOnce() { updatedOnce = false; }
+
+    void SOBRASADA_API_ENGINE BindBonesBuffer();
+    void SOBRASADA_API_ENGINE UnbindBonesBuffer();
 
   private:
     void LockBuffer();

--- a/SobrassadaEngine/Modules/ShaderScriptModule.cpp
+++ b/SobrassadaEngine/Modules/ShaderScriptModule.cpp
@@ -46,6 +46,9 @@ void ShaderScriptModule::AddShaderScript(
     case ShaderScriptType::POST_LIGHTING_PASS:
         postLightingComponents.push_back({component, scriptIndex});
         break;
+    case ShaderScriptType::POST_EFFECTS_PASS:
+        postEffectsComponents.push_back({component, scriptIndex});
+        break;
     default:
         break;
     }
@@ -67,6 +70,9 @@ void ShaderScriptModule::ShaderScriptTypeChange(
         break;
     case ShaderScriptType::POST_LIGHTING_PASS:
         originalVector = &postLightingComponents;
+        break;
+    case ShaderScriptType::POST_EFFECTS_PASS:
+        originalVector = &postEffectsComponents;
         break;
     default:
         return;
@@ -99,6 +105,9 @@ void ShaderScriptModule::ShaderScriptTypeChange(
             break;
         case ShaderScriptType::POST_LIGHTING_PASS:
             destinationVector = &postLightingComponents;
+            break;
+        case ShaderScriptType::POST_EFFECTS_PASS:
+            destinationVector = &postEffectsComponents;
             break;
         default:
             return;
@@ -157,6 +166,21 @@ void ShaderScriptModule::ComponentDeleted(ShaderScriptComponent* component)
     }
 
     iteratorsToRemove.clear();
+
+    for (auto iterator = postEffectsComponents.begin(); iterator != postEffectsComponents.end(); ++iterator)
+    {
+        if (iterator->first == component)
+        {
+            iteratorsToRemove.push_back(iterator);
+        }
+    }
+
+    for (auto& iterator : iteratorsToRemove)
+    {
+        postEffectsComponents.erase(iterator);
+    }
+
+    iteratorsToRemove.clear();
 }
 
 void ShaderScriptModule::ComponentDeletedScript(ShaderScriptComponent* component)
@@ -177,6 +201,9 @@ void ShaderScriptModule::ComponentDeletedScript(ShaderScriptComponent* component
             break;
         case ShaderScriptType::POST_LIGHTING_PASS:
             postLightingComponents.push_back({component, i});
+            break;
+        case ShaderScriptType::POST_EFFECTS_PASS:
+            postEffectsComponents.push_back({component, i});
             break;
         default:
             break;
@@ -264,6 +291,14 @@ void ShaderScriptModule::RenderTransparentPassShaders(float deltaTime, CameraCom
 void ShaderScriptModule::RenderPostLightingPassShaders(float deltaTime, CameraComponent* camera)
 {
     for (auto& shaderPair : postLightingComponents)
+    {
+        shaderPair.first->RenderScript(deltaTime, camera, shaderPair.second);
+    }
+}
+
+void ShaderScriptModule::RenderPostEffectsPassShaders(float deltaTime, CameraComponent* camera)
+{
+    for (auto& shaderPair : postEffectsComponents)
     {
         shaderPair.first->RenderScript(deltaTime, camera, shaderPair.second);
     }

--- a/SobrassadaEngine/Modules/ShaderScriptModule.h
+++ b/SobrassadaEngine/Modules/ShaderScriptModule.h
@@ -28,9 +28,11 @@ class ShaderScriptModule : public Module
     void RenderGeometryPassShaders(float deltaTime, CameraComponent* camera);
     void RenderTransparentPassShaders(float deltaTime, CameraComponent* camera);
     void RenderPostLightingPassShaders(float deltaTime, CameraComponent* camera);
+    void RenderPostEffectsPassShaders(float deltaTime, CameraComponent* camera);
 
   private:
     std::vector<std::pair<ShaderScriptComponent*, unsigned int>> geometryPassComponents;
     std::vector<std::pair<ShaderScriptComponent*, unsigned int>> transparentComponents;
     std::vector<std::pair<ShaderScriptComponent*, unsigned int>> postLightingComponents;
+    std::vector<std::pair<ShaderScriptComponent*, unsigned int>> postEffectsComponents;
 };

--- a/SobrassadaEngine/Scene/Components/ComponentUtils.h
+++ b/SobrassadaEngine/Scene/Components/ComponentUtils.h
@@ -79,10 +79,11 @@ enum class ShaderScriptType : int
     NONE = -1,
     GEOMERTY_PASS,
     TRANSPARENT_PASS,
-    POST_LIGHTING_PASS
+    POST_LIGHTING_PASS,
+    POST_EFFECTS_PASS
 };
 
-constexpr const char* ShaderScriptTypeStrings[] = {"Opaque", "Transparent", "Post lighting"};
+constexpr const char* ShaderScriptTypeStrings[] = {"Opaque", "Transparent", "Post lighting", "Post effects"};
 constexpr int ShaderScriptTypeStringsSize       = sizeof(ShaderScriptTypeStrings) / sizeof(char*);
 
 class ComponentUtils

--- a/SobrassadaEngine/Scene/Components/Standalone/MeshComponent.h
+++ b/SobrassadaEngine/Scene/Components/Standalone/MeshComponent.h
@@ -50,6 +50,7 @@ class MeshComponent : public Component
     bool GetProduceShadows() const { return produceShadows; }
     bool GetBatchWasEnabled() { return batchWasEnabled; }
     bool GetBoneIndexOffset() const { return boneIndexOffset; }
+    bool GetUpdateShaderStorage() const { return updateShaderStorage; }
 
     void SetBones(const std::vector<GameObject*>& bones, const std::vector<UID> bonesIds)
     {
@@ -73,6 +74,7 @@ class MeshComponent : public Component
     }
 
     void SetBoneIndexOffset(unsigned int newIndexOffset) { boneIndexOffset = newIndexOffset; }
+    void SetUpdateShaderStorage(bool newUpdate) { updateShaderStorage = newUpdate; }
 
   private:
     std::string currentMeshName       = "Not selected";
@@ -85,21 +87,22 @@ class MeshComponent : public Component
     std::vector<UID> bonesUIDs;
     std::vector<GameObject*> bones;
     std::vector<float4x4> bindMatrices;
-    bool hasBones           = false;
+    bool hasBones                = false;
 
-    UID modelUID            = INVALID_UID;
-    int skinIndex           = -1;
+    UID modelUID                 = INVALID_UID;
+    int skinIndex                = -1;
 
-    float4x4 combinedMatrix = float4x4::identity;
+    float4x4 combinedMatrix      = float4x4::identity;
 
-    GeometryBatch* batch    = nullptr;
-    bool uniqueBatch        = false;
+    GeometryBatch* batch         = nullptr;
+    bool uniqueBatch             = false;
 
-    int renderMode          = 0; // 0 = Opaque, 1 = Alpha Blend, 2 = Alpha Discard
+    int renderMode               = 0; // 0 = Opaque, 1 = Alpha Blend, 2 = Alpha Discard
 
-    bool produceShadows     = true;
+    bool produceShadows          = true;
 
-    bool batchWasEnabled    = false;
+    bool batchWasEnabled         = false;
 
-    unsigned int boneIndexOffset  = 0;
+    unsigned int boneIndexOffset = 0;
+    bool updateShaderStorage     = false;
 };

--- a/SobrassadaEngine/Scene/Components/Standalone/MeshComponent.h
+++ b/SobrassadaEngine/Scene/Components/Standalone/MeshComponent.h
@@ -49,6 +49,7 @@ class MeshComponent : public Component
     int GetRenderMode() const { return renderMode; }
     bool GetProduceShadows() const { return produceShadows; }
     bool GetBatchWasEnabled() { return batchWasEnabled; }
+    bool GetBoneIndexOffset() const { return boneIndexOffset; }
 
     void SetBones(const std::vector<GameObject*>& bones, const std::vector<UID> bonesIds)
     {
@@ -70,6 +71,8 @@ class MeshComponent : public Component
 
         batchWasEnabled = false;
     }
+
+    void SetBoneIndexOffset(unsigned int newIndexOffset) { boneIndexOffset = newIndexOffset; }
 
   private:
     std::string currentMeshName       = "Not selected";
@@ -97,4 +100,6 @@ class MeshComponent : public Component
     bool produceShadows     = true;
 
     bool batchWasEnabled    = false;
+
+    unsigned int boneIndexOffset  = 0;
 };

--- a/SobrassadaEngine/Scene/RenderPass.cpp
+++ b/SobrassadaEngine/Scene/RenderPass.cpp
@@ -230,7 +230,9 @@ void RenderPass::GeometryPassRender(const std::vector<GameObject*>& objectsToRen
     for (const auto& gameObject : objectsToRender)
     {
         MeshComponent* mesh = gameObject->GetComponent<MeshComponent*>();
-        if (mesh != nullptr && mesh->GetEnabled() && mesh->GetBatch() != nullptr && mesh->GetRenderMode() != 1)
+
+        if (mesh != nullptr && (mesh->GetEnabled() || mesh->GetUpdateShaderStorage()) && mesh->GetBatch() != nullptr &&
+            mesh->GetRenderMode() != 1)
             meshesToRender.push_back(mesh);
     }
 
@@ -264,7 +266,7 @@ void RenderPass::NavMeshPassRender(const std::vector<GameObject*>& objectsToRend
     for (const auto& gameObject : objectsToRender)
     {
         MeshComponent* mesh = gameObject->GetComponent<MeshComponent*>();
-        if (mesh != nullptr && mesh->GetEnabled() && mesh->GetBatch() != nullptr)
+        if (mesh != nullptr && (mesh->GetEnabled() || mesh->GetUpdateShaderStorage()) && mesh->GetBatch() != nullptr)
         {
             if (gameObject->IsNavMeshValid()) navMeshesToRender.push_back(mesh);
             else nonNavMeshesToRender.push_back(mesh);
@@ -450,8 +452,8 @@ void RenderPass::ShadowMapPassRender(
     for (const auto& gameObject : shadowObjectsToRender)
     {
         MeshComponent* mesh = gameObject->GetComponent<MeshComponent*>();
-        if (mesh != nullptr && mesh->GetEnabled() && mesh->GetBatch() != nullptr && mesh->GetRenderMode() != 1 &&
-            mesh->GetProduceShadows())
+        if (mesh != nullptr && (mesh->GetEnabled() || mesh->GetUpdateShaderStorage()) && mesh->GetBatch() != nullptr &&
+            mesh->GetRenderMode() != 1 && mesh->GetProduceShadows())
             meshesToRender.push_back(mesh);
     }
 
@@ -773,7 +775,8 @@ void RenderPass::TransparentPassRender(const std::vector<GameObject*>& objectsTo
         for (const auto& gameObject : objectsToRender)
         {
             MeshComponent* mesh = gameObject->GetComponent<MeshComponent*>();
-            if (mesh != nullptr && mesh->GetEnabled() && mesh->GetBatch() != nullptr && mesh->GetRenderMode() == 1)
+            if (mesh != nullptr && (mesh->GetEnabled() || mesh->GetUpdateShaderStorage()) &&
+                mesh->GetBatch() != nullptr && mesh->GetRenderMode() == 1)
             {
                 if (gameObject->IsNavMeshValid()) navmeshesToRender.push_back(mesh);
                 else nonnavmeshesToRender.push_back(mesh);

--- a/SobrassadaEngine/Scene/Scene.cpp
+++ b/SobrassadaEngine/Scene/Scene.cpp
@@ -350,9 +350,6 @@ update_status Scene::Update(float deltaTime)
         App->GetSceneModule()->ResetOnlyOnceInPlayMode();
     }
 
-    // for (auto& gameObject : gameObjectsContainer)
-    //     gameObject.second->UpdateComponents(deltaTime);
-
     for (auto gameObject : toUpdateGameObjects)
         gameObject->UpdateComponents(deltaTime);
 
@@ -432,6 +429,10 @@ void Scene::RenderScene(float deltaTime, CameraComponent* camera)
 
     glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, -1, "Particles Pass");
     App->GetParticleModule()->RenderParticles();
+    glPopDebugGroup();
+
+    glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, -1, "Post effects Pass");
+    App->GetShaderScriptModule()->RenderPostEffectsPassShaders(deltaTime, camera);
     glPopDebugGroup();
 }
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MovingUVLight.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MovingUVLight.cpp
@@ -8,6 +8,7 @@
 #include "Components/Standalone/MeshComponent.h"
 #include "GBuffer.h"
 #include "GameObject.h"
+#include "GeometryBatch.h"
 #include "Mesh.h"
 #include "OpenGLModule.h"
 #include "ResourceMaterial.h"
@@ -71,6 +72,12 @@ bool MovingUVLight::Init()
             glEnableVertexAttribArray(3);
             glVertexAttribPointer(3, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, texCoord));
 
+            glEnableVertexAttribArray(4);
+            glVertexAttribIPointer(4, 4, GL_INT, sizeof(Vertex), (void*)offsetof(Vertex, joint));
+
+            glEnableVertexAttribArray(5);
+            glVertexAttribPointer(5, 4, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, weights));
+
             glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ebo);
             glBufferData(
                 GL_ELEMENT_ARRAY_BUFFER, rmesh->GetIndices().size() * sizeof(unsigned int), rmesh->GetIndices().data(),
@@ -101,9 +108,8 @@ bool MovingUVLight::Init()
         }
 
         meshComp->SetEnabled(false);
+        meshComp->SetUpdateShaderStorage(true);
     }
-    uvOffset = uvOffsetStart;
-
     uvOffset = uvOffsetStart;
 
     return true;
@@ -141,6 +147,8 @@ void MovingUVLight::Render(float deltaTime, CameraComponent* cameraComp)
         glUniformMatrix4fv(1, 1, GL_TRUE, &viewMatrix[0][0]);
         glUniformMatrix4fv(2, 1, GL_TRUE, &basicModelMatrix[0][0]);
         glUniform2fv(3, 1, &uvOffset[0]);
+        glUniform1i(9, meshComp->GetHasBones());
+        glUniform1ui(10, meshComp->GetBoneIndexOffset());
 
         glUniform1i(4, 0);
         glUniform1i(5, isAlphaDiscard);
@@ -148,6 +156,8 @@ void MovingUVLight::Render(float deltaTime, CameraComponent* cameraComp)
 
         glUniform1f(7, roughnessFactor);
         glUniform1f(8, metallicFactor);
+
+        meshComp->GetBatch()->BindBonesBuffer();
 
         glActiveTexture(GL_TEXTURE0);
         glBindTexture(GL_TEXTURE_2D, diffuseTex);
@@ -164,6 +174,8 @@ void MovingUVLight::Render(float deltaTime, CameraComponent* cameraComp)
         glBindVertexArray(vao);
 
         glDrawElements(GL_TRIANGLES, indexCount, GL_UNSIGNED_INT, 0);
+
+        meshComp->GetBatch()->UnbindBonesBuffer();
 
         glBindVertexArray(0);
     }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MovingUVPostScript.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MovingUVPostScript.cpp
@@ -8,6 +8,7 @@
 #include "Components/Standalone/MeshComponent.h"
 #include "GBuffer.h"
 #include "GameObject.h"
+#include "GeometryBatch.h"
 #include "Mesh.h"
 #include "OpenGLModule.h"
 #include "ResourceMaterial.h"
@@ -59,13 +60,23 @@ bool MovingUVPostScript::Init()
                 GL_STATIC_DRAW
             );
 
-            // VERTICES
             glEnableVertexAttribArray(0);
             glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, position));
 
-            // UV'S
             glEnableVertexAttribArray(1);
-            glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, texCoord));
+            glVertexAttribPointer(1, 4, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, tangent));
+
+            glEnableVertexAttribArray(2);
+            glVertexAttribPointer(2, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, normal));
+
+            glEnableVertexAttribArray(3);
+            glVertexAttribPointer(3, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, texCoord));
+
+            glEnableVertexAttribArray(4);
+            glVertexAttribIPointer(4, 4, GL_INT, sizeof(Vertex), (void*)offsetof(Vertex, joint));
+
+            glEnableVertexAttribArray(5);
+            glVertexAttribPointer(5, 4, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, weights));
 
             glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ebo);
             glBufferData(
@@ -83,7 +94,11 @@ bool MovingUVPostScript::Init()
         {
             texture = rmat->GetDiffuseColorID();
         }
+
+        meshComp->SetEnabled(false);
+        meshComp->SetUpdateShaderStorage(true);
     }
+
     uvOffset = uvOffsetStart;
 
     return true;
@@ -121,6 +136,10 @@ void MovingUVPostScript::Render(float deltaTime, CameraComponent* cameraComp)
         glUniformMatrix4fv(1, 1, GL_TRUE, &viewMatrix[0][0]);
         glUniformMatrix4fv(2, 1, GL_TRUE, &basicModelMatrix[0][0]);
         glUniform2fv(3, 1, &uvOffset[0]);
+        glUniform1i(9, meshComp->GetHasBones());
+        glUniform1ui(10, meshComp->GetBoneIndexOffset());
+
+        meshComp->GetBatch()->BindBonesBuffer();
 
         glActiveTexture(GL_TEXTURE0);
         glBindTexture(GL_TEXTURE_2D, texture);
@@ -128,6 +147,8 @@ void MovingUVPostScript::Render(float deltaTime, CameraComponent* cameraComp)
         glBindVertexArray(vao);
 
         glDrawElements(GL_TRIANGLES, indexCount, GL_UNSIGNED_INT, 0);
+
+        meshComp->GetBatch()->UnbindBonesBuffer();
 
         glBindVertexArray(0);
     }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MovingUVTransparent.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MovingUVTransparent.cpp
@@ -105,6 +105,7 @@ bool MovingUVTransparent::Init()
         }
 
         meshComp->SetEnabled(false);
+        meshComp->SetUpdateShaderStorage(true);
     }
     uvOffset = uvOffsetStart;
     return true;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MovingUVTransparent.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MovingUVTransparent.cpp
@@ -8,6 +8,7 @@
 #include "Components/Standalone/MeshComponent.h"
 #include "GBuffer.h"
 #include "GameObject.h"
+#include "GeometryBatch.h"
 #include "LightsConfig.h"
 #include "Mesh.h"
 #include "OpenGLModule.h"
@@ -75,6 +76,12 @@ bool MovingUVTransparent::Init()
             glEnableVertexAttribArray(3);
             glVertexAttribPointer(3, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, texCoord));
 
+            glEnableVertexAttribArray(4);
+            glVertexAttribIPointer(4, 4, GL_INT, sizeof(Vertex), (void*)offsetof(Vertex, joint));
+
+            glEnableVertexAttribArray(5);
+            glVertexAttribPointer(5, 4, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, weights));
+
             glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ebo);
             glBufferData(
                 GL_ELEMENT_ARRAY_BUFFER, rmesh->GetIndices().size() * sizeof(unsigned int), rmesh->GetIndices().data(),
@@ -137,11 +144,14 @@ void MovingUVTransparent::Render(float deltaTime, CameraComponent* cameraComp)
         glUniformMatrix4fv(1, 1, GL_TRUE, &viewMatrix[0][0]);
         glUniformMatrix4fv(2, 1, GL_TRUE, &basicModelMatrix[0][0]);
         glUniform2fv(3, 1, &uvOffset[0]);
+        glUniform1i(9, meshComp->GetHasBones());
+        glUniform1ui(10, meshComp->GetBoneIndexOffset());
 
         glUniform1i(4, 0);
         glUniform1i(5, isAlphaDiscard);
 
         glBindBufferBase(GL_UNIFORM_BUFFER, 6, materialBuffer);
+        meshComp->GetBatch()->BindBonesBuffer();
 
         float3 cameraPos = float3::zero;
         if (cameraComp == nullptr) cameraPos = AppEngine->GetCameraModule()->GetCameraPosition();
@@ -152,6 +162,8 @@ void MovingUVTransparent::Render(float deltaTime, CameraComponent* cameraComp)
         glBindVertexArray(vao);
 
         glDrawElements(GL_TRIANGLES, indexCount, GL_UNSIGNED_INT, 0);
+
+        meshComp->GetBatch()->UnbindBonesBuffer();
 
         glBindVertexArray(0);
     }


### PR DESCRIPTION
Moving UV shaders now are compatible with meshes using animations, it also adds the option to use shader scripts after the particles and billboards, options is called Post Effects.

![movingUV_Anim](https://github.com/user-attachments/assets/1d5275dd-e689-4677-b5f1-b4a0de610182)
