### PR TITLE
fix arrow crash

### DIFF
--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -553,7 +553,7 @@ void CuChulainn::OnDamageTaken(int amount)
     if (audio) audio->EmitEvent(AK::EVENTS::PLAY_SFX_MC_HURT);
     AddRiastrad(riastradOnDamageTaken);
 
-    if (arrowVfxIsActive && !arrowHitVfxObject->IsEnabled())
+    if (arrowVfxIsActive && arrowHitVfxObject && !arrowHitVfxObject->IsEnabled())
     {
         GLOG("Activating arrow VFX - isActive: %s, timer: %f", arrowVfxIsActive ? "true" : "false", arrowHitVfxTimer);
 
@@ -945,7 +945,7 @@ void CuChulainn::OnDamageTaken(int amount)
             if (dashBufferTimer < 0.0f) desiredDash = false;
         }
 
-        if (arrowVfxIsActive && arrowHitVfxObject->IsEnabled())
+        if (arrowVfxIsActive && arrowHitVfxObject && arrowHitVfxObject->IsEnabled())
         {
             arrowHitVfxTimer += deltaTime;
             if (arrowHitVfxTimer >= arrowHitVfxDuration)


### PR DESCRIPTION
I couldn't test it because to me in alpha 2 archers don't shoot and teleport around, but this should fix the crash