### PR TITLE
Constant vpo for magical objects

### DIFF
--- a/Game/EngineDefaults/Shader/Vertex/VertexShader.glsl
+++ b/Game/EngineDefaults/Shader/Vertex/VertexShader.glsl
@@ -15,8 +15,8 @@ uniform mat4 projLight;
 uniform vec4 windParameters;
 // x: v0 (no movement border), y: v1 (full movement border), z: use central pivot, w: use gravity
 uniform vec4 windUVParameters;
-// x: axis amplitude, y: axis amplitude, z: axis amplitude
-uniform vec3 windAmplitudes;
+// x: axis amplitude, y: axis amplitude, z: axis amplitude, w: use constant movement
+uniform vec4 windAmplitudes;
 // x: axis frequency, y: axis frequency, z: axis frequency, w: time scale
 uniform vec4 windFrequency;
 
@@ -78,14 +78,14 @@ void main()
     {
     // windParameters: x: currentTime (set to 0 disables the wind), y: wind speed, z: gust frequency, y: gust speed
     // windUVParameters: x: v0 (no movement border), y: v1 (full movement border), z: use central pivot, w: use gravity
-    // windAmplitudes: x: axis amplitude, y: axis amplitude, z: axis amplitude
+    // windAmplitudes: x: axis amplitude, y: axis amplitude, z: axis amplitude, w: use constant movement
     // windFrequency: x: axis frequency, y: axis frequency, z: axis frequency, w: time scale
 
         pos = vertex_position;
 
         if (bool(windParameters.x))
         {
-            float vCoordLerp = max(min(((1-uv0.y) - windUVParameters.x) / (windUVParameters.y - windUVParameters.x), 1), 0);
+            float adaptedYUV = bool(windAmplitudes.w) ? 1 : max(min(((1-uv0.y) - windUVParameters.x) / (windUVParameters.y - windUVParameters.x), 1), 0);
 
             vec4 deltaWindDirection = deltaWindDirections[instance_index];
 
@@ -101,11 +101,11 @@ void main()
             float scaledTime = windParameters.x * 0.001 * (log(windParameters.y * 2) + 1) * windFrequency.w;
             float scaledWindSpeed = combinedWindSpeed;
 
-            float basicOffset = sin(pos.x + scaledTime + 1.0 - vCoordLerp) * vCoordLerp * scaledWindSpeed;
+            vec3 sinOffsetPos = bool(windAmplitudes.w) ? vec3(0, 0, 0) : pos;
 
-            float offsetX = sin((pos.x + scaledTime + 1.0 - vCoordLerp) * windFrequency.x) * vCoordLerp * scaledWindSpeed * windAmplitudes.x;
-            float offsetY = sin((pos.y + scaledTime + 1.0 - vCoordLerp) * windFrequency.y) * vCoordLerp * scaledWindSpeed * windAmplitudes.y;
-            float offsetZ = sin((pos.z + scaledTime + 1.0 - vCoordLerp) * windFrequency.z) * vCoordLerp * scaledWindSpeed * windAmplitudes.z;
+            float offsetX = sin((sinOffsetPos.x + scaledTime + 1.0 - adaptedYUV) * windFrequency.x) * adaptedYUV * scaledWindSpeed * windAmplitudes.x;
+            float offsetY = sin((sinOffsetPos.y + scaledTime + 1.0 - adaptedYUV) * windFrequency.y) * adaptedYUV * scaledWindSpeed * windAmplitudes.y;
+            float offsetZ = sin((sinOffsetPos.z + scaledTime + 1.0 - adaptedYUV) * windFrequency.z) * adaptedYUV * scaledWindSpeed * windAmplitudes.z;
 
             vec3 offset = vec3(offsetX, offsetY, offsetZ);
 

--- a/SobrassadaEngine/FileSystem/Batching/BatchManager.cpp
+++ b/SobrassadaEngine/FileSystem/Batching/BatchManager.cpp
@@ -151,9 +151,9 @@ void BatchManager::Render(const std::vector<MeshComponent*>& meshesToRender, Cam
                     glGetUniformLocation(program, "windUVParameters"), it->GetVCoord0(), it->GetVCoord1(),
                     it->UseCentralPivot(), it->UseWindGravity()
                 );
-                glUniform3f(
+                glUniform4f(
                     glGetUniformLocation(program, "windAmplitudes"), it->GetWindXAmplitude(), it->GetWindYAmplitude(),
-                    it->GetWindZAmplitude()
+                    it->GetWindZAmplitude(), it->UseConstantMovement()
                 );
                 glUniform4f(
                     glGetUniformLocation(program, "windFrequency"), it->GetWindXFrequency(), it->GetWindYFrequency(),
@@ -353,6 +353,7 @@ GeometryBatch* BatchManager::RequestBatch(const MeshComponent* component)
                 Equal(material->GetVCoord0(), it->GetVCoord0()) && Equal(material->GetVCoord1(), it->GetVCoord1()) &&
                 material->UseCentralPivot() == it->UseCentralPivot() &&
                 material->UseWindGravity() == it->UseWindGravity() &&
+                material->UseConstantMovement() == it->UseConstantMovement() &&
                 Equal(material->GetWindXAmplitude(), it->GetWindXAmplitude()) &&
                 Equal(material->GetWindYAmplitude(), it->GetWindYAmplitude()) &&
                 Equal(material->GetWindZAmplitude(), it->GetWindZAmplitude()) &&

--- a/SobrassadaEngine/FileSystem/Batching/GeometryBatch.cpp
+++ b/SobrassadaEngine/FileSystem/Batching/GeometryBatch.cpp
@@ -27,25 +27,26 @@ struct Command
 GeometryBatch::GeometryBatch(const MeshComponent* component)
     : totalVertexCount(0), totalIndexCount(0), currentBufferIndex(0)
 {
-    mode            = component->GetResourceMesh()->GetMode();
-    isSpecular      = component->GetResourceMaterial()->GetIsSpecular();
-    isMetallic      = component->GetResourceMaterial()->GetIsMetallicRoughness();
-    hasBones        = component->GetHasBones();
-    isNavmeshValid  = component->GetParent()->IsNavMeshValid();
-    isAlpha         = component->GetRenderMode() == 2;
-    isDoubleSided   = component->GetResourceMaterial()->IsDoubleSided();
-    doApplyWind     = component->GetResourceMaterial()->DoApplyWind();
-    vCoord0         = component->GetResourceMaterial()->GetVCoord0();
-    vCoord1         = component->GetResourceMaterial()->GetVCoord1();
-    useCentralPivot = component->GetResourceMaterial()->UseCentralPivot();
-    useWindGravity  = component->GetResourceMaterial()->UseWindGravity();
-    windXAmplitude  = component->GetResourceMaterial()->GetWindXAmplitude();
-    windYAmplitude  = component->GetResourceMaterial()->GetWindYAmplitude();
-    windZAmplitude  = component->GetResourceMaterial()->GetWindZAmplitude();
-    windXFrequency  = component->GetResourceMaterial()->GetWindXFrequency();
-    windYFrequency  = component->GetResourceMaterial()->GetWindYFrequency();
-    windZFrequency  = component->GetResourceMaterial()->GetWindZFrequency();
-    windTimeScale   = component->GetResourceMaterial()->GetWindTimeScale();
+    mode                = component->GetResourceMesh()->GetMode();
+    isSpecular          = component->GetResourceMaterial()->GetIsSpecular();
+    isMetallic          = component->GetResourceMaterial()->GetIsMetallicRoughness();
+    hasBones            = component->GetHasBones();
+    isNavmeshValid      = component->GetParent()->IsNavMeshValid();
+    isAlpha             = component->GetRenderMode() == 2;
+    isDoubleSided       = component->GetResourceMaterial()->IsDoubleSided();
+    doApplyWind         = component->GetResourceMaterial()->DoApplyWind();
+    vCoord0             = component->GetResourceMaterial()->GetVCoord0();
+    vCoord1             = component->GetResourceMaterial()->GetVCoord1();
+    useCentralPivot     = component->GetResourceMaterial()->UseCentralPivot();
+    useWindGravity      = component->GetResourceMaterial()->UseWindGravity();
+    useConstantMovement = component->GetResourceMaterial()->UseConstantMovement();
+    windXAmplitude      = component->GetResourceMaterial()->GetWindXAmplitude();
+    windYAmplitude      = component->GetResourceMaterial()->GetWindYAmplitude();
+    windZAmplitude      = component->GetResourceMaterial()->GetWindZAmplitude();
+    windXFrequency      = component->GetResourceMaterial()->GetWindXFrequency();
+    windYFrequency      = component->GetResourceMaterial()->GetWindYFrequency();
+    windZFrequency      = component->GetResourceMaterial()->GetWindZFrequency();
+    windTimeScale       = component->GetResourceMaterial()->GetWindTimeScale();
 
     glGenVertexArrays(1, &vao);
     glGenBuffers(1, &indirect);

--- a/SobrassadaEngine/FileSystem/Batching/GeometryBatch.h
+++ b/SobrassadaEngine/FileSystem/Batching/GeometryBatch.h
@@ -45,6 +45,7 @@ class GeometryBatch
     const float GetVCoord1() const { return vCoord1; }
     const bool UseCentralPivot() const { return useCentralPivot; }
     const bool UseWindGravity() const { return useWindGravity; }
+    const bool UseConstantMovement() const { return useConstantMovement; }
     const float GetWindXAmplitude() const { return windXAmplitude; }
     const float GetWindYAmplitude() const { return windYAmplitude; }
     const float GetWindZAmplitude() const { return windZAmplitude; }
@@ -116,6 +117,7 @@ class GeometryBatch
     float vCoord1                 = 1.0f;
     bool useCentralPivot          = false;
     bool useWindGravity           = false;
+    bool useConstantMovement      = false;
     float windXAmplitude          = 1.0f;
     float windYAmplitude          = 1.0f;
     float windZAmplitude          = 1.0f;

--- a/SobrassadaEngine/ResourceManagement/Resources/ResourceMaterial.cpp
+++ b/SobrassadaEngine/ResourceManagement/Resources/ResourceMaterial.cpp
@@ -40,6 +40,7 @@ void ResourceMaterial::OnEditorUpdate()
         updated |= ImGui::SliderFloat("UV 1 border", &vCoord1, vCoord0 + 0.01f, 1);
         updated |= ImGui::Checkbox("Use central pivot", &useCentralPivot);
         updated |= ImGui::Checkbox("Wind gravity", &useWindGravity);
+        updated |= ImGui::Checkbox("Use constant movement", &useConstantMovement);
         updated |= ImGui::SliderFloat("X amplitude", &windXAmplitude, 0, 2);
         updated |= ImGui::SliderFloat("Y amplitude", &windYAmplitude, 0, 2);
         updated |= ImGui::SliderFloat("Z amplitude", &windZAmplitude, 0, 2);
@@ -325,6 +326,7 @@ void ResourceMaterial::SaveToMeta()
                 importOptions.AddMember("vCoord1", vCoord1, allocator);
                 importOptions.AddMember("useCentralPivot", useCentralPivot, allocator);
                 importOptions.AddMember("useWindGravity", useWindGravity, allocator);
+                importOptions.AddMember("useConstantMovement", useConstantMovement, allocator);
                 importOptions.AddMember("windXAmplitude", windXAmplitude, allocator);
                 importOptions.AddMember("windYAmplitude", windYAmplitude, allocator);
                 importOptions.AddMember("windZAmplitude", windZAmplitude, allocator);
@@ -435,6 +437,10 @@ void ResourceMaterial::LoadMaterialData(const Material& mat, const rapidjson::Va
     if (importOptions.HasMember("useWindGravity") && importOptions["useWindGravity"].IsBool())
         useWindGravity = importOptions["useWindGravity"].GetBool();
     else useWindGravity = false;
+
+    if (importOptions.HasMember("useConstantMovement") && importOptions["useConstantMovement"].IsBool())
+        useConstantMovement = importOptions["useConstantMovement"].GetBool();
+    else useConstantMovement = false;
 
     if (importOptions.HasMember("windXAmplitude") && importOptions["windXAmplitude"].IsFloat())
         windXAmplitude = importOptions["windXAmplitude"].GetFloat();

--- a/SobrassadaEngine/ResourceManagement/Resources/ResourceMaterial.h
+++ b/SobrassadaEngine/ResourceManagement/Resources/ResourceMaterial.h
@@ -64,6 +64,7 @@ class ResourceMaterial : public Resource
     const float GetVCoord1() const { return vCoord1; }
     const bool UseCentralPivot() const { return useCentralPivot; }
     const bool UseWindGravity() const { return useWindGravity; }
+    const bool UseConstantMovement() const { return useConstantMovement; }
     const float GetWindXAmplitude() const { return windXAmplitude; }
     const float GetWindYAmplitude() const { return windYAmplitude; }
     const float GetWindZAmplitude() const { return windZAmplitude; }
@@ -92,24 +93,25 @@ class ResourceMaterial : public Resource
     TextureInfo emmisiveTexture;
     TextureInfo occlusionTexture;
 
-    MaterialGPU material  = {};
-    bool isTransparent    = false;
-    bool isAlpha          = false;
-    bool doubleSided      = false;
-    bool hasNormal        = false;
-    bool applyWind        = false;
-    float vCoord0         = 0.0f;
-    float vCoord1         = 1.0f;
-    bool useCentralPivot  = false;
-    bool useWindGravity   = false;
-    float windXAmplitude  = 1.0f;
-    float windYAmplitude  = 1.0f;
-    float windZAmplitude  = 1.0f;
-    float windXFrequency  = 1.0f;
-    float windYFrequency  = 1.0f;
-    float windZFrequency  = 1.0f;
-    float windTimeScale   = 1.0f;
-    UID defaultTextureUID = INVALID_UID;
+    MaterialGPU material        = {};
+    bool isTransparent          = false;
+    bool isAlpha                = false;
+    bool doubleSided            = false;
+    bool hasNormal              = false;
+    bool applyWind              = false;
+    float vCoord0               = 0.0f;
+    float vCoord1               = 1.0f;
+    bool useCentralPivot        = false;
+    bool useWindGravity         = false;
+    bool useConstantMovement    = false;
+    float windXAmplitude        = 1.0f;
+    float windYAmplitude        = 1.0f;
+    float windZAmplitude        = 1.0f;
+    float windXFrequency        = 1.0f;
+    float windYFrequency        = 1.0f;
+    float windZFrequency        = 1.0f;
+    float windTimeScale         = 1.0f;
+    UID defaultTextureUID       = INVALID_UID;
 
-    bool wasUpdated       = false;
+    bool wasUpdated             = false;
 };


### PR DESCRIPTION
Adds a checkbox to the material wind parameters which removes all position or uv based variables from the vpo calculation. 
This results in the possibility to create objects which just gently sway around without deforming, planned for usage in magic environment rocks.

For testing, just apply the wind to any mesh and check the use constant movement checkbox. The mesh should not deform anymore, only move, while all other controls stay functional. 
Also test that this change does not break the normal wind shader when the constant movement is disabled.