### PR TITLE
THO-892 Animation scales

### DIFF
--- a/Game/EngineDefaults/Shader/Custom/Vertex/MovingUV_Light_Vertex.glsl
+++ b/Game/EngineDefaults/Shader/Custom/Vertex/MovingUV_Light_Vertex.glsl
@@ -13,7 +13,6 @@ layout(location=3) uniform vec2 uvOffset;
 layout(location=9) uniform bool hasBones;
 layout(location=10) uniform uint boneIndex;
 
-
 readonly layout(std430, row_major, binding = 12) buffer Bones {
     mat4 palettes[];
 };

--- a/SobrassadaEngine/Scene/Components/Standalone/AnimController.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/AnimController.cpp
@@ -116,7 +116,7 @@ update_status AnimController::Update(float deltaTime)
     return UPDATE_CONTINUE;
 }
 
-void AnimController::GetTransform(const HashString& nodeName, float3& pos, Quat& rot)
+void AnimController::GetTransform(const HashString& nodeName, float3& pos, Quat& rot, float3& scale)
 {
     if (!playAnimation || resource == INVALID_UID || currentAnimation == nullptr) return;
 
@@ -142,6 +142,11 @@ void AnimController::GetTransform(const HashString& nodeName, float3& pos, Quat&
         {
             GetChannelRotation(animChannel, rot, currentTime);
         }
+
+        if (animChannel->numScales > 0)
+        {
+            GetChannelScale(animChannel, scale, currentTime);
+        }
     }
     else
     {
@@ -155,8 +160,9 @@ void AnimController::GetTransform(const HashString& nodeName, float3& pos, Quat&
             return; // Don't modify pos/rot if no channel exists in either animation
         }
 
-        float3 animPos = float3(pos);
-        Quat animQuat  = Quat(rot);
+        float3 animPos   = float3(pos);
+        Quat animQuat    = Quat(rot);
+        float3 animScale = float3(scale);
 
         // Only get transforms from animation channels if they exist
         if (animChannel)
@@ -169,10 +175,15 @@ void AnimController::GetTransform(const HashString& nodeName, float3& pos, Quat&
             {
                 GetChannelRotation(animChannel, animQuat, currentTime);
             }
+            if (animChannel->numScales > 0)
+            {
+                GetChannelScale(animChannel, animScale, currentTime);
+            }
         }
 
-        float3 targetAnimPos = float3(pos);
-        Quat targetAnimQuat  = Quat(rot);
+        float3 targetAnimPos   = float3(pos);
+        Quat targetAnimQuat    = Quat(rot);
+        float3 targetAnimScale = float3(scale);
 
         // Only get transforms from target animation channels if they exist
         if (targetAnimChannel)
@@ -185,6 +196,11 @@ void AnimController::GetTransform(const HashString& nodeName, float3& pos, Quat&
             {
                 GetChannelRotation(targetAnimChannel, targetAnimQuat, currentTargetTime);
             }
+
+            if (targetAnimChannel->numScales > 0)
+            {
+                GetChannelScale(targetAnimChannel, targetAnimScale, currentTime);
+            }
         }
 
         // Blend the animations
@@ -192,6 +208,8 @@ void AnimController::GetTransform(const HashString& nodeName, float3& pos, Quat&
                             (targetAnimChannel && targetAnimChannel->numPositions > 0);
         bool hasRotations = (animChannel && animChannel->numRotations > 0) ||
                             (targetAnimChannel && targetAnimChannel->numRotations > 0);
+        bool hasScale =
+            (animChannel && animChannel->numScales > 0) || (targetAnimChannel && targetAnimChannel->numScales > 0);
 
         // Only blend if there's actual data to blend
         if (hasPositions)
@@ -201,6 +219,10 @@ void AnimController::GetTransform(const HashString& nodeName, float3& pos, Quat&
         if (hasRotations)
         {
             rot = Quat::Slerp(animQuat, targetAnimQuat, weight);
+        }
+        if (hasScale)
+        {
+            scale = animScale.Lerp(targetAnimScale, weight);
         }
     }
 }
@@ -295,6 +317,44 @@ void AnimController::GetChannelRotation(Channel* animChannel, Quat& rot, const f
                 lambda                = (lambda < 0) ? 0 : (lambda > 1) ? 1 : lambda;
 
                 rot = Interpolate(animChannel->rotations[prevIndex], animChannel->rotations[nextIndex], lambda);
+            }
+        }
+    }
+}
+
+void AnimController::GetChannelScale(Channel* animChannel, float3& scale, float time) const
+{
+    if (animChannel->numPositions > 0)
+    {
+        if (animChannel->numPositions == 1)
+        {
+            scale = animChannel->scales[0];
+        }
+        else
+        {
+            size_t nextIndex = FindChannelIndex(animChannel->scaleTimeStamps, time);
+
+            size_t prevIndex = (nextIndex > 0) ? nextIndex - 1 : 0;
+
+            if (nextIndex >= animChannel->numScales)
+            {
+                scale = animChannel->scales[animChannel->numScales - 1];
+            }
+            else if (nextIndex == 0)
+            {
+                scale = animChannel->scales[0];
+            }
+            else
+            {
+                const float startTime = animChannel->scaleTimeStamps[prevIndex];
+                const float endTime   = animChannel->scaleTimeStamps[nextIndex];
+                const float timeDiff  = endTime - startTime;
+
+                float lambda          = (timeDiff > 0.0001f) ? (time - startTime) / timeDiff : 0.0f;
+
+                lambda                = (lambda < 0) ? 0 : (lambda > 1) ? 1 : lambda;
+
+                scale = float3::Lerp(animChannel->scales[prevIndex], animChannel->scales[nextIndex], lambda);
             }
         }
     }

--- a/SobrassadaEngine/Scene/Components/Standalone/AnimController.h
+++ b/SobrassadaEngine/Scene/Components/Standalone/AnimController.h
@@ -17,7 +17,7 @@ class AnimController
     void Pause() { playAnimation = false; }
     void Resume() { playAnimation = true; }
 
-    void GetTransform(const HashString& nodeName, float3& pos, Quat& rot);
+    void GetTransform(const HashString& nodeName, float3& pos, Quat& rot, float3& scale);
 
     ResourceAnimation* GetCurrentAnimation() const { return currentAnimation; }
     float GetTime() const { return currentTime; }
@@ -32,6 +32,7 @@ class AnimController
   private:
     void GetChannelPosition(const Channel* animChannel, float3& pos, float time) const;
     void GetChannelRotation(Channel* animChannel, Quat& rot, float time);
+    void GetChannelScale(Channel* animChannel, float3& scale, float time) const;
    
     void SetAnimationResource(ResourceAnimation* anim) { currentAnimation = anim; }
 

--- a/SobrassadaEngine/Scene/Components/Standalone/AnimationComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/AnimationComponent.cpp
@@ -1,11 +1,14 @@
 #include "AnimationComponent.h"
 
 #include "AnimController.h"
+#include "Animation/AnimationTrigger.h"
 #include "Application.h"
+#include "AudioModule.h"
 #include "CameraModule.h"
 #include "EditorUIModule.h"
 #include "FileSystem.h"
 #include "GameObject.h"
+#include "GameTimer.h"
 #include "HashString.h"
 #include "LibraryModule.h"
 #include "ProjectModule.h"
@@ -15,11 +18,6 @@
 #include "ResourcesModule.h"
 #include "SceneModule.h"
 #include "StateMachineEditor.h"
-#include "GameTimer.h"
-#include "Animation/AnimationTrigger.h"
-#include "AudioModule.h"
-#include "ResourceAnimation.h"
-
 
 #include "Math/Quat.h"
 #include "imgui.h"
@@ -106,11 +104,9 @@ void AnimationComponent::OnPlay(bool isTransition)
                                     clip.animationResourceUID, transitionTime, clip.loop, clip.animationSpeed
                                 );
                             }
