### PR TITLE
Task/Soldier Bugs fixing + attack audio

### DIFF
--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.cpp
@@ -13,6 +13,9 @@
 #include "Standalone/AnimationComponent.h"
 #include "Standalone/CharacterControllerComponent.h"
 #include "Standalone/Physics/CapsuleColliderComponent.h"
+#include "Standalone/Audio/AudioSourceComponent.h"
+
+#include "Wwise_IDs.h"
 #include <random>
 
 Soldier::Soldier(GameObject* parent)
@@ -55,6 +58,9 @@ bool Soldier::Init()
         GLOG("Melee trail found for melee attack in Soldier")
         meleeTrailObject->SetEnabled(false);
     }
+
+    audio = parent->GetComponent<AudioSourceComponent*>();
+    if (!audio) GLOG("[WARNING] Soldier: No audio component found");
 
     return true;
 }
@@ -214,6 +220,7 @@ void Soldier::HandleState(float deltaTime)
 void Soldier::PatrolAI(float deltaTime)
 {
     const HashString& playerLocation = AppEngine->GetSceneModule()->GetScene()->GetPlayerLocation();
+    GLOG("Player location: %s", playerLocation.GetString().c_str());
     bool playerInLocation            = parent->HasTag(playerLocation);
 
     if (!playerScript->IsDead())
@@ -327,6 +334,8 @@ void Soldier::Attack(float deltaTime)
             if ((inFirstWindow || inSecondWindow) && !weaponCollider->GetEnabled())
             {
                 weaponCollider->SetEnabled(true);
+                if (inFirstWindow && audio) audio->EmitEvent(AK::EVENTS::PLAY_SFX_SOLDIER_SLASH_1);
+                if (inSecondWindow && audio) audio->EmitEvent(AK::EVENTS::PLAY_SFX_SOLDIER_SLASH_2);
             }
             else if (!inFirstWindow && !inSecondWindow && weaponCollider->GetEnabled())
             {
@@ -339,6 +348,7 @@ void Soldier::Attack(float deltaTime)
                 attackTimer <= attackHitboxDelay + attackHitboxDuration)
             {
                 weaponCollider->SetEnabled(true);
+                if (audio) audio->EmitEvent(AK::EVENTS::PLAY_SFX_SOLDIER_THRUST);
 
                 thrustAdvance = true;
             }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.cpp
@@ -147,6 +147,7 @@ void Soldier::OnDamageTaken(int amount)
     // std::string animState               = animStateFromPlayer.GetString();
     // GLOG("Soldier %s damaged with state %s", parent->GetName().c_str(), animState.c_str());
     if (animComponent) animComponent->UseTrigger("damaged");
+    if (meleeTrailObject) meleeTrailObject->SetEnabled(false);
 }
 
 void Soldier::PerformAttack()

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.cpp
@@ -375,7 +375,7 @@ void Soldier::ChangeState()
 {
     if (playerScript->IsDead())
     {
-        currentState = SoldierStates::DEATH;
+        currentState = SoldierStates::PATROL;
         return;
     }
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.h
@@ -4,6 +4,7 @@
 
 class GameObject;
 class AIAgentComponent;
+class AudioSourceComponent;
 
 enum class SoldierStates
 {
@@ -48,6 +49,8 @@ class Soldier : public Character
   private:
     AIAgentComponent* agentAI        = nullptr;
     SoldierStates currentState       = SoldierStates::NONE;
+
+    AudioSourceComponent* audio      = nullptr;
 
     float3 patrolPoint               = float3::zero;
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Wwise_IDs.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Wwise_IDs.h
@@ -15,10 +15,13 @@ namespace AK
     {
         static const AkUniqueID PLAY_FIRST_THEME = 1086074370U;
         static const AkUniqueID PLAY_FOREST = 207755397U;
+        static const AkUniqueID PLAY_SFX_ARCHER_ATTACK = 1559026790U;
+        static const AkUniqueID PLAY_SFX_ARCHER_OVERSHOOTING = 2850888511U;
         static const AkUniqueID PLAY_SFX_BANSHEE_ATTACK = 2747797885U;
         static const AkUniqueID PLAY_SFX_BUTTON_01 = 920741356U;
         static const AkUniqueID PLAY_SFX_BUTTON_02 = 920741359U;
         static const AkUniqueID PLAY_SFX_BUTTON_03 = 920741358U;
+        static const AkUniqueID PLAY_SFX_CATAPULT = 4294826722U;
         static const AkUniqueID PLAY_SFX_CAVE_01 = 3434634929U;
         static const AkUniqueID PLAY_SFX_CAVE_02 = 3434634930U;
         static const AkUniqueID PLAY_SFX_CAVE_03 = 3434634931U;
@@ -37,6 +40,9 @@ namespace AK
         static const AkUniqueID PLAY_SFX_POOKA_DEATH = 4271776059U;
         static const AkUniqueID PLAY_SFX_POOKA_HURT = 1906970548U;
         static const AkUniqueID PLAY_SFX_SOLDIER_ATTACK = 3285336459U;
+        static const AkUniqueID PLAY_SFX_SOLDIER_SLASH_1 = 3272153282U;
+        static const AkUniqueID PLAY_SFX_SOLDIER_SLASH_2 = 3272153281U;
+        static const AkUniqueID PLAY_SFX_SOLDIER_THRUST = 1691226597U;
         static const AkUniqueID PLAY_SFX_STEPS_GRASS = 879946080U;
         static const AkUniqueID PLAY_SFX_STEPS_ROCK = 2099665009U;
         static const AkUniqueID PLAY_SFX_STEPS_WOOD = 2418067177U;


### PR DESCRIPTION
PR fixing 2 bugs and adding audio to the attacks of the Soldier. Wanted to include the changing helmets functionality to this PR but i didn't get the meshes at time so i priorized having the bugs fixed.

To test:
-Go tho the SoldierNewRig branch at the game repo in Level 1
-Check the Soldier now doesen't dissapear when killing the player
-Check The trail now works correctly
-Check the audio is correct when the soldier attacks. It has a different audio for each attack.