-                            else
-                                animController->Play(clip.animationResourceUID, clip.loop, clip.animationSpeed);
+                            else animController->Play(clip.animationResourceUID, clip.loop, clip.animationSpeed);
 
-                            if (currentAnimResource)
-                                App->GetResourcesModule()->ReleaseResource(currentAnimResource);
+                            if (currentAnimResource) App->GetResourcesModule()->ReleaseResource(currentAnimResource);
 
                             currentAnimResource = dynamic_cast<ResourceAnimation*>(
                                 App->GetResourcesModule()->RequestResource(clip.animationResourceUID)
@@ -120,17 +116,14 @@ void AnimationComponent::OnPlay(bool isTransition)
 
                             resource = clip.animationResourceUID;
 
-
                             SetBoneMapping();
 
-                            float clipLen       = currentAnimResource->GetDuration();
+                            float clipLen = currentAnimResource->GetDuration();
                             if (clipLen <= 0.f) clipLen = 1.f;
 
-                            float startSec      = animController->GetTime();
-                            float startNorm     = (clipLen > 0.f) ? (startSec / clipLen) : 0.f;
-                            SetActiveTriggers(
-                                currentState->triggers, startNorm
-                            );
+                            float startSec  = animController->GetTime();
+                            float startNorm = (clipLen > 0.f) ? (startSec / clipLen) : 0.f;
+                            SetActiveTriggers(currentState->triggers, startNorm);
                         }
                     }
                 }
@@ -141,7 +134,7 @@ void AnimationComponent::OnPlay(bool isTransition)
             if (currentAnimResource) App->GetResourcesModule()->ReleaseResource(currentAnimResource);
 
             animController->Play(resource, true, defaultTime);
-            activeTriggers.clear(); 
+            activeTriggers.clear();
 
             currentAnimResource = animController->GetCurrentAnimation();
             if (currentAnimResource) currentAnimResource->AddReference();
@@ -486,7 +479,7 @@ void AnimationComponent::Update(float deltaTime)
                 // Pass CURRENT values to GetTransform - it will only modify them
                 // if the animation has data for that channel type
 
-                animController->GetTransform(boneName, position, rotation);
+                animController->GetTransform(boneName, position, rotation, scale);
                 rotation.Normalize();
 
                 float4x4 transformMatrix = float4x4::FromTRS(position, rotation, scale);
@@ -615,4 +608,3 @@ bool AnimationComponent::UseTrigger(const std::string& triggerName)
     }
     return triggerDone;
 }
-

--- a/SobrassadaEngine/Scene/Components/Standalone/MeshComponent.h
+++ b/SobrassadaEngine/Scene/Components/Standalone/MeshComponent.h
@@ -49,7 +49,8 @@ class MeshComponent : public Component
     int GetRenderMode() const { return renderMode; }
     bool GetProduceShadows() const { return produceShadows; }
     bool GetBatchWasEnabled() { return batchWasEnabled; }
-    bool GetBoneIndexOffset() const { return boneIndexOffset; }
+
+    unsigned int GetBoneIndexOffset() const { return boneIndexOffset; }
     bool GetUpdateShaderStorage() const { return updateShaderStorage; }
 
     void SetBones(const std::vector<GameObject*>& bones, const std::vector<UID> bonesIds)

--- a/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
+++ b/SobrassadaEngine/Scene/GameObjects/GameObject.cpp
@@ -757,7 +757,7 @@ void GameObject::RenderEditorInspector(bool drawGizmo)
 
 void GameObject::UpdateTransformForGOBranch()
 {
-    if (!IsGloballyEnabled()) return;
+    //if (!IsGloballyEnabled()) return;
     App->GetSceneModule()->AddGameObjectToUpdateComponents(this);
     std::stack<UID> childrenBuffer;
     childrenBuffer.push(uid);

--- a/SobrassadaEngine/Scene/RenderPass.cpp
+++ b/SobrassadaEngine/Scene/RenderPass.cpp
@@ -897,7 +897,8 @@ void RenderPass::TransparentPassRender(const std::vector<GameObject*>& objectsTo
         for (const auto& gameObject : objectsToRender)
         {
             MeshComponent* mesh = gameObject->GetComponent<MeshComponent*>();
-            if (mesh != nullptr && mesh->GetEnabled() && mesh->GetBatch() != nullptr && mesh->GetRenderMode() == 1)
+            if (mesh != nullptr && (mesh->GetEnabled() || mesh->GetUpdateShaderStorage()) &&
+                mesh->GetBatch() != nullptr && mesh->GetRenderMode() == 1)
             {
                 if (mesh->GetResourceMaterial() != nullptr && mesh->GetResourceMaterial()->DoApplyWind())
                     vertexOffsetMeshesToRender.push_back(mesh);

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MovingUVLight.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MovingUVLight.cpp
@@ -124,7 +124,7 @@ void MovingUVLight::Update(float deltaTime)
 
 void MovingUVLight::Render(float deltaTime, CameraComponent* cameraComp)
 {
-    if (shaderProgram && indexCount > 0 && meshComp)
+    if (shaderProgram && indexCount > 0 && meshComp && meshComp->GetBatch())
     {
         float4x4 projectionMatrix, viewMatrix, basicModelMatrix;
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MovingUVPostScript.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MovingUVPostScript.cpp
@@ -113,7 +113,7 @@ void MovingUVPostScript::Update(float deltaTime)
 
 void MovingUVPostScript::Render(float deltaTime, CameraComponent* cameraComp)
 {
-    if (shaderProgram && indexCount > 0 && texture && meshComp)
+    if (shaderProgram && indexCount > 0 && texture && meshComp && meshComp->GetBatch())
     {
         float4x4 projectionMatrix, viewMatrix, basicModelMatrix;
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MovingUVTransparent.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MovingUVTransparent.cpp
@@ -121,7 +121,7 @@ void MovingUVTransparent::Update(float deltaTime)
 
 void MovingUVTransparent::Render(float deltaTime, CameraComponent* cameraComp)
 {
-    if (shaderProgram && indexCount > 0 && meshComp)
+    if (shaderProgram && indexCount > 0 && meshComp && meshComp->GetBatch())
     {
         float4x4 projectionMatrix, viewMatrix, basicModelMatrix;
 


### PR DESCRIPTION
This adds the scaling to the transform for animations which were not used, needed for VFX mesh animations. It also fixes an error that happend during merge that broke the transparent moving uv shader.

If you want to test with a mesh and animation that contains scaling: 
[shoutstart.zip](https://github.com/user-attachments/files/21761145/shoutstart.zip)


![movingUV_Anim_scale](https://github.com/user-attachments/assets/6cd7884f-0dbb-4715-b4d1-13dbe62e3577)
