### PR TITLE
THO-1002 transparency order

### DIFF
--- a/Game/EngineDefaults/Shader/Custom/Fragment/AttackVfx_Fragment.glsl
+++ b/Game/EngineDefaults/Shader/Custom/Fragment/AttackVfx_Fragment.glsl
@@ -11,6 +11,10 @@ out vec4 fragColor;
 void main()
 {
     vec4 texColor = texture2D(sampler2D(myTexture), uv);
-    // fragColor = vec4(0, 0, 1.0f, 1.0f);
+    
+    if (texColor.a < 0.1f) {
+        discard;
+    }
+
     fragColor = texColor;
 }

--- a/Game/EngineDefaults/Shader/Custom/Fragment/ColorChange_Fragment.glsl
+++ b/Game/EngineDefaults/Shader/Custom/Fragment/ColorChange_Fragment.glsl
@@ -1,0 +1,10 @@
+#version 460
+
+layout(location=3) uniform vec3 targetColor;
+
+out vec4 fragColor;
+
+void main()
+{
+    fragColor = vec4(targetColor, 1.0f);
+}

--- a/Game/EngineDefaults/Shader/Custom/Vertex/ColorChange_Vertex.glsl
+++ b/Game/EngineDefaults/Shader/Custom/Vertex/ColorChange_Vertex.glsl
@@ -1,0 +1,33 @@
+#version 460
+
+layout(location=0) in vec3 vertexPosition;
+layout(location=1) in vec4 vertexTangent;
+layout(location=2) in vec3 vertexNormal;
+layout(location=3) in vec2 vertexUV;
+layout(location=4) in ivec4 vertexJoint;
+layout(location=5) in vec4 vertexWeights;
+
+layout(location=0) uniform mat4 proj;
+layout(location=1) uniform mat4 view;
+layout(location=2) uniform mat4 model;
+
+layout(location=9) uniform bool hasBones;
+layout(location=10) uniform uint boneIndex;
+
+readonly layout(std430, row_major, binding = 12) buffer Bones {
+    mat4 palettes[];
+};
+
+void main()
+{
+    vec3 pos = vec3(model * vec4(vertexPosition, 1.0));
+
+    if (hasBones) 
+    {
+        mat4 skin    = palettes[boneIndex + vertexJoint[0]] * vertexWeights[0] + palettes[boneIndex + vertexJoint[1]] * vertexWeights[1] +             
+                       palettes[boneIndex + vertexJoint[2]] * vertexWeights[2] + palettes[boneIndex + vertexJoint[3]] * vertexWeights[3];
+        pos          = (skin * vec4(vertexPosition, 1.0)).xyz;
+    }
+
+    gl_Position = proj * view * vec4(pos, 1.0f);
+}

--- a/SobrassadaEngine/.vscode/settings.json
+++ b/SobrassadaEngine/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "files.associations": {
-        "xiosbase": "cpp",
-        "functional": "cpp"
-    }
-}

--- a/SobrassadaEngine/FileSystem/Batching/BatchManager.cpp
+++ b/SobrassadaEngine/FileSystem/Batching/BatchManager.cpp
@@ -241,7 +241,8 @@ void BatchManager::RenderTransparent(
     GeometryBatch* currentBatch = batchMeshes[0]->GetBatch();
     std::vector<MeshComponent*> currentBatchMeshes;
 
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    //glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE);
 
     currentBatchMeshes.push_back(batchMeshes[0]);
     glEnable(GL_BLEND);

--- a/SobrassadaEngine/FileSystem/Importers/MaterialImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/MaterialImporter.cpp
@@ -262,9 +262,10 @@ ResourceMaterial* MaterialImporter::LoadMaterial(UID materialUID)
     }
 
     char* cursor = buffer;
-    
+
+    rapidjson::Document doc;
     rapidjson::Value importOptions;
-    App->GetLibraryModule()->GetImportOptions(materialUID, importOptions);
+    App->GetLibraryModule()->GetImportOptions(materialUID, doc, importOptions);
 
     // Create Mesh
     Material mat               = *reinterpret_cast<Material*>(cursor);

--- a/SobrassadaEngine/FileSystem/Importers/MaterialImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/MaterialImporter.cpp
@@ -262,10 +262,9 @@ ResourceMaterial* MaterialImporter::LoadMaterial(UID materialUID)
     }
 
     char* cursor = buffer;
-
-    rapidjson::Document doc;
+    
     rapidjson::Value importOptions;
-    App->GetLibraryModule()->GetImportOptions(materialUID, doc, importOptions);
+    App->GetLibraryModule()->GetImportOptions(materialUID, importOptions);
 
     // Create Mesh
     Material mat               = *reinterpret_cast<Material*>(cursor);

--- a/SobrassadaEngine/FileSystem/Importers/MeshImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/MeshImporter.cpp
@@ -497,9 +497,8 @@ namespace MeshImporter
         float3 maxPos  = *reinterpret_cast<float3*>(cursor);
         cursor        += sizeof(float3);
 
-        rapidjson::Document doc;
         rapidjson::Value importOptions;
-        App->GetLibraryModule()->GetImportOptions(meshUID, doc, importOptions);
+        App->GetLibraryModule()->GetImportOptions(meshUID, importOptions);
 
         ResourceMesh* mesh = new ResourceMesh(meshUID, name, maxPos, minPos, importOptions);
 

--- a/SobrassadaEngine/FileSystem/Importers/MeshImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/MeshImporter.cpp
@@ -497,8 +497,9 @@ namespace MeshImporter
         float3 maxPos  = *reinterpret_cast<float3*>(cursor);
         cursor        += sizeof(float3);
 
+        rapidjson::Document doc;
         rapidjson::Value importOptions;
-        App->GetLibraryModule()->GetImportOptions(meshUID, importOptions);
+        App->GetLibraryModule()->GetImportOptions(meshUID, doc, importOptions);
 
         ResourceMesh* mesh = new ResourceMesh(meshUID, name, maxPos, minPos, importOptions);
 

--- a/SobrassadaEngine/FileSystem/Importers/SceneImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/SceneImporter.cpp
@@ -15,6 +15,7 @@
 #define TINYGLTF_NO_STB_IMAGE
 #define TINYGLTF_NO_EXTERNAL_IMAGE
 #define TINYGLTF_IMPLEMENTATION /* Only in one of the includes */
+#include "LibraryModule.h"
 #include "MetaMesh.h"
 #include "tiny_gltf.h"
 #include <utility>
@@ -105,6 +106,10 @@ namespace SceneImporter
 
         // Import Model
         ModelImporter::ImportModel(model, gltfMeshes, filePath, targetFilePath);
+
+        // Could also create new cache entries for all imported files, however the performance gain is minimal and the
+        // risk for missing files high. Not worth the development work
+        App->GetLibraryModule()->InvalidateMetadataCache();
     }
 
     void CopyGLTF(const char* filePath, const std::string& targetFilePath, std::string& copiedFilePath)

--- a/SobrassadaEngine/Modules/LibraryModule.cpp
+++ b/SobrassadaEngine/Modules/LibraryModule.cpp
@@ -236,15 +236,9 @@ bool LibraryModule::LoadLibraryMaps(const std::string& projectPath)
     return true;
 }
 
-void LibraryModule::GetImportOptions(UID uid, rapidjson::Value& outImportOptions)
+void LibraryModule::GetImportOptions(UID uid, rapidjson::Document& doc, rapidjson::Value& importOptions)
 {
-    const std::string& projectPath = App->GetProjectModule()->GetLoadedProjectPath();
-    SearchImportOptionsFromUID(uid, projectPath, outImportOptions);
-    if (outImportOptions.IsNull())
-    {
-        const std::string& engineDefaultPath = ENGINE_DEFAULT_ASSETS;
-        SearchImportOptionsFromUID(uid, engineDefaultPath, outImportOptions);
-    }
+    SearchImportOptionsFromUID(uid, doc, importOptions);
 }
 
 UID LibraryModule::GetUIDFromMetaFile(const std::string& filePath) const
@@ -257,35 +251,19 @@ UID LibraryModule::GetUIDFromMetaFile(const std::string& filePath) const
     return INVALID_UID;
 }
 
-void LibraryModule::SearchImportOptionsFromUID(UID uid, const std::string& path, rapidjson::Value& outImportOptions)
+void LibraryModule::SearchImportOptionsFromUID(UID uid, rapidjson::Document& doc, rapidjson::Value& importOptions)
 {
     if (cachedMetadataDocuments.empty())
     {
-        for (const auto& entry : std::filesystem::recursive_directory_iterator(path + METADATA_PATH))
-        {
-            if (entry.is_regular_file() && (FileSystem::GetFileExtension(entry.path().string()) == META_EXTENSION))
-            {
-                std::string filePath = entry.path().string();
-                rapidjson::Document doc;
-                if (!FileSystem::LoadJSON(filePath.c_str(), doc)) continue;
-
-                UID assetUID = doc["UID"].GetUint64();
-                
-                if (doc.HasMember("importOptions") && doc["importOptions"].IsObject())
-                {
-                    cachedMetadataDocuments[assetUID] = entry.path().string();
-                }
-            }
-        }
+        CreateCacheForMetadata(ENGINE_DEFAULT_ASSETS);
+        CreateCacheForMetadata(App->GetProjectModule()->GetLoadedProjectPath());
     }
 
     if (const auto it = cachedMetadataDocuments.find(uid); it != cachedMetadataDocuments.end())
     {
-        // Doc can not be cached, so we have to load the json twice
-        rapidjson::Document doc;
         if (!FileSystem::LoadJSON(it->second.c_str(), doc)) return;
-        
-        outImportOptions = doc["importOptions"];
+
+        importOptions = doc["importOptions"];
     }
 }
 
@@ -499,6 +477,26 @@ const std::string& LibraryModule::GetResourcePath(UID resourceID) const
     }
 
     return emptyString;
+}
+
+void LibraryModule::CreateCacheForMetadata(const std::string& path)
+{
+    for (const auto& entry : std::filesystem::recursive_directory_iterator(path + METADATA_PATH))
+    {
+        if (entry.is_regular_file() && (FileSystem::GetFileExtension(entry.path().string()) == META_EXTENSION))
+        {
+            std::string filePath = entry.path().string();
+            rapidjson::Document doc;
+            if (!FileSystem::LoadJSON(filePath.c_str(), doc)) continue;
+
+            UID assetUID = doc["UID"].GetUint64();
+
+            if (doc.HasMember("importOptions") && doc["importOptions"].IsObject())
+            {
+                cachedMetadataDocuments[assetUID] = entry.path().string();
+            }
+        }
+    }
 }
 
 const std::string& LibraryModule::GetResourceName(UID resourceID) const

--- a/SobrassadaEngine/Modules/LibraryModule.cpp
+++ b/SobrassadaEngine/Modules/LibraryModule.cpp
@@ -236,14 +236,14 @@ bool LibraryModule::LoadLibraryMaps(const std::string& projectPath)
     return true;
 }
 
-void LibraryModule::GetImportOptions(UID uid, rapidjson::Document& doc, rapidjson::Value& outImportOptions) const
+void LibraryModule::GetImportOptions(UID uid, rapidjson::Value& outImportOptions)
 {
     const std::string& projectPath = App->GetProjectModule()->GetLoadedProjectPath();
-    SearchImportOptionsFromUID(uid, projectPath, doc, outImportOptions);
+    SearchImportOptionsFromUID(uid, projectPath, outImportOptions);
     if (outImportOptions.IsNull())
     {
         const std::string& engineDefaultPath = ENGINE_DEFAULT_ASSETS;
-        SearchImportOptionsFromUID(uid, engineDefaultPath, doc, outImportOptions);
+        SearchImportOptionsFromUID(uid, engineDefaultPath, outImportOptions);
     }
 }
 
@@ -257,25 +257,35 @@ UID LibraryModule::GetUIDFromMetaFile(const std::string& filePath) const
     return INVALID_UID;
 }
 
-void LibraryModule::SearchImportOptionsFromUID(
-    UID uid, const std::string& path, rapidjson::Document& doc, rapidjson::Value& outImportOptions
-) const
+void LibraryModule::SearchImportOptionsFromUID(UID uid, const std::string& path, rapidjson::Value& outImportOptions)
 {
-    for (const auto& entry : std::filesystem::recursive_directory_iterator(path + METADATA_PATH))
+    if (cachedMetadataDocuments.empty())
     {
-        if (entry.is_regular_file() && (FileSystem::GetFileExtension(entry.path().string()) == META_EXTENSION))
+        for (const auto& entry : std::filesystem::recursive_directory_iterator(path + METADATA_PATH))
         {
-            std::string filePath = entry.path().string();
-            if (!FileSystem::LoadJSON(filePath.c_str(), doc)) continue;
-
-            UID assetUID = doc["UID"].GetUint64();
-
-            if (uid == assetUID && doc.HasMember("importOptions") && doc["importOptions"].IsObject())
+            if (entry.is_regular_file() && (FileSystem::GetFileExtension(entry.path().string()) == META_EXTENSION))
             {
-                outImportOptions = doc["importOptions"];
-                return;
+                std::string filePath = entry.path().string();
+                rapidjson::Document doc;
+                if (!FileSystem::LoadJSON(filePath.c_str(), doc)) continue;
+
+                UID assetUID = doc["UID"].GetUint64();
+                
+                if (doc.HasMember("importOptions") && doc["importOptions"].IsObject())
+                {
+                    cachedMetadataDocuments[assetUID] = entry.path().string();
+                }
             }
         }
+    }
+
+    if (const auto it = cachedMetadataDocuments.find(uid); it != cachedMetadataDocuments.end())
+    {
+        // Doc can not be cached, so we have to load the json twice
+        rapidjson::Document doc;
+        if (!FileSystem::LoadJSON(it->second.c_str(), doc)) return;
+        
+        outImportOptions = doc["importOptions"];
     }
 }
 
@@ -344,6 +354,11 @@ void LibraryModule::DeletePrefabFiles(UID prefabUID)
     resourcePathsMap.erase(prefabUID);
 
     App->GetSceneModule()->GetScene()->OverridePrefabs(prefabUID);
+}
+
+void LibraryModule::InvalidateMetadataCache()
+{
+    cachedMetadataDocuments.clear();
 }
 
 void LibraryModule::AddTexture(UID textureUID, const std::string& textureName)

--- a/SobrassadaEngine/Modules/LibraryModule.h
+++ b/SobrassadaEngine/Modules/LibraryModule.h
@@ -43,9 +43,9 @@ class LibraryModule : public Module
     bool LoadScene(const char* fileName, bool reload = false) const;
 
     bool LoadLibraryMaps(const std::string& projectPath);
-    void GetImportOptions(UID uid, rapidjson::Value& importOptions);
+    void GetImportOptions(UID uid, rapidjson::Document& doc, rapidjson::Value& importOptions);
     UID GetUIDFromMetaFile(const std::string& path) const;
-    void SearchImportOptionsFromUID(UID uid, const std::string& path, rapidjson::Value& importOptions);
+    void SearchImportOptionsFromUID(UID uid, rapidjson::Document& doc, rapidjson::Value& importOptions);
     UID AssignFiletypeUID(UID originalUID, FileType fileType);
     void DeletePrefabFiles(UID prefabUID);
 
@@ -87,9 +87,10 @@ class LibraryModule : public Module
     const std::unordered_map<UID, HashString>& GetAllNamesMap() const { return namesMap; }
 
   private:
+    void CreateCacheForMetadata(const std::string& path);
 
     std::unordered_map<UID, std::string> cachedMetadataDocuments;
-    
+
     // maps for user visuals | name -> UID
     std::unordered_map<HashString, UID> textureMap;
     std::unordered_map<HashString, UID> materialMap;

--- a/SobrassadaEngine/Modules/LibraryModule.h
+++ b/SobrassadaEngine/Modules/LibraryModule.h
@@ -43,13 +43,14 @@ class LibraryModule : public Module
     bool LoadScene(const char* fileName, bool reload = false) const;
 
     bool LoadLibraryMaps(const std::string& projectPath);
-    void GetImportOptions(UID uid, rapidjson::Document& doc, rapidjson::Value& importOptions) const;
+    void GetImportOptions(UID uid, rapidjson::Value& importOptions);
     UID GetUIDFromMetaFile(const std::string& path) const;
-    void SearchImportOptionsFromUID(
-        UID uid, const std::string& path, rapidjson::Document& doc, rapidjson::Value& importOptions
-    ) const;
+    void SearchImportOptionsFromUID(UID uid, const std::string& path, rapidjson::Value& importOptions);
     UID AssignFiletypeUID(UID originalUID, FileType fileType);
     void DeletePrefabFiles(UID prefabUID);
+
+    // Deletes the metadata cache so its regenerated with the next call to access it
+    void InvalidateMetadataCache();
 
     void AddTexture(UID textureUID, const std::string& ddsPath);
     void AddMesh(UID meshUID, const std::string& matPath);
@@ -86,6 +87,9 @@ class LibraryModule : public Module
     const std::unordered_map<UID, HashString>& GetAllNamesMap() const { return namesMap; }
 
   private:
+
+    std::unordered_map<UID, std::string> cachedMetadataDocuments;
+    
     // maps for user visuals | name -> UID
     std::unordered_map<HashString, UID> textureMap;
     std::unordered_map<HashString, UID> materialMap;

--- a/SobrassadaEngine/Modules/PhysicsModule.cpp
+++ b/SobrassadaEngine/Modules/PhysicsModule.cpp
@@ -10,6 +10,7 @@
 #include "Standalone/Physics/CubeColliderComponent.h"
 #include "Standalone/Physics/SphereColliderComponent.h"
 
+#include "Geometry/LineSegment.h"
 #include "Math/float3.h"
 #include "btBulletDynamicsCommon.h"
 
@@ -360,7 +361,6 @@ void PhysicsModule::AddRigidBody(btRigidBody* rigidBody, ColliderType colliderTy
     int mask                      = 0;
     const LayerBitset& maskBitset = colliderLayerConfig[(int)layerType];
 
- 
     for (int i = 0; i < maskBitset.size(); ++i)
     {
         if (maskBitset[i]) mask |= 1 << i;
@@ -370,7 +370,7 @@ void PhysicsModule::AddRigidBody(btRigidBody* rigidBody, ColliderType colliderTy
 // TODO READ FROM CONFIG FILE
 void PhysicsModule::LoadLayerData(const rapidjson::Value* initialState)
 {
-   
+
     for (int i = 0; i < colliderLayerConfig.size(); ++i)
         colliderLayerConfig[i].reset();
     // loading defaults if no scene state with saved data
@@ -394,17 +394,16 @@ void PhysicsModule::LoadLayerData(const rapidjson::Value* initialState)
                  1 << (int)ColliderLayer::TRIGGERS | 1 << (int)ColliderLayer::ENEMY_PROJECTILE;
         colliderLayerConfig[3] |= config;
 
-       config                  = 1 << (int)ColliderLayer::ENEMY | 1 << (int)ColliderLayer::WALL;
-        colliderLayerConfig[4] |= config; 
+        config                  = 1 << (int)ColliderLayer::ENEMY | 1 << (int)ColliderLayer::WALL;
+        colliderLayerConfig[4] |= config;
 
         // ENEMY PROJECTILE
-        config                  = 1 << (int)ColliderLayer::PLAYER | 1 <<(int)ColliderLayer::WALL;
+        config                  = 1 << (int)ColliderLayer::PLAYER | 1 << (int)ColliderLayer::WALL;
         colliderLayerConfig[5] |= config;
 
-       // WALL
+        // WALL
         config = 1 << (int)ColliderLayer::PLAYER_PROJECTILE | 1 << (int)ColliderLayer::ENEMY_PROJECTILE;
         colliderLayerConfig[6] |= config;
-       
     }
     else
     {
@@ -460,8 +459,6 @@ void PhysicsModule::LoadLayerData(const rapidjson::Value* initialState)
             colliderLayerConfig[6] |= currentMask;
         }
     }
-
-
 }
 
 void PhysicsModule::SaveLayerData(rapidjson::Value& targetState, rapidjson::Document::AllocatorType& allocator)
@@ -528,4 +525,26 @@ void PhysicsModule::RebuildWorld()
     {
         gameObject.second->ParentUpdatedComponents();
     }
+}
+
+BulletUserPointer* PhysicsModule::RaycastToWorld(const math::LineSegment& ray)
+{
+    if (!dynamicsWorld) return nullptr;
+
+    btVector3 start, finish;
+
+    start  = btVector3(ray.a.x, ray.a.y, ray.a.z);
+    finish = btVector3(ray.b.x, ray.b.y, ray.b.z);
+
+    btCollisionWorld::ClosestRayResultCallback raycastResult(start, finish);
+    dynamicsWorld->rayTest(start, finish, raycastResult);
+
+    if (raycastResult.hasHit())
+    {
+        BulletUserPointer* userPointer =
+            static_cast<BulletUserPointer*>(raycastResult.m_collisionObject->getUserPointer());
+        if (userPointer) return userPointer;
+    }
+
+    return nullptr;
 }

--- a/SobrassadaEngine/Modules/PhysicsModule.h
+++ b/SobrassadaEngine/Modules/PhysicsModule.h
@@ -21,6 +21,11 @@ class CubeColliderComponent;
 class SphereColliderComponent;
 class CapsuleColliderComponent;
 
+namespace math
+{
+    class LineSegment;
+}
+
 constexpr float DEFAULT_GRAVITY = -9.81f;
 
 typedef std::bitset<sizeof(ColliderLayerStrings) / sizeof(char*)> LayerBitset;
@@ -41,6 +46,8 @@ class SOBRASADA_API_ENGINE PhysicsModule : public Module
     void SaveLayerData(rapidjson::Value& targetState, rapidjson::Document::AllocatorType& allocator);
     void EmptyWorld();
     void RebuildWorld();
+
+    BulletUserPointer* RaycastToWorld(const math::LineSegment& ray);
 
     void CreateCubeRigidBody(CubeColliderComponent* colliderComponent);
     void UpdateCubeRigidBody(CubeColliderComponent* colliderComponent);

--- a/SobrassadaEngine/Modules/SceneModule.cpp
+++ b/SobrassadaEngine/Modules/SceneModule.cpp
@@ -450,7 +450,7 @@ void SceneModule::HandleTreesUpdates()
     OPTICK_CATEGORY("Application::HandleTreesUpdates", Optick::Category::GameLogic)
 #endif
     {
-        if (loadedScene->IsStaticModified())
+        if (loadedScene->IsStaticModified() && !inPlayMode)
         {
             loadedScene->UpdateStaticSpatialStructure();
         }

--- a/SobrassadaEngine/Modules/ShaderScriptModule.cpp
+++ b/SobrassadaEngine/Modules/ShaderScriptModule.cpp
@@ -264,6 +264,7 @@ void ShaderScriptModule::RenderGeometryPassShaders(float deltaTime, CameraCompon
 
 void ShaderScriptModule::RenderTransparentPassShaders(float deltaTime, CameraComponent* camera)
 {
+    glDepthMask(GL_FALSE);
     // SORT MESHES TO CAMERA DISTABCE
     std::sort(
         transparentComponents.begin(), transparentComponents.end(),
@@ -314,6 +315,7 @@ void ShaderScriptModule::RenderTransparentPassShaders(float deltaTime, CameraCom
     }
 
     glDisable(GL_BLEND);
+    glDepthMask(GL_TRUE);
 }
 
 void ShaderScriptModule::RenderPostLightingPassShaders(float deltaTime, CameraComponent* camera)

--- a/SobrassadaEngine/Scene/Components/Standalone/CharacterControllerComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/Standalone/CharacterControllerComponent.cpp
@@ -14,6 +14,7 @@
 #include "ResourcesModule.h"
 #include "SceneModule.h"
 #include "Utils/RaycastController.h"
+#include "BulletUserPointer.h"
 
 #include "Geometry/LineSegment.h"
 #include "Geometry/Plane.h"
@@ -526,6 +527,14 @@ void CharacterControllerComponent::CheckDashObstacles()
     GameObject* leftHit = RaycastController::GetRayIntersectionTrees(
         leftRay, App->GetSceneModule()->GetScene()->GetOctree(), App->GetSceneModule()->GetScene()->GetDynamicTree()
     );
+
+    GameObject* hitParent          = nullptr;
+    BulletUserPointer* userPointer = RaycastController::GetRayIntersectionPhysics(centralRay);
+    if (userPointer)
+    {
+        hitParent = userPointer->collider->GetParent();
+        GLOG("[CharacterControllerComponent]: Physics Raycast hit!, %s", hitParent->GetName().c_str());
+    }
 
     DebugDrawModule* debug = App->GetDebugDrawModule();
     if (debug->GetDebugOptionValue((int)DebugOptions::RENDER_DEBUG_VISUALS))

--- a/SobrassadaEngine/Scene/RenderPass.cpp
+++ b/SobrassadaEngine/Scene/RenderPass.cpp
@@ -924,6 +924,7 @@ void RenderPass::TransparentPassRender(const std::vector<GameObject*>& objectsTo
 {
     Bind();
 
+    glDepthMask(GL_FALSE);
     BatchManager* batchManager    = App->GetResourcesModule()->GetBatchManager();
 
     const unsigned int program    = App->GetShaderModule()->GetTransparentPassProgram();
@@ -1019,7 +1020,8 @@ void RenderPass::TransparentPassRender(const std::vector<GameObject*>& objectsTo
             batchManager->RenderTransparent(vertexOffsetMeshesToRender, wPOProgram, camera);
 
             glEnable(GL_BLEND);
-            glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+            //glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+            glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
             glDisable(GL_CULL_FACE);
             glDepthMask(GL_FALSE);
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Archer.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Archer.cpp
@@ -125,6 +125,17 @@ void Archer::Update(float deltaTime)
 {
     if (agentAI == nullptr) return;
 
+    if (currentState == ArcherStates::DEATH && animComponent && animComponent->IsFinished())
+    {
+        parent->SetEnabled(false);
+    }
+
+    if (currentState == ArcherStates::DEATH)
+    {
+        Character::UpdateTimers(deltaTime);
+        return;
+    }
+
     if (isKnockback)
     {
         float3 currentPos   = parent->GetGlobalTransform().TranslatePart();
@@ -156,14 +167,6 @@ void Archer::Update(float deltaTime)
             archerVfxObject->SetEnabled(false);
             hitVfxTimer    = 0.0f;
             hitVfxIsActive = false;
-        }
-    }
-    if (isDead)
-    {
-        if (currentState == ArcherStates::DEATH && animComponent && animComponent->IsFinished())
-        {
-            GLOG("DEATH ANIMATION FINISHED - DISABLING OBJECT");
-            parent->SetEnabled(false);
         }
     }
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/AttackVfxSpritesheet.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/AttackVfxSpritesheet.cpp
@@ -28,6 +28,7 @@ AttackVfxSpritesheet::AttackVfxSpritesheet(GameObject* parent) : Script(parent)
     fields.push_back({"Update Rate", InspectorField::FieldType::Float, &updateRate, 0.0f, 1.0f});
     fields.push_back({"Row major", InspectorField::FieldType::Bool, &isRowMajor});
     fields.push_back({"Double sided", InspectorField::FieldType::Bool, &isDoubleSided});
+    fields.push_back({"Is One Shot", InspectorField::FieldType::Bool, &isOneShot});
     fields.push_back({"Texture", InspectorField::FieldType::Resource, &otherImageUID});
 }
 
@@ -152,6 +153,11 @@ void AttackVfxSpritesheet::Update(float deltaTime)
         }
     }
     timer = 0.0f;
+
+    if (isOneShot && uvRange.y >= 1.0f && uvRange.w >= 1.0f)
+    {
+        parent->SetEnabled(false);
+    }
 }
 
 void AttackVfxSpritesheet::Render(float deltaTime, CameraComponent* cameraComp)
@@ -194,7 +200,7 @@ void AttackVfxSpritesheet::Render(float deltaTime, CameraComponent* cameraComp)
         glBlendFunc(GL_SRC_ALPHA, GL_ONE);
 
         glEnable(GL_POLYGON_OFFSET_FILL);
-        glPolygonOffset(-10.0f, -10.0f);
+        glPolygonOffset(-2.0f, -2.0f);
 
         if (isDoubleSided) glDisable(GL_CULL_FACE);
         AppEngine->GetOpenGLModule()->DrawElements(GL_TRIANGLES, indexCount, GL_UNSIGNED_INT, 0);

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/AttackVfxSpritesheet.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/AttackVfxSpritesheet.h
@@ -41,4 +41,6 @@ class AttackVfxSpritesheet : public Script
     ResourceTexture* otherImage = nullptr;
     UID otherImageUID           = 0;
     UID otherImageBindlessUID   = 0;
+
+    bool isOneShot              = false;
 };

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Character.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Character.cpp
@@ -1,11 +1,13 @@
 #include "pch.h"
 
 #include "Application.h"
+#include "AttackVfxSpritesheet.h"
 #include "ArcherProjectile.h"
 #include "Banshee_v2.h"
 #include "Boss.h"
 #include "CameraComponent.h"
 #include "Character.h"
+#include "ColorChange.h"
 #include "CuChulainn.h"
 #include "DebugDrawModule.h"
 #include "EditorUIModule.h"
@@ -13,16 +15,20 @@
 #include "GameObject.h"
 #include "GameTimer.h"
 #include "MagicBarrier.h"
+#include "Math/Quat.h"
 #include "Mushroom.h"
 #include "Projectile.h"
 #include "ScriptComponent.h"
+#include "ShaderScriptComponent.h"
 #include "Spouts.h"
 #include "Standalone/AnimationComponent.h"
 #include "Standalone/CharacterControllerComponent.h"
+#include "Standalone/MeshComponent.h"
 #include "Standalone/Physics/CapsuleColliderComponent.h"
 #include "Standalone/Physics/CubeColliderComponent.h"
 #include "Standalone/Physics/SphereColliderComponent.h"
 #include "WindowModule.h"
+#include <math.h>
 
 #include <string>
 
@@ -49,12 +55,17 @@ Character::Character(
 
     fields.push_back({"Heal Cooldown", InspectorField::FieldType::Float, &healCooldown, 0.0f, 5.0f});
 
-    if (type != CharacterType::CuChulainn)
+    if (type != CharacterType::CuChulainn && type != CharacterType::Mirage)
     {
         fields.push_back({"AI Chase Range", InspectorField::FieldType::Float, &rangeAIChase, 0.0f, 20.0f});
         fields.push_back({"AI Attack Range", InspectorField::FieldType::Float, &rangeAIAttack, 0.0f, 15.0f});
         fields.push_back({"AI Max Detection Range", InspectorField::FieldType::Float, &maxDetectionRange, 0.0f, 15.0f});
         fields.push_back({"Player search duration", InspectorField::FieldType::Float, &searchDuration, 0.0f, 10.0f});
+        fields.push_back({"Mesh name", InspectorField::FieldType::InputText, &meshName});
+        fields.push_back({"On Hit VFX Duration", InspectorField::FieldType::Float, &onHitVfxDuration, 0.0f, 1.0f});
+        fields.push_back({"On Hit Pivot Name", InspectorField::FieldType::InputText, &onHitPivotName});
+        fields.push_back({"On Hit VFX 1", InspectorField::FieldType::InputText, &onHitVfx1Name});
+        fields.push_back({"On Hit VFX 2", InspectorField::FieldType::InputText, &onHitVfx2Name});
     }
 }
 
@@ -85,6 +96,33 @@ bool Character::Init()
         weapon = weaponCollider->GetParent();
         if (!weapon) GLOG("Weapon game object not found")
         else weaponCollider->SetEnabled(false);
+    }
+
+    if (type != CharacterType::CuChulainn && type != CharacterType::Mirage)
+    {
+        onHitPivot = parent->GetChildGameObjectByName(onHitPivotName);
+        if (!onHitPivot) GLOG("[WARNING - %s] No on hit Pivot found for enemy", parent->GetName())
+
+        onHitVfx1 = parent->GetChildGameObjectByName(onHitVfx1Name);
+        if (!onHitVfx1) GLOG("[WARNING - %s] No on hit VFX found for enemy", parent->GetName())
+        else onHitVfx1->SetEnabled(false);
+
+        onHitVfx2 = parent->GetChildGameObjectByName(onHitVfx2Name);
+        if (!onHitVfx2) GLOG("[WARNING - %s] No on hit VFX found for enemy", parent->GetName())
+        else onHitVfx2->SetEnabled(false);
+
+        GameObject* meshObject = parent->GetChildGameObjectByName(meshName);
+        if (!meshObject) GLOG("[WARNING - %s] No mesh object found in children", parent->GetName())
+        else
+        {
+            mesh = meshObject->GetComponent<MeshComponent*>();
+            if (mesh) mesh->SetEnabled(true);
+            else GLOG("[WARNING - %s] No mesh component found", parent->GetName())
+
+            colorChange = meshObject->GetComponent<ShaderScriptComponent*>();
+            if (colorChange) colorChange->SetEnabled(false);
+            else GLOG("[WARNING - %s] No shader script component found", parent->GetName())
+        }
     }
 
     startPos = parent->GetGlobalTransform().TranslatePart();
@@ -290,6 +328,26 @@ void Character::UpdateTimers(float deltaTime)
 
     searchTimer -= deltaTime;
     if (searchTimer < 0.0f) searchTimer = 0.0f;
+
+    if (type != CharacterType::CuChulainn && type != CharacterType::Mirage && isHit)
+    {
+        onHitVfxTimer -= deltaTime;
+
+        // Do this in the next frame after enabling the mesh to avoid popping
+        if (mesh && mesh->GetEnabled() && colorChange && colorChange->GetEnabled())
+        {
+            colorChange->SetEnabled(false);
+            isHit = false;
+        }
+
+        if (onHitVfxTimer < 0.0f)
+        {
+            if (onHitVfx1 && onHitVfx1->IsEnabled()) onHitVfx1->SetEnabled(false);
+            if (onHitVfx2 && onHitVfx2->IsEnabled()) onHitVfx2->SetEnabled(false);
+
+            if (mesh && !mesh->GetEnabled()) mesh->SetEnabled(true);
+        }
+    }
 }
 
 void Character::TakeDamage(int amount)
@@ -303,7 +361,53 @@ void Character::TakeDamage(int amount)
 
     OnDamageTaken(amount);
 
-    if (type != CharacterType::CuChulainn) playerScript->OnEnemyHit();
+    if (type != CharacterType::CuChulainn && type != CharacterType::Mirage)
+    {
+        playerScript->OnEnemyHit();
+
+        if (onHitPivot)
+        {
+            float3 pivotPos  = onHitPivot->GetGlobalTransform().TranslatePart();
+            float3 targetPos = character->GetParent()->GetGlobalTransform().TranslatePart();
+
+            float3 dirWorld  = targetPos - pivotPos;
+            dirWorld.y       = 0.0f;
+            dirWorld.Normalize();
+
+            float4x4 parentWorld = onHitPivot->GetParentGlobalTransform();
+            float3 dirLocal      = parentWorld.Inverted().TransformDir(dirWorld);
+
+            float localYaw       = atan2(dirLocal.x, dirLocal.z);
+            Quat yawRot          = Quat::RotateY(localYaw);
+
+            float4x4 local       = onHitPivot->GetLocalTransform();
+            float4x4 newLocal    = float4x4::FromTRS(local.TranslatePart(), yawRot, local.GetScale());
+            onHitPivot->SetLocalTransform(newLocal);
+        }
+
+        if (onHitVfx1)
+        {
+            onHitVfx1->SetEnabled(true);
+            onHitVfx1->GetComponent<MeshComponent*>()->SetEnabled(false);
+            onHitVfx1->GetComponent<ShaderScriptComponent*>()->GetScriptByType<AttackVfxSpritesheet>()->Reset();
+        }
+
+        if (onHitVfx2)
+        {
+            onHitVfx2->SetEnabled(true);
+            onHitVfx2->GetComponent<MeshComponent*>()->SetEnabled(false);
+            onHitVfx2->GetComponent<ShaderScriptComponent*>()->GetScriptByType<AttackVfxSpritesheet>()->Reset();
+        }
+
+        if (colorChange && mesh)
+        {
+            mesh->SetEnabled(false);
+            colorChange->SetEnabled(true);
+        }
+
+        isHit         = true;
+        onHitVfxTimer = onHitVfxDuration;
+    }
 
     if (currentHealth <= 0) Die();
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Character.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Character.h
@@ -3,14 +3,16 @@
 #include "HashString.h"
 #include "Script.h"
 
-#include <vector>
 #include <unordered_set>
+#include <vector>
 
 class MagicBarrier;
 class GameObject;
 class CharacterControllerComponent;
 class AnimationComponent;
 class CapsuleColliderComponent;
+class ShaderScriptComponent;
+class MeshComponent;
 
 enum class PlayerDistances
 {
@@ -28,7 +30,8 @@ enum class CharacterType
     Banshee,
     Destructible,
     Changeling,
-    Boss
+    Boss,
+    Mirage
 };
 
 class Character : public Script
@@ -78,7 +81,6 @@ class Character : public Script
     CapsuleColliderComponent* characterCollider = nullptr;
     GameObject* weapon                          = nullptr;
     CapsuleColliderComponent* weaponCollider    = nullptr;
-    
 
     int maxHealth                               = 0;
     int currentHealth                           = 0;
@@ -117,6 +119,21 @@ class Character : public Script
     float searchTimer                           = 0.0f;
     float searchDuration                        = 5.0f;
     bool isSearching                            = false;
+
+    // Hit VFX
+    bool isHit                                  = false;
+    float onHitVfxDuration                      = 0.1f;
+    float onHitVfxTimer                         = 0.0;
+    std::string onHitPivotName                  = "OnHitPivot";
+    std::string onHitVfx1Name                   = "OnHitVfx1";
+    std::string onHitVfx2Name                   = "OnHitVfx2";
+    GameObject* onHitPivot                      = nullptr;
+    GameObject* onHitVfx1                       = nullptr;
+    GameObject* onHitVfx2                       = nullptr;
+
+    std::string meshName                        = "";
+    MeshComponent* mesh                         = nullptr;
+    ShaderScriptComponent* colorChange          = nullptr;
 
     // Level
     MagicBarrier* associatedBarrier             = nullptr;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/ColorChange.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/ColorChange.cpp
@@ -1,0 +1,133 @@
+#include "pch.h"
+
+#include "ColorChange.h"
+
+#include "Application.h"
+#include "CameraModule.h"
+#include "Components/CameraComponent.h"
+#include "Components/Standalone/MeshComponent.h"
+#include "GBuffer.h"
+#include "GameObject.h"
+#include "GeometryBatch.h"
+#include "Mesh.h"
+#include "OpenGLModule.h"
+#include "ResourceMaterial.h"
+#include "ResourceMesh.h"
+#include "Scene.h"
+#include "SceneModule.h"
+#include "ShaderModule.h"
+
+#include "glew.h"
+
+ColorChange::ColorChange(GameObject* parent) : Script(parent)
+{
+    fields.push_back({"Target Color", InspectorField::FieldType::Color, &targetColor});
+}
+
+ColorChange::~ColorChange()
+{
+    glDeleteVertexArrays(1, &vao);
+    glDeleteBuffers(1, &vbo);
+    glDeleteBuffers(1, &ebo);
+}
+
+bool ColorChange::Init()
+{
+    shaderProgram = AppEngine->GetShaderModule()->RequestShaderProgram(
+        "./EngineDefaults/Shader/Custom/Vertex/ColorChange_Vertex.glsl",
+        "./EngineDefaults/Shader/Custom/Fragment/ColorChange_Fragment.glsl"
+    );
+
+    meshComp = parent->GetComponent<MeshComponent*>();
+
+    if (meshComp)
+    {
+        const ResourceMesh* rmesh = meshComp->GetResourceMesh();
+
+        if (rmesh)
+        {
+            glGenVertexArrays(1, &vao);
+            glGenBuffers(1, &vbo);
+            glGenBuffers(1, &ebo);
+
+            glBindVertexArray(vao);
+
+            glBindBuffer(GL_ARRAY_BUFFER, vbo);
+            glBufferData(
+                GL_ARRAY_BUFFER, rmesh->GetLocalVertices().size() * sizeof(Vertex), rmesh->GetLocalVertices().data(),
+                GL_STATIC_DRAW
+            );
+
+            glEnableVertexAttribArray(0);
+            glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, position));
+
+            glEnableVertexAttribArray(1);
+            glVertexAttribPointer(1, 4, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, tangent));
+
+            glEnableVertexAttribArray(2);
+            glVertexAttribPointer(2, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, normal));
+
+            glEnableVertexAttribArray(3);
+            glVertexAttribPointer(3, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, texCoord));
+
+            glEnableVertexAttribArray(4);
+            glVertexAttribIPointer(4, 4, GL_INT, sizeof(Vertex), (void*)offsetof(Vertex, joint));
+
+            glEnableVertexAttribArray(5);
+            glVertexAttribPointer(5, 4, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, weights));
+
+            glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ebo);
+            glBufferData(
+                GL_ELEMENT_ARRAY_BUFFER, rmesh->GetIndices().size() * sizeof(unsigned int), rmesh->GetIndices().data(),
+                GL_STATIC_DRAW
+            );
+
+            glBindVertexArray(0);
+
+            indexCount = (unsigned int)rmesh->GetIndices().size();
+        }
+
+        meshComp->SetUpdateShaderStorage(true);
+    }
+    return true;
+}
+
+void ColorChange::Render(float deltaTime, CameraComponent* cameraComp)
+{
+    if (shaderProgram && indexCount > 0 && meshComp && meshComp->GetBatch())
+    {
+        float4x4 projectionMatrix, viewMatrix, basicModelMatrix;
+
+        basicModelMatrix = meshComp->GetCombinedMatrix();
+
+        if (cameraComp)
+        {
+            projectionMatrix = cameraComp->GetProjectionMatrix();
+            viewMatrix       = cameraComp->GetViewMatrix();
+        }
+        else
+        {
+            projectionMatrix = AppEngine->GetCameraModule()->GetProjectionMatrix();
+            viewMatrix       = AppEngine->GetCameraModule()->GetViewMatrix();
+        }
+
+        glUseProgram(shaderProgram);
+
+        glUniformMatrix4fv(0, 1, GL_TRUE, &projectionMatrix[0][0]);
+        glUniformMatrix4fv(1, 1, GL_TRUE, &viewMatrix[0][0]);
+        glUniformMatrix4fv(2, 1, GL_TRUE, &basicModelMatrix[0][0]);
+        glUniform3fv(3, 1, targetColor.ptr());
+        glUniform1i(9, meshComp->GetHasBones());
+        glUniform1ui(10, meshComp->GetBoneIndexOffset());
+
+        meshComp->GetBatch()->BindBonesBuffer();
+
+        glBindVertexArray(vao);
+        glBlendFunc(GL_SRC_ALPHA, GL_ONE);
+        glDrawElements(GL_TRIANGLES, indexCount, GL_UNSIGNED_INT, 0);
+
+        meshComp->GetBatch()->UnbindBonesBuffer();
+
+        glBindVertexArray(0);
+    }
+}

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/ColorChange.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/ColorChange.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "Script.h"
+
+#include "Math/float2.h"
+
+class MeshComponent;
+
+class ColorChange : public Script
+{
+  public:
+    ColorChange(GameObject* parent);
+    ~ColorChange() override;
+
+    bool Init() override;
+    void Update(float deltaTime) override {};
+    void Render(float deltaTime, CameraComponent* cameraComp) override;
+
+  private:
+    unsigned int shaderProgram = 0;
+
+    unsigned int vao           = 0;
+    unsigned int vbo           = 0;
+    unsigned int ebo           = 0;
+
+    unsigned int indexCount    = 0;
+
+    float3 targetColor         = float3::one;
+    MeshComponent* meshComp    = nullptr;
+};

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -26,7 +26,6 @@
 #include "Scene.h"
 #include "SceneModule.h"
 #include "ScriptComponent.h"
-#include "ParticleSystemComponent.h"
 #include "ShaderScriptComponent.h"
 #include "Standalone/AnimController.h"
 #include "Standalone/AnimationComponent.h"
@@ -62,6 +61,10 @@ CuChulainn::CuChulainn(GameObject* parent)
     fields.push_back({"Dash Icon Name", InspectorField::FieldType::InputText, &dashIconName});
     fields.push_back({"Health Bar Name", InspectorField::FieldType::InputText, &healthBarName});
     fields.push_back({"Melee VFX delay", InspectorField::FieldType::Float, &meleeVfxDelay, 0.0f, 1.0f});
+    fields.push_back({"Time Stop on hit duration", InspectorField::FieldType::Float, &hitTimeStopDuration, 0.0f, 1.0f});
+    fields.push_back(
+        {"Time Stop on death duration", InspectorField::FieldType::Float, &deathTimeStopDuration, 0.0f, 1.0f}
+    );
 
     // Unlocked abilities
     fields.push_back({InspectorField::FieldType::Text, (void*)"Unlocked Abilities from Start"});
@@ -180,7 +183,7 @@ bool CuChulainn::Init()
         if (!spear) GLOG("[WARNING] No projectile found by the name %s", spearName.c_str());
     }
 
-    spearCharacter        = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(spearNameMesh);
+    spearCharacter = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(spearNameMesh);
     if (!spearCharacter) GLOG("[WARNING] No spear (non projectile) found for CuChualin")
     else spearCharacter->SetEnabled(true);
 
@@ -208,9 +211,9 @@ bool CuChulainn::Init()
     if (!meleeVfxObject) GLOG("[WARNING] No melee VFX found for melee attack in CuChulain")
     else meleeVfxObject->SetEnabled(false);
 
-     arrowHitVfxObject = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(arrowHitVfxName);
+    arrowHitVfxObject = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(arrowHitVfxName);
     if (!arrowHitVfxObject) GLOG("[WARNING] No arrow Hit particles found for Hits in CuChulain")
-     else arrowHitVfxObject->SetEnabled(false);
+    else arrowHitVfxObject->SetEnabled(false);
     attackVfxHorizontal1 = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(attackVfxHorizontal1Name);
     if (!attackVfxHorizontal1) GLOG("[WARNING] No melee VFX 1 found for melee attack in CuChulain")
     else attackVfxHorizontal1->SetEnabled(false);
@@ -538,9 +541,6 @@ void CuChulainn::OnDeath()
     character->EnableMovement(false);
     state = CharacterStates::DEATH;
     if (animComponent) animComponent->UseTrigger("Death");
-   
-     
-    
 }
 
 void CuChulainn::OnDamageTaken(int amount)
@@ -595,726 +595,719 @@ void CuChulainn::OnDamageTaken(int amount)
     }
 }
 
-    void CuChulainn::OnHealed(int amount)
+void CuChulainn::OnHealed(int amount)
+{
+    // TODO: play CuChulainn recover sound
+    if (healthBar) healthBar->SetFillAmount(static_cast<float>(currentHealth) / static_cast<float>(maxHealth));
+    if (damageMask) damageMask->SetLife(static_cast<float>(currentHealth));
+}
+
+void CuChulainn::HandleState(float deltaTime)
+{
+    if (state == CharacterStates::AIM && !desiredAim && !resetWeapon)
     {
-        // TODO: play CuChulainn recover sound
-        if (healthBar) healthBar->SetFillAmount(static_cast<float>(currentHealth) / static_cast<float>(maxHealth));
-        if (damageMask) damageMask->SetLife(static_cast<float>(currentHealth));
+        animComponent->OnResume();
+        animComponent->UseTrigger("Idle");
+        state    = CharacterStates::IDLE;
+        aimTimer = 0.0f;
     }
 
-    void CuChulainn::HandleState(float deltaTime)
+    if (desiredTransform && CanTransform()) ToggleRiastrad();
+    else if (desiredDash && CanDash()) Dash();
+    else if (desiredHeal && CanHeal()) UseMushroom();
+    else if (desiredUltimate && CanUltimate()) UltimateAttack();
+    else if (desiredAttack && CanAttack()) Attack(deltaTime);
+    else if (desiredAim && CanAim()) Aim(deltaTime);
+    else if (attackPressTimer >= chargeThreshold && CanChargeAttack()) ChargeAttack();
+    else if (state != CharacterStates::BASIC_ATTACK && !character->IsDashing() && state != CharacterStates::RESPAWN &&
+             state != CharacterStates::AIM && state != CharacterStates::FALL && state != CharacterStates::ULTIMATE &&
+             state != CharacterStates::CHARGED_ATTACK && state != CharacterStates::CHARGING &&
+             state != CharacterStates::HEAL && state != CharacterStates::TRANSFORM && state != CharacterStates::HURT)
+        Move();
+
+    // When finished animation, go back to idle state
+    if (animComponent && animComponent->IsFinished())
     {
-        if (state == CharacterStates::AIM && !desiredAim && !resetWeapon)
+        if (stateName == HashString("Attack_1") || stateName == HashString("Attack_2") ||
+            stateName == HashString("Attack_3") || stateName == HashString("Attack_4"))
         {
-            animComponent->OnResume();
-            animComponent->UseTrigger("Idle");
-            state    = CharacterStates::IDLE;
-            aimTimer = 0.0f;
+            if (isAttacking) comboBufferTimer = 0.1f;
+            isAttacking = false;
+            if (meleeVfxObject) meleeVfxObject->SetEnabled(false);
+            if (attackVfxHorizontal1) attackVfxHorizontal1->SetEnabled(false);
+            if (attackVfxVertical1) attackVfxVertical1->SetEnabled(false);
+            if (attackVfxHorizontal2) attackVfxHorizontal2->SetEnabled(false);
+            if (attackVfxVertical2) attackVfxVertical2->SetEnabled(false);
+            if (attackVfxHorizontal3) attackVfxHorizontal3->SetEnabled(false);
+            if (attackVfxVertical3) attackVfxVertical3->SetEnabled(false);
         }
-
-        if (desiredTransform && CanTransform()) ToggleRiastrad();
-        else if (desiredDash && CanDash()) Dash();
-        else if (desiredHeal && CanHeal()) UseMushroom();
-        else if (desiredUltimate && CanUltimate()) UltimateAttack();
-        else if (desiredAttack && CanAttack()) Attack(deltaTime);
-        else if (desiredAim && CanAim()) Aim(deltaTime);
-        else if (attackPressTimer >= chargeThreshold && CanChargeAttack()) ChargeAttack();
-        else if (state != CharacterStates::BASIC_ATTACK && !character->IsDashing() &&
-                 state != CharacterStates::RESPAWN && state != CharacterStates::AIM && state != CharacterStates::FALL &&
-                 state != CharacterStates::ULTIMATE && state != CharacterStates::CHARGED_ATTACK &&
-                 state != CharacterStates::CHARGING && state != CharacterStates::HEAL &&
-                 state != CharacterStates::TRANSFORM && state != CharacterStates::HURT)
-            Move();
-
-        // When finished animation, go back to idle state
-        if (animComponent && animComponent->IsFinished())
+        else if (stateName == HashString("Charge"))
         {
-            if (stateName == HashString("Attack_1") || stateName == HashString("Attack_2") ||
-                stateName == HashString("Attack_3") || stateName == HashString("Attack_4"))
-            {
-                if (isAttacking) comboBufferTimer = 0.1f;
-                isAttacking = false;
-                if (meleeVfxObject) meleeVfxObject->SetEnabled(false);
-                if (attackVfxHorizontal1) attackVfxHorizontal1->SetEnabled(false);
-                if (attackVfxVertical1) attackVfxVertical1->SetEnabled(false);
-                if (attackVfxHorizontal2) attackVfxHorizontal2->SetEnabled(false);
-                if (attackVfxVertical2) attackVfxVertical2->SetEnabled(false);
-                if (attackVfxHorizontal3) attackVfxHorizontal3->SetEnabled(false);
-                if (attackVfxVertical3) attackVfxVertical3->SetEnabled(false);
-            }
-            else if (stateName == HashString("Charge"))
-            {
-                animComponent->UseTrigger("Charge");
-            }
-            else
-            {
-                if (state == CharacterStates::HEAL && healVfx) healVfx->SetEnabled(false);
-                if (state == CharacterStates::ULTIMATE &&
-                    ultimateObject->GetComponent<AnimationComponent*>()->IsPlaying())
-                {
-                    // if (ultimateGlow)
-                    //     ultimateGlow->SetEnabled(false);
-                    // if (ultimateBlur) ultimateBlur->SetEnabled(false);
-                    // if (ultimateBrust) ultimateBrust->SetEnabled(false);
-                    // if (ultimateCrack1) ultimateCrack1->SetEnabled(false);
-                    // if (ultimateCrack2) ultimateCrack2->SetEnabled(false);
-                    // if (ultimateHalo) ultimateHalo->SetEnabled(false);
-                    // if (ultimateSmoke) ultimateSmoke->SetEnabled(false);
-                    // if (ultimateSphere) ultimateSphere->SetEnabled(false);
-                    // if (ultimateWarning) ultimateWarning->SetEnabled(false);
-                    return;
-                }
-                if (state == CharacterStates::CHARGED_ATTACK && meleeTrailObject) meleeTrailObject->SetEnabled(false);
-                if (state == CharacterStates::HEAL && healKnockback) healKnockback->SetEnabled(false);
-                if (state == CharacterStates::TRANSFORM)
-                {
-                    transformTimer = 0.0f;
-                    chargedAttackCollider->SetEnabled(false);
-                    riastradVfx->GetComponent<AnimationComponent*>()->OnStop();
-                    // riastradVfx->SetEnabled(false);
-
-                    if (riastradBlur) riastradBlur->SetEnabled(false);
-                    if (riastradBurst) riastradBurst->SetEnabled(false);
-                    if (riastradHalo) riastradHalo->SetEnabled(false);
-                    if (riastradSphere) riastradSphere->SetEnabled(false);
-                    if (riastradCrack) riastradCrack->SetEnabled(false);
-                    if (riastradWaring) riastradWaring->SetEnabled(false);
-                    if (riastradSmoke1) riastradSmoke1->SetEnabled(false);
-                    if (riastradSmoke2) riastradSmoke2->SetEnabled(false);
-                    if (riastradSmoke3) riastradSmoke3->SetEnabled(false);
-                    if (riastradStars) riastradStars->SetEnabled(false);
-                }
-                state = CharacterStates::IDLE;
-                animComponent->UseTrigger("Idle");
-            }
-        }
-    }
-
-    void CuChulainn::GetInputs()
-    {
-        if (AppEngine->GetGameTimer()->GetDeltaTime() <= 0.0f) return;
-
-        const InputModule* input   = AppEngine->GetInputModule();
-        const KeyState* keyboard   = input->GetKeyboard();
-        const KeyState* mouse      = input->GetMouseButtons();
-        const KeyState* controller = input->GetControllerButtons();
-        const float2& leftJoystick = input->GetLeftStick();
-
-        float3 direction           = float3::zero;
-        if (input->IsUsingKeyboard())
-        {
-
-            if (keyboard[SDL_SCANCODE_W] == KEY_REPEAT) direction.z -= 1.0f;
-            if (keyboard[SDL_SCANCODE_S] == KEY_REPEAT) direction.z += 1.0f;
-            if (keyboard[SDL_SCANCODE_A] == KEY_REPEAT) direction.x -= 1.0f;
-            if (keyboard[SDL_SCANCODE_D] == KEY_REPEAT) direction.x += 1.0f;
+            animComponent->UseTrigger("Charge");
         }
         else
         {
-            direction.x = leftJoystick.x;
-            direction.z = leftJoystick.y;
-
-            if (controller[SDL_CONTROLLER_BUTTON_DPAD_LEFT] == KEY_REPEAT) direction.x = -1.0f;
-            if (controller[SDL_CONTROLLER_BUTTON_DPAD_UP] == KEY_REPEAT) direction.z = -1.0f;
-            if (controller[SDL_CONTROLLER_BUTTON_DPAD_RIGHT] == KEY_REPEAT) direction.x = 1.0f;
-            if (controller[SDL_CONTROLLER_BUTTON_DPAD_DOWN] == KEY_REPEAT) direction.z = 1.0f;
-        }
-
-        if (direction.Length() < 0.55f) character->SetIsRunning(false);
-        else character->SetIsRunning(true);
-        direction = camFront * direction.z + camRight * direction.x;
-        character->SetDirection(direction);
-
-        // Heal
-        if (keyboard[SDL_SCANCODE_E] == KEY_DOWN || controller[SDL_CONTROLLER_BUTTON_RIGHTSHOULDER] == KEY_DOWN)
-        {
-            desiredTakeMushroom = true;
-            takeMushroomCdTimer = takeMushroomCd;
-        }
-        if (keyboard[SDL_SCANCODE_R] == KEY_DOWN || controller[SDL_CONTROLLER_BUTTON_LEFTSHOULDER] == KEY_DOWN)
-        {
-            if (mushrooms != 0)
+            if (state == CharacterStates::HEAL && healVfx) healVfx->SetEnabled(false);
+            if (state == CharacterStates::ULTIMATE && ultimateObject->GetComponent<AnimationComponent*>()->IsPlaying())
             {
-                desiredHeal = true;
-                healCdTimer = healCooldown;
+                // if (ultimateGlow)
+                //     ultimateGlow->SetEnabled(false);
+                // if (ultimateBlur) ultimateBlur->SetEnabled(false);
+                // if (ultimateBrust) ultimateBrust->SetEnabled(false);
+                // if (ultimateCrack1) ultimateCrack1->SetEnabled(false);
+                // if (ultimateCrack2) ultimateCrack2->SetEnabled(false);
+                // if (ultimateHalo) ultimateHalo->SetEnabled(false);
+                // if (ultimateSmoke) ultimateSmoke->SetEnabled(false);
+                // if (ultimateSphere) ultimateSphere->SetEnabled(false);
+                // if (ultimateWarning) ultimateWarning->SetEnabled(false);
+                return;
             }
-        }
-
-        // Riastrad
-        if (keyboard[SDL_SCANCODE_Q] == KEY_DOWN ||
-            (input->GetLeftTrigger().first == KEY_REPEAT && input->GetRightTrigger().first == KEY_REPEAT))
-        {
-            if (!isRiastrad)
+            if (state == CharacterStates::CHARGED_ATTACK && meleeTrailObject) meleeTrailObject->SetEnabled(false);
+            if (state == CharacterStates::HEAL && healKnockback) healKnockback->SetEnabled(false);
+            if (state == CharacterStates::TRANSFORM)
             {
-                desiredTransform     = true;
-                transformBufferTimer = inputBuffer;
+                transformTimer = 0.0f;
+                chargedAttackCollider->SetEnabled(false);
+                riastradVfx->GetComponent<AnimationComponent*>()->OnStop();
+                // riastradVfx->SetEnabled(false);
+
+                if (riastradBlur) riastradBlur->SetEnabled(false);
+                if (riastradBurst) riastradBurst->SetEnabled(false);
+                if (riastradHalo) riastradHalo->SetEnabled(false);
+                if (riastradSphere) riastradSphere->SetEnabled(false);
+                if (riastradCrack) riastradCrack->SetEnabled(false);
+                if (riastradWaring) riastradWaring->SetEnabled(false);
+                if (riastradSmoke1) riastradSmoke1->SetEnabled(false);
+                if (riastradSmoke2) riastradSmoke2->SetEnabled(false);
+                if (riastradSmoke3) riastradSmoke3->SetEnabled(false);
+                if (riastradStars) riastradStars->SetEnabled(false);
             }
+            state = CharacterStates::IDLE;
+            animComponent->UseTrigger("Idle");
         }
+    }
+}
 
-        // Dash
-        if (keyboard[SDL_SCANCODE_SPACE] == KEY_DOWN || controller[SDL_CONTROLLER_BUTTON_A] == KEY_DOWN)
-        {
-            desiredDash     = true;
-            dashBufferTimer = inputBuffer;
-        }
+void CuChulainn::GetInputs()
+{
+    if (AppEngine->GetGameTimer()->GetDeltaTime() <= 0.0f) return;
 
-        // Attack
-        if (mouse[SDL_BUTTON_LEFT - 1] == KEY_UP || controller[SDL_CONTROLLER_BUTTON_X] == KEY_UP)
-        {
-            desiredAttack     = true;
-            attackBufferTimer = inputBuffer;
-        }
-        if (mouse[SDL_BUTTON_LEFT - 1] == KEY_REPEAT || controller[SDL_CONTROLLER_BUTTON_X] == KEY_REPEAT)
-        {
-            isChargingAttack = true;
-        }
-        if (mouse[SDL_BUTTON_LEFT - 1] == KEY_UP || controller[SDL_CONTROLLER_BUTTON_X] == KEY_UP)
-        {
-            isChargingAttack     = true;
-            desiredChargedAttack = true;
-        }
+    const InputModule* input   = AppEngine->GetInputModule();
+    const KeyState* keyboard   = input->GetKeyboard();
+    const KeyState* mouse      = input->GetMouseButtons();
+    const KeyState* controller = input->GetControllerButtons();
+    const float2& leftJoystick = input->GetLeftStick();
 
-        // Ranged
-        if (mouse[SDL_BUTTON_RIGHT - 1] == KEY_REPEAT || controller[SDL_CONTROLLER_BUTTON_Y] == KEY_REPEAT)
-        {
-            desiredAim = true;
-        }
-        if (input->GetLeftTrigger().first == KEY_UP)
-        {
-            if (state == CharacterStates::AIM) camera->EnableAimOffset(false);
-        }
-        if (mouse[SDL_BUTTON_RIGHT - 1] == KEY_UP || controller[SDL_CONTROLLER_BUTTON_Y] == KEY_UP)
-        {
-            if (state == CharacterStates::AIM && throwTimer <= 0.0f) ThrowSpear();
-        }
+    float3 direction           = float3::zero;
+    if (input->IsUsingKeyboard())
+    {
 
-        // Ultimatee
-        if (keyboard[SDL_SCANCODE_F] == KEY_DOWN || controller[SDL_CONTROLLER_BUTTON_B] == KEY_DOWN)
-        {
-            desiredUltimate     = true;
-            ultimateBufferTimer = inputBuffer;
-        }
+        if (keyboard[SDL_SCANCODE_W] == KEY_REPEAT) direction.z -= 1.0f;
+        if (keyboard[SDL_SCANCODE_S] == KEY_REPEAT) direction.z += 1.0f;
+        if (keyboard[SDL_SCANCODE_A] == KEY_REPEAT) direction.x -= 1.0f;
+        if (keyboard[SDL_SCANCODE_D] == KEY_REPEAT) direction.x += 1.0f;
+    }
+    else
+    {
+        direction.x = leftJoystick.x;
+        direction.z = leftJoystick.y;
 
-        // Debug
-        if (keyboard[SDL_SCANCODE_F5] == KEY_DOWN)
+        if (controller[SDL_CONTROLLER_BUTTON_DPAD_LEFT] == KEY_REPEAT) direction.x = -1.0f;
+        if (controller[SDL_CONTROLLER_BUTTON_DPAD_UP] == KEY_REPEAT) direction.z = -1.0f;
+        if (controller[SDL_CONTROLLER_BUTTON_DPAD_RIGHT] == KEY_REPEAT) direction.x = 1.0f;
+        if (controller[SDL_CONTROLLER_BUTTON_DPAD_DOWN] == KEY_REPEAT) direction.z = 1.0f;
+    }
+
+    if (direction.Length() < 0.55f) character->SetIsRunning(false);
+    else character->SetIsRunning(true);
+    direction = camFront * direction.z + camRight * direction.x;
+    character->SetDirection(direction);
+
+    // Heal
+    if (keyboard[SDL_SCANCODE_E] == KEY_DOWN || controller[SDL_CONTROLLER_BUTTON_RIGHTSHOULDER] == KEY_DOWN)
+    {
+        desiredTakeMushroom = true;
+        takeMushroomCdTimer = takeMushroomCd;
+    }
+    if (keyboard[SDL_SCANCODE_R] == KEY_DOWN || controller[SDL_CONTROLLER_BUTTON_LEFTSHOULDER] == KEY_DOWN)
+    {
+        if (mushrooms != 0)
         {
-            // TODO: This should be SetPosition, Respawn is here to test
-            // SetPosition(spawnPos);
-            Respawn();
-        }
-        if (keyboard[SDL_SCANCODE_F6] == KEY_DOWN)
-        {
-            spawnPos = parent->GetGlobalTransform().TranslatePart();
-        }
-        if (keyboard[SDL_SCANCODE_F7] == KEY_DOWN)
-        {
-            godMode = !godMode;
-            if (godMode) GLOG("God Mode enabled")
-            else GLOG("God Mode disabled")
-        }
-        if (keyboard[SDL_SCANCODE_F8] == KEY_DOWN)
-        {
-            AddRiastrad(100);
-            GLOG("Fill riastrad")
-        }
-        if (keyboard[SDL_SCANCODE_F10] == KEY_DOWN)
-        {
-            AddRiastrad(10);
-            Heal(10);
-        }
-        if (keyboard[SDL_SCANCODE_F9] == KEY_DOWN)
-        {
-            StartCurse();
+            desiredHeal = true;
+            healCdTimer = healCooldown;
         }
     }
 
-    bool CuChulainn::CanDash() const
+    // Riastrad
+    if (keyboard[SDL_SCANCODE_Q] == KEY_DOWN ||
+        (input->GetLeftTrigger().first == KEY_REPEAT && input->GetRightTrigger().first == KEY_REPEAT))
     {
-        if (!dashUnlocked) return false; // When tutorial map is correctly fixed, put this to make progression
-
-        bool canDash = dashTimer <= 0 && state != CharacterStates::AIM && !isAttacking &&
-                       state != CharacterStates::FALL && state != CharacterStates::RESPAWN &&
-                       state != CharacterStates::ULTIMATE && state != CharacterStates::CHARGED_ATTACK &&
-                       state != CharacterStates::TAKE_MUSHROOM && state != CharacterStates::HEAL && !isCursed &&
-                       state != CharacterStates::TRANSFORM && state != CharacterStates::HURT;
-
-        if (canDash && state == CharacterStates::BASIC_ATTACK) canDash = comboBufferTimer > 0.0f;
-
-        return canDash;
-    }
-
-    bool CuChulainn::CanAttack() const
-    {
-        return attackPressTimer < chargeThreshold && state != CharacterStates::DASH && !isAttacking &&
-               state != CharacterStates::FALL && state != CharacterStates::RESPAWN && comboCounter <= 1 &&
-               attackCdTimer <= 0.0f && state != CharacterStates::ULTIMATE &&
-               state != CharacterStates::CHARGED_ATTACK && state != CharacterStates::CHARGING &&
-               state != CharacterStates::TAKE_MUSHROOM && state != CharacterStates::HEAL &&
-               state != CharacterStates::TRANSFORM && state != CharacterStates::HURT;
-    }
-
-    bool CuChulainn::CanUltimate() const
-    {
-        bool canUltimate = state != CharacterStates::DASH && !isAttacking && state != CharacterStates::FALL &&
-                           state != CharacterStates::RESPAWN && ultimateCdTimer <= 0.0f &&
-                           state != CharacterStates::CHARGED_ATTACK && state != CharacterStates::TAKE_MUSHROOM &&
-                           state != CharacterStates::HEAL && state != CharacterStates::TRANSFORM &&
-                           state != CharacterStates::HURT;
-
-        if (canUltimate && state == CharacterStates::BASIC_ATTACK) canUltimate = comboBufferTimer > 0.0f;
-
-        return canUltimate;
-    }
-
-    bool CuChulainn::CanTakeMushroom() const
-    {
-        return state != CharacterStates::DASH && state != CharacterStates::BASIC_ATTACK &&
-               state != CharacterStates::AIM && state != CharacterStates::RESPAWN && state != CharacterStates::DEATH &&
-               state != CharacterStates::FALL && state != CharacterStates::ULTIMATE && state != CharacterStates::HEAL &&
-               state != CharacterStates::TRANSFORM && state != CharacterStates::HURT;
-    }
-
-    bool CuChulainn::CanHeal() const
-    {
-        return state != CharacterStates::DASH && !isAttacking && state != CharacterStates::AIM &&
-               state != CharacterStates::RESPAWN && state != CharacterStates::DEATH && state != CharacterStates::FALL &&
-               state != CharacterStates::ULTIMATE && state != CharacterStates::TAKE_MUSHROOM &&
-               state != CharacterStates::CHARGED_ATTACK && state != CharacterStates::CHARGING && mushrooms > 0 &&
-               !isHealing && state != CharacterStates::TRANSFORM && state != CharacterStates::HURT;
-    }
-
-    bool CuChulainn::CanAim() const
-    {
-        return state != CharacterStates::DASH && state != CharacterStates::BASIC_ATTACK && throwTimer <= 0 &&
-               state != CharacterStates::FALL && state != CharacterStates::RESPAWN &&
-               state != CharacterStates::ULTIMATE && state != CharacterStates::CHARGED_ATTACK &&
-               state != CharacterStates::CHARGING && state != CharacterStates::TAKE_MUSHROOM &&
-               state != CharacterStates::HEAL && state != CharacterStates::TRANSFORM && state != CharacterStates::HURT;
-    }
-
-    bool CuChulainn::CanChargeAttack() const
-    {
-        bool canChargeAttack = state != CharacterStates::DASH && !isAttacking && state != CharacterStates::FALL &&
-                               state != CharacterStates::RESPAWN && state != CharacterStates::ULTIMATE &&
-                               state != CharacterStates::AIM && state != CharacterStates::CHARGED_ATTACK &&
-                               state != CharacterStates::TAKE_MUSHROOM && state != CharacterStates::HEAL &&
-                               state != CharacterStates::TRANSFORM && state != CharacterStates::HURT;
-
-        if (canChargeAttack && state == CharacterStates::BASIC_ATTACK) canChargeAttack = comboBufferTimer > 0.0f;
-
-        return canChargeAttack;
-    }
-
-    bool CuChulainn::CanTransform() const
-    {
-        bool canTransform = false;
         if (!isRiastrad)
         {
-            canTransform = riastradMeter == 100 && state != CharacterStates::DASH && !isAttacking &&
-                           character->IsGrounded() && state != CharacterStates::FALL &&
+            desiredTransform     = true;
+            transformBufferTimer = inputBuffer;
+        }
+    }
+
+    // Dash
+    if (keyboard[SDL_SCANCODE_SPACE] == KEY_DOWN || controller[SDL_CONTROLLER_BUTTON_A] == KEY_DOWN)
+    {
+        desiredDash     = true;
+        dashBufferTimer = inputBuffer;
+    }
+
+    // Attack
+    if (mouse[SDL_BUTTON_LEFT - 1] == KEY_UP || controller[SDL_CONTROLLER_BUTTON_X] == KEY_UP)
+    {
+        desiredAttack     = true;
+        attackBufferTimer = inputBuffer;
+    }
+    if (mouse[SDL_BUTTON_LEFT - 1] == KEY_REPEAT || controller[SDL_CONTROLLER_BUTTON_X] == KEY_REPEAT)
+    {
+        isChargingAttack = true;
+    }
+    if (mouse[SDL_BUTTON_LEFT - 1] == KEY_UP || controller[SDL_CONTROLLER_BUTTON_X] == KEY_UP)
+    {
+        isChargingAttack     = true;
+        desiredChargedAttack = true;
+    }
+
+    // Ranged
+    if (mouse[SDL_BUTTON_RIGHT - 1] == KEY_REPEAT || controller[SDL_CONTROLLER_BUTTON_Y] == KEY_REPEAT)
+    {
+        desiredAim = true;
+    }
+    if (input->GetLeftTrigger().first == KEY_UP)
+    {
+        if (state == CharacterStates::AIM) camera->EnableAimOffset(false);
+    }
+    if (mouse[SDL_BUTTON_RIGHT - 1] == KEY_UP || controller[SDL_CONTROLLER_BUTTON_Y] == KEY_UP)
+    {
+        if (state == CharacterStates::AIM && throwTimer <= 0.0f) ThrowSpear();
+    }
+
+    // Ultimatee
+    if (keyboard[SDL_SCANCODE_F] == KEY_DOWN || controller[SDL_CONTROLLER_BUTTON_B] == KEY_DOWN)
+    {
+        desiredUltimate     = true;
+        ultimateBufferTimer = inputBuffer;
+    }
+
+    // Debug
+    if (keyboard[SDL_SCANCODE_F5] == KEY_DOWN)
+    {
+        // TODO: This should be SetPosition, Respawn is here to test
+        // SetPosition(spawnPos);
+        Respawn();
+    }
+    if (keyboard[SDL_SCANCODE_F6] == KEY_DOWN)
+    {
+        spawnPos = parent->GetGlobalTransform().TranslatePart();
+    }
+    if (keyboard[SDL_SCANCODE_F7] == KEY_DOWN)
+    {
+        godMode = !godMode;
+        if (godMode) GLOG("God Mode enabled")
+        else GLOG("God Mode disabled")
+    }
+    if (keyboard[SDL_SCANCODE_F8] == KEY_DOWN)
+    {
+        AddRiastrad(100);
+        GLOG("Fill riastrad")
+    }
+    if (keyboard[SDL_SCANCODE_F10] == KEY_DOWN)
+    {
+        AddRiastrad(10);
+        Heal(10);
+    }
+    if (keyboard[SDL_SCANCODE_F9] == KEY_DOWN)
+    {
+        StartCurse();
+    }
+}
+
+bool CuChulainn::CanDash() const
+{
+    if (!dashUnlocked) return false; // When tutorial map is correctly fixed, put this to make progression
+
+    bool canDash = dashTimer <= 0 && state != CharacterStates::AIM && !isAttacking && state != CharacterStates::FALL &&
+                   state != CharacterStates::RESPAWN && state != CharacterStates::ULTIMATE &&
+                   state != CharacterStates::CHARGED_ATTACK && state != CharacterStates::TAKE_MUSHROOM &&
+                   state != CharacterStates::HEAL && !isCursed && state != CharacterStates::TRANSFORM &&
+                   state != CharacterStates::HURT;
+
+    if (canDash && state == CharacterStates::BASIC_ATTACK) canDash = comboBufferTimer > 0.0f;
+
+    return canDash;
+}
+
+bool CuChulainn::CanAttack() const
+{
+    return attackPressTimer < chargeThreshold && state != CharacterStates::DASH && !isAttacking &&
+           state != CharacterStates::FALL && state != CharacterStates::RESPAWN && comboCounter <= 1 &&
+           attackCdTimer <= 0.0f && state != CharacterStates::ULTIMATE && state != CharacterStates::CHARGED_ATTACK &&
+           state != CharacterStates::CHARGING && state != CharacterStates::TAKE_MUSHROOM &&
+           state != CharacterStates::HEAL && state != CharacterStates::TRANSFORM && state != CharacterStates::HURT;
+}
+
+bool CuChulainn::CanUltimate() const
+{
+    bool canUltimate = state != CharacterStates::DASH && !isAttacking && state != CharacterStates::FALL &&
+                       state != CharacterStates::RESPAWN && ultimateCdTimer <= 0.0f &&
+                       state != CharacterStates::CHARGED_ATTACK && state != CharacterStates::TAKE_MUSHROOM &&
+                       state != CharacterStates::HEAL && state != CharacterStates::TRANSFORM &&
+                       state != CharacterStates::HURT;
+
+    if (canUltimate && state == CharacterStates::BASIC_ATTACK) canUltimate = comboBufferTimer > 0.0f;
+
+    return canUltimate;
+}
+
+bool CuChulainn::CanTakeMushroom() const
+{
+    return state != CharacterStates::DASH && state != CharacterStates::BASIC_ATTACK && state != CharacterStates::AIM &&
+           state != CharacterStates::RESPAWN && state != CharacterStates::DEATH && state != CharacterStates::FALL &&
+           state != CharacterStates::ULTIMATE && state != CharacterStates::HEAL &&
+           state != CharacterStates::TRANSFORM && state != CharacterStates::HURT;
+}
+
+bool CuChulainn::CanHeal() const
+{
+    return state != CharacterStates::DASH && !isAttacking && state != CharacterStates::AIM &&
+           state != CharacterStates::RESPAWN && state != CharacterStates::DEATH && state != CharacterStates::FALL &&
+           state != CharacterStates::ULTIMATE && state != CharacterStates::TAKE_MUSHROOM &&
+           state != CharacterStates::CHARGED_ATTACK && state != CharacterStates::CHARGING && mushrooms > 0 &&
+           !isHealing && state != CharacterStates::TRANSFORM && state != CharacterStates::HURT;
+}
+
+bool CuChulainn::CanAim() const
+{
+    return state != CharacterStates::DASH && state != CharacterStates::BASIC_ATTACK && throwTimer <= 0 &&
+           state != CharacterStates::FALL && state != CharacterStates::RESPAWN && state != CharacterStates::ULTIMATE &&
+           state != CharacterStates::CHARGED_ATTACK && state != CharacterStates::CHARGING &&
+           state != CharacterStates::TAKE_MUSHROOM && state != CharacterStates::HEAL &&
+           state != CharacterStates::TRANSFORM && state != CharacterStates::HURT;
+}
+
+bool CuChulainn::CanChargeAttack() const
+{
+    bool canChargeAttack = state != CharacterStates::DASH && !isAttacking && state != CharacterStates::FALL &&
                            state != CharacterStates::RESPAWN && state != CharacterStates::ULTIMATE &&
                            state != CharacterStates::AIM && state != CharacterStates::CHARGED_ATTACK &&
                            state != CharacterStates::TAKE_MUSHROOM && state != CharacterStates::HEAL &&
                            state != CharacterStates::TRANSFORM && state != CharacterStates::HURT;
 
-            if (canTransform && state == CharacterStates::BASIC_ATTACK) canTransform = comboBufferTimer > 0.0f;
-        }
-        else
-        {
-            canTransform = state != CharacterStates::DASH && state != CharacterStates::BASIC_ATTACK &&
-                           state != CharacterStates::FALL && state != CharacterStates::RESPAWN &&
-                           state != CharacterStates::ULTIMATE && state != CharacterStates::AIM &&
-                           state != CharacterStates::CHARGED_ATTACK && state != CharacterStates::TAKE_MUSHROOM &&
-                           state != CharacterStates::HEAL && state != CharacterStates::TRANSFORM;
-        }
+    if (canChargeAttack && state == CharacterStates::BASIC_ATTACK) canChargeAttack = comboBufferTimer > 0.0f;
 
-        return canTransform;
+    return canChargeAttack;
+}
+
+bool CuChulainn::CanTransform() const
+{
+    bool canTransform = false;
+    if (!isRiastrad)
+    {
+        canTransform = riastradMeter == 100 && state != CharacterStates::DASH && !isAttacking &&
+                       character->IsGrounded() && state != CharacterStates::FALL && state != CharacterStates::RESPAWN &&
+                       state != CharacterStates::ULTIMATE && state != CharacterStates::AIM &&
+                       state != CharacterStates::CHARGED_ATTACK && state != CharacterStates::TAKE_MUSHROOM &&
+                       state != CharacterStates::HEAL && state != CharacterStates::TRANSFORM &&
+                       state != CharacterStates::HURT;
+
+        if (canTransform && state == CharacterStates::BASIC_ATTACK) canTransform = comboBufferTimer > 0.0f;
+    }
+    else
+    {
+        canTransform = state != CharacterStates::DASH && state != CharacterStates::BASIC_ATTACK &&
+                       state != CharacterStates::FALL && state != CharacterStates::RESPAWN &&
+                       state != CharacterStates::ULTIMATE && state != CharacterStates::AIM &&
+                       state != CharacterStates::CHARGED_ATTACK && state != CharacterStates::TAKE_MUSHROOM &&
+                       state != CharacterStates::HEAL && state != CharacterStates::TRANSFORM;
     }
 
-    void CuChulainn::UpdateTimers(float deltaTime)
+    return canTransform;
+}
+
+void CuChulainn::UpdateTimers(float deltaTime)
+{
+    weaponCollider->SetEnabled(false);
+    Character::UpdateTimers(deltaTime);
+
+    // Dash
+    dashTimer -= deltaTime;
+    if (dashTimer < 0.0f) dashTimer = 0.0f;
+    if (desiredDash)
     {
-        weaponCollider->SetEnabled(false);
-        Character::UpdateTimers(deltaTime);
+        dashBufferTimer -= deltaTime;
+        if (dashBufferTimer < 0.0f) desiredDash = false;
+    }
 
-        // Dash
-        dashTimer -= deltaTime;
-        if (dashTimer < 0.0f) dashTimer = 0.0f;
-        if (desiredDash)
+    if (arrowVfxIsActive && arrowHitVfxObject && arrowHitVfxObject->IsEnabled())
+    {
+        arrowHitVfxTimer += deltaTime;
+        if (arrowHitVfxTimer >= arrowHitVfxDuration)
         {
-            dashBufferTimer -= deltaTime;
-            if (dashBufferTimer < 0.0f) desiredDash = false;
+            arrowHitVfxObject->SetEnabled(false);
+            arrowHitVfxTimer = 0.0f;
+            arrowVfxIsActive = false;
         }
+    }
 
-        if (arrowVfxIsActive && arrowHitVfxObject && arrowHitVfxObject->IsEnabled())
+    // Dash decal
+    dashDecalBufferTimer -= deltaTime;
+    if (dashDecalBufferTimer < 0.0f)
+    {
+        if (dashDecal) dashDecal->SetEnabled(false);
+
+        dashDecalBufferTimer = 0.0f;
+    }
+
+    // Melee attack
+    if (desiredAttack)
+    {
+        attackBufferTimer -= deltaTime;
+        if (attackBufferTimer < 0.0f) desiredAttack = false;
+    }
+
+    // Ranged attack
+    desiredAim  = false;
+    throwTimer -= deltaTime;
+    if (throwTimer < 0.0f)
+    {
+        if (resetWeapon)
         {
-            arrowHitVfxTimer += deltaTime;
-            if (arrowHitVfxTimer >= arrowHitVfxDuration)
+            weapon->SetEnabled(true);
+            resetWeapon = false;
+            spearCharacter->GetComponent<MeshComponent*>()->SetEnabled(true);
+        }
+        throwTimer = 0.0f;
+    }
+
+    // Take mushrooms
+    takeMushroomCdTimer -= deltaTime;
+    if (takeMushroomCdTimer <= 0.0f)
+    {
+        desiredTakeMushroom = false;
+        takeMushroomCdTimer = 0.0f;
+    }
+
+    if (!isAttacking && comboBufferTimer > 0.0f)
+    {
+        comboBufferTimer -= deltaTime;
+        if (comboBufferTimer <= 0.0f)
+        {
+            comboCounter  = -1;
+            attackCdTimer = attackCooldown;
+            if (state != CharacterStates::ULTIMATE && meleeTrailObject) meleeTrailObject->SetEnabled(false);
+
+            if (state == CharacterStates::BASIC_ATTACK)
             {
-                arrowHitVfxObject->SetEnabled(false);
-                arrowHitVfxTimer = 0.0f;
-                arrowVfxIsActive = false;
+                state = CharacterStates::IDLE;
+                if (animComponent) animComponent->UseTrigger("AttackEnd");
+            }
+        }
+    }
+
+    // Ultimate
+    ultimateCdTimer -= deltaTime;
+    if (ultimateCdTimer < 0.0f) ultimateCdTimer = 0.0f;
+    if (desiredUltimate)
+    {
+        ultimateBufferTimer -= deltaTime;
+        if (ultimateBufferTimer < 0.0f) desiredUltimate = false;
+    }
+
+    // Charged attack
+    if (isChargingAttack)
+    {
+        attackPressTimer += deltaTime;
+        // GLOG("Attack press timer: %f", attackPressTimer);
+
+        if (state == CharacterStates::CHARGING)
+        {
+            // GLOG("Charge timer: %f", chargeTimer);
+            chargeTimer -= deltaTime;
+            if (chargeTimer < 0.0f) chargeTimer = 0.0f;
+        }
+    }
+    else
+    {
+        attackPressTimer = 0.0f;
+    }
+    isChargingAttack     = false;
+    desiredChargedAttack = false;
+
+    // Riastrad
+    if (desiredTransform)
+    {
+        transformBufferTimer -= deltaTime;
+        if (transformBufferTimer < 0.0f) desiredTransform = false;
+    }
+    if (isRiastrad)
+    {
+        riastradTimer -= deltaTime;
+        if (riastradTimer <= 0.0f) desiredTransform = true;
+    }
+
+    if (isCursed)
+    {
+        curseTimer -= deltaTime;
+        if (curseTimer <= 0.0f) EndCurse();
+    }
+
+    timeStopTimer -= AppEngine->GetGameTimer()->GetUnscaledDeltaTime() / 1000.0f;
+    if (timeStopTimer <= 0.0f) AppEngine->GetGameTimer()->SetTimeScale(1.0f);
+
+    if (state == CharacterStates::ULTIMATE) ultimateTimer += deltaTime;
+    if (state == CharacterStates::CHARGED_ATTACK) chargedAttackTimer += deltaTime;
+    if (state == CharacterStates::IDLE) idleTimer += deltaTime;
+    if (state == CharacterStates::RUN) runTimer += deltaTime;
+    if (state == CharacterStates::HEAL) healTimer += deltaTime;
+    if (state == CharacterStates::TRANSFORM) transformTimer += deltaTime;
+
+    if (state == CharacterStates::DASH || state == CharacterStates::HURT || state == CharacterStates::RESPAWN)
+        isInvulnerable = true;
+
+    isDashing = state == CharacterStates::DASH ? true : false;
+    isHealing = state == CharacterStates::HEAL ? true : false;
+}
+
+void CuChulainn::LookAtMouse()
+{
+    const float3 mouseWorldPos = AppEngine->GetSceneModule()->GetScene()->GetMainCamera()->ScreenPointToXZ(
+        parent->GetGlobalTransform().TranslatePart().y
+    );
+    float3 direction = mouseWorldPos - parent->GetGlobalTransform().TranslatePart();
+    direction.y      = 0;
+    direction.Normalize();
+    character->LookAt(direction);
+}
+
+void CuChulainn::LookAtRightStick()
+{
+    const float2& stick    = AppEngine->GetInputModule()->GetRightStick();
+    const float3 direction = camFront * stick.y + camRight * stick.x;
+    if (direction.LengthSq() > 0.001f) character->LookAt(direction);
+}
+
+void CuChulainn::LookAtLeftStick()
+{
+    const float2& stick    = AppEngine->GetInputModule()->GetLeftStick();
+    const float3 direction = camFront * stick.y + camRight * stick.x;
+    if (direction.LengthSq() > 0.001f) character->LookAt(direction);
+}
+
+void CuChulainn::CheckIsFalling()
+{
+    const float verticalSpeed = character->GetRealSpeed().y;
+
+    // GLOG("Vertical speed %f", verticalSpeed);
+    if (verticalSpeed <= -3.0f && !character->IsGrounded() && animComponent)
+    {
+        animComponent->UseTrigger("Fall");
+        state = CharacterStates::FALL;
+    }
+
+    if (state == CharacterStates::FALL && verticalSpeed >= -1.0f)
+    {
+        animComponent->UseTrigger("Land");
+        character->EnableMovement(false);
+    }
+
+    const float maxDepth = -60.0f;
+
+    if (parent->GetGlobalTransform().TranslatePart().y < maxDepth)
+    {
+        SetPosition(lastDashStartPos);
+        TakeDamage(1);
+    }
+}
+
+void CuChulainn::ThrowSpear()
+{
+    if (camera) camera->EnableAimOffset(false);
+    if (meleeTrailObject) meleeTrailObject->SetEnabled(false);
+    // if (audio) audio->EmitEvent(AK::EVENTS::PLAY_SFX_MC_DASH);
+    animComponent->OnResume();
+    aimTimer   = 0.0f;
+
+    throwTimer = throwCooldown;
+    if (weapon)
+    {
+        weapon->SetEnabled(false);
+        resetWeapon = true;
+        spearCharacter->GetComponent<MeshComponent*>()->SetEnabled(false);
+    }
+    if (aimShadowObject) aimShadowObject->SetEnabled(false);
+
+    spear->Shoot(parent->GetGlobalTransform().TranslatePart(), character->GetFrontDirection());
+}
+
+void CuChulainn::Dash()
+{
+    if (state == CharacterStates::AIM && camera)
+    {
+        camera->EnableAimOffset(false);
+        if (meleeTrailObject) meleeTrailObject->SetEnabled(true);
+    }
+    else if (state == CharacterStates::BASIC_ATTACK)
+    {
+        comboBufferTimer = character->GetDashDuration() + 0.1f;
+        isAttacking      = false;
+    }
+    desiredDash      = false;
+    state            = CharacterStates::DASH;
+
+    // GLOG("DASH");
+
+    dashTimer        = isRiastrad ? dashCooldown * 0.75f : dashCooldown;
+    lastDashStartPos = parent->GetGlobalTransform().TranslatePart();
+    LookAtLeftStick();
+    character->StartDash();
+    isDashing = true;
+
+    if (audio) audio->EmitEvent(AK::EVENTS::PLAY_SFX_MC_DASH);
+
+    if (animComponent) animComponent->UseTrigger("Dash");
+    if (dashTrail) dashTrail->SetEnabled(true);
+    if (dashDecal)
+    {
+        // TODO: set dash decal to the final position of player and not to direction
+        dashDecal->SetEnabled(true);
+        const float3 scale  = dashDecal->GetLocalTransform().ExtractScale();
+        const Quat rotation = Quat::LookAt(float3::unitY, character->GetFrontDirection(), float3::unitZ, float3::unitY);
+        const float3 pos    = lastDashStartPos + 2.5f * character->GetFrontDirection().Normalized();
+        const float4x4 decalTransform = float4x4::FromTRS(pos, rotation, scale);
+        dashDecal->SetLocalTransform(decalTransform);
+        dashDecalBufferTimer = dashDecalTimer;
+    }
+}
+
+void CuChulainn::PerformAttack()
+{
+    if (isAttacking && state == CharacterStates::BASIC_ATTACK)
+    {
+        float currentVfxDelay    = isRiastrad ? meleeVfxDelay / riastradAnimationsSpeedRatio : meleeVfxDelay;
+        float currentHitboxDelay = isRiastrad ? attackHitboxDelay / riastradAnimationsSpeedRatio : attackHitboxDelay;
+        float currentHitboxDuration =
+            isRiastrad ? attackHitboxDuration / riastradAnimationsSpeedRatio : attackHitboxDuration;
+
+        if (attackTimer > currentVfxDelay)
+        {
+            GameObject* vfxHorizontal = nullptr;
+            GameObject* vfxVertical   = nullptr;
+            switch (comboCounter)
+            {
+            case 0:
+                vfxHorizontal = attackVfxHorizontal1;
+                vfxVertical   = attackVfxVertical1;
+                break;
+            case 1:
+                vfxHorizontal = attackVfxHorizontal2;
+                vfxVertical   = attackVfxVertical2;
+                break;
+            case 2:
+                vfxVertical = attackVfxVertical3;
+                break;
+            }
+
+            if (vfxHorizontal && !vfxHorizontal->IsEnabled())
+            {
+                vfxHorizontal->SetEnabled(true);
+                vfxHorizontal->GetComponent<MeshComponent*>()->SetEnabled(false);
+                vfxHorizontal->GetComponent<ShaderScriptComponent*>()->GetScriptByType<AttackVfxSpritesheet>()->Reset();
+            }
+            if (vfxVertical && !vfxVertical->IsEnabled())
+            {
+                vfxVertical->SetEnabled(true);
+                vfxVertical->GetComponent<MeshComponent*>()->SetEnabled(false);
+                vfxVertical->GetComponent<ShaderScriptComponent*>()->GetScriptByType<AttackVfxSpritesheet>()->Reset();
             }
         }
 
-        // Dash decal
-        dashDecalBufferTimer -= deltaTime;
-        if (dashDecalBufferTimer < 0.0f)
+        if (attackTimer < currentHitboxDelay)
         {
-            if (dashDecal) dashDecal->SetEnabled(false);
-
-            dashDecalBufferTimer = 0.0f;
+            float distance = comboCounter == 2 ? 10.0f : 5.0f;
+            character->MoveTo(distance);
         }
-
-        // Melee attack
-        if (desiredAttack)
+        else if (!weaponCollider->GetEnabled() && attackTimer >= currentHitboxDelay &&
+                 attackTimer < currentHitboxDelay + currentHitboxDuration)
         {
-            attackBufferTimer -= deltaTime;
-            if (attackBufferTimer < 0.0f) desiredAttack = false;
+            weaponCollider->SetEnabled(true);
         }
-
-        // Ranged attack
-        desiredAim  = false;
-        throwTimer -= deltaTime;
-        if (throwTimer < 0.0f)
+        else if (weaponCollider->GetEnabled() && attackTimer >= currentHitboxDelay + currentHitboxDuration)
         {
-            if (resetWeapon)
+            weaponCollider->SetEnabled(false);
+        }
+    }
+    else if (state == CharacterStates::ULTIMATE)
+    {
+        float currentHitboxDelay =
+            isRiastrad ? ultimateHitboxDelay / riastradAnimationsSpeedRatio : ultimateHitboxDelay;
+        float currentHitboxDuration =
+            isRiastrad ? ultimateHitboxDuration / riastradAnimationsSpeedRatio : ultimateHitboxDuration;
+        float currentAnimationDelay =
+            isRiastrad ? ultimateAnimationDelay / riastradAnimationsSpeedRatio : ultimateAnimationDelay;
+
+        if (!ultimateObject->IsEnabled() && ultimateTimer >= currentAnimationDelay)
+        {
+            ultimateObject->GetComponent<AnimationComponent*>()->OnStop();
+            ultimateObject->GetComponent<AnimationComponent*>()->OnPlay(false);
+            ultimateObject->GetComponent<AnimationComponent*>()->GetAnimationController()->SetTime(0.0f);
+            ultimateObject->SetEnabled(true);
+            ultimateObject->GetComponent<AnimationComponent*>()->Update(0.0f);
+            ultimateObject->GetComponent<SphereColliderComponent*>()->SetEnabled(false);
+
+            UpdateUltimateVfx();
+        }
+        else if (ultimateObject->IsEnabled())
+        {
+            if (ultimateSpikes) // Control spikes animation appearance
             {
-                weapon->SetEnabled(true);
-                resetWeapon = false;
-                spearCharacter->GetComponent<MeshComponent*>()->SetEnabled(true);
-            }
-            throwTimer = 0.0f;
-        }
-
-        // Take mushrooms
-        takeMushroomCdTimer -= deltaTime;
-        if (takeMushroomCdTimer <= 0.0f)
-        {
-            desiredTakeMushroom = false;
-            takeMushroomCdTimer = 0.0f;
-        }
-
-        if (!isAttacking && comboBufferTimer > 0.0f)
-        {
-            comboBufferTimer -= deltaTime;
-            if (comboBufferTimer <= 0.0f)
-            {
-                comboCounter  = -1;
-                attackCdTimer = attackCooldown;
-                if (state != CharacterStates::ULTIMATE && meleeTrailObject) meleeTrailObject->SetEnabled(false);
-
-                if (state == CharacterStates::BASIC_ATTACK)
+                AnimationComponent* ac = ultimateObject->GetComponent<AnimationComponent*>();
+                if (ac && ac->GetCurrentAnimation())
                 {
-                    state = CharacterStates::IDLE;
-                    if (animComponent) animComponent->UseTrigger("AttackEnd");
+                    const float dur  = ac->GetCurrentAnimation()->GetDuration();
+                    const float t    = ac->GetAnimationController()->GetTime();
+                    const float norm = (dur > 0.0f) ? (t / dur) : 0.0f;
+
+                    ultimateSpikes->SetEnabled(norm >= 0.15f);
+                    if (ultimateCrack) ultimateCrack->SetEnabled(norm >= 0.15f);
                 }
             }
-        }
-
-        // Ultimate
-        ultimateCdTimer -= deltaTime;
-        if (ultimateCdTimer < 0.0f) ultimateCdTimer = 0.0f;
-        if (desiredUltimate)
-        {
-            ultimateBufferTimer -= deltaTime;
-            if (ultimateBufferTimer < 0.0f) desiredUltimate = false;
-        }
-
-        // Charged attack
-        if (isChargingAttack)
-        {
-            attackPressTimer += deltaTime;
-            // GLOG("Attack press timer: %f", attackPressTimer);
-
-            if (state == CharacterStates::CHARGING)
+            if (ultimateTimer >= currentHitboxDelay + currentAnimationDelay &&
+                ultimateTimer < currentHitboxDelay + currentHitboxDuration + currentAnimationDelay)
             {
-                // GLOG("Charge timer: %f", chargeTimer);
-                chargeTimer -= deltaTime;
-                if (chargeTimer < 0.0f) chargeTimer = 0.0f;
+                ultimateObject->GetComponent<SphereColliderComponent*>()->SetEnabled(true);
             }
-        }
-        else
-        {
-            attackPressTimer = 0.0f;
-        }
-        isChargingAttack     = false;
-        desiredChargedAttack = false;
-
-        // Riastrad
-        if (desiredTransform)
-        {
-            transformBufferTimer -= deltaTime;
-            if (transformBufferTimer < 0.0f) desiredTransform = false;
-        }
-        if (isRiastrad)
-        {
-            riastradTimer -= deltaTime;
-            if (riastradTimer <= 0.0f) desiredTransform = true;
-        }
-
-        if (isCursed)
-        {
-            curseTimer -= deltaTime;
-            if (curseTimer <= 0) EndCurse();
-        }
-
-        if (state == CharacterStates::ULTIMATE) ultimateTimer += deltaTime;
-        if (state == CharacterStates::CHARGED_ATTACK) chargedAttackTimer += deltaTime;
-        if (state == CharacterStates::IDLE) idleTimer += deltaTime;
-        if (state == CharacterStates::RUN) runTimer += deltaTime;
-        if (state == CharacterStates::HEAL) healTimer += deltaTime;
-        if (state == CharacterStates::TRANSFORM) transformTimer += deltaTime;
-
-        if (state == CharacterStates::DASH || state == CharacterStates::HURT || state == CharacterStates::RESPAWN)
-            isInvulnerable = true;
-
-        isDashing = state == CharacterStates::DASH ? true : false;
-        isHealing = state == CharacterStates::HEAL ? true : false;
-    }
-
-    void CuChulainn::LookAtMouse()
-    {
-        const float3 mouseWorldPos = AppEngine->GetSceneModule()->GetScene()->GetMainCamera()->ScreenPointToXZ(
-            parent->GetGlobalTransform().TranslatePart().y
-        );
-        float3 direction = mouseWorldPos - parent->GetGlobalTransform().TranslatePart();
-        direction.y      = 0;
-        direction.Normalize();
-        character->LookAt(direction);
-    }
-
-    void CuChulainn::LookAtRightStick()
-    {
-        const float2& stick    = AppEngine->GetInputModule()->GetRightStick();
-        const float3 direction = camFront * stick.y + camRight * stick.x;
-        if (direction.LengthSq() > 0.001f) character->LookAt(direction);
-    }
-
-    void CuChulainn::LookAtLeftStick()
-    {
-        const float2& stick    = AppEngine->GetInputModule()->GetLeftStick();
-        const float3 direction = camFront * stick.y + camRight * stick.x;
-        if (direction.LengthSq() > 0.001f) character->LookAt(direction);
-    }
-
-    void CuChulainn::CheckIsFalling()
-    {
-        const float verticalSpeed = character->GetRealSpeed().y;
-
-        // GLOG("Vertical speed %f", verticalSpeed);
-        if (verticalSpeed <= -3.0f && !character->IsGrounded() && animComponent)
-        {
-            animComponent->UseTrigger("Fall");
-            state = CharacterStates::FALL;
-        }
-
-        if (state == CharacterStates::FALL && verticalSpeed >= -1.0f)
-        {
-            animComponent->UseTrigger("Land");
-            character->EnableMovement(false);
-        }
-
-        const float maxDepth = -60.0f;
-
-        if (parent->GetGlobalTransform().TranslatePart().y < maxDepth)
-        {
-            SetPosition(lastDashStartPos);
-            TakeDamage(1);
-        }
-    }
-
-    void CuChulainn::ThrowSpear()
-    {
-        if (camera) camera->EnableAimOffset(false);
-        if (meleeTrailObject) meleeTrailObject->SetEnabled(false);
-        // if (audio) audio->EmitEvent(AK::EVENTS::PLAY_SFX_MC_DASH);
-        animComponent->OnResume();
-        aimTimer   = 0.0f;
-
-        throwTimer = throwCooldown;
-        if (weapon)
-        {
-            weapon->SetEnabled(false);
-            resetWeapon = true;
-            spearCharacter->GetComponent<MeshComponent*>()->SetEnabled(false);
-        }
-        if (aimShadowObject) aimShadowObject->SetEnabled(false);
-
-        spear->Shoot(parent->GetGlobalTransform().TranslatePart(), character->GetFrontDirection());
-    }
-
-    void CuChulainn::Dash()
-    {
-        if (state == CharacterStates::AIM && camera)
-        {
-            camera->EnableAimOffset(false);
-            if (meleeTrailObject) meleeTrailObject->SetEnabled(true);
-        }
-        else if (state == CharacterStates::BASIC_ATTACK)
-        {
-            comboBufferTimer = character->GetDashDuration() + 0.1f;
-            isAttacking      = false;
-        }
-        desiredDash      = false;
-        state            = CharacterStates::DASH;
-
-        // GLOG("DASH");
-
-        dashTimer        = isRiastrad ? dashCooldown * 0.75f : dashCooldown;
-        lastDashStartPos = parent->GetGlobalTransform().TranslatePart();
-        LookAtLeftStick();
-        character->StartDash();
-        isDashing = true;
-
-        if (audio) audio->EmitEvent(AK::EVENTS::PLAY_SFX_MC_DASH);
-
-        if (animComponent) animComponent->UseTrigger("Dash");
-        if (dashTrail) dashTrail->SetEnabled(true);
-        if (dashDecal)
-        {
-            // TODO: set dash decal to the final position of player and not to direction
-            dashDecal->SetEnabled(true);
-            const float3 scale = dashDecal->GetLocalTransform().ExtractScale();
-            const Quat rotation =
-                Quat::LookAt(float3::unitY, character->GetFrontDirection(), float3::unitZ, float3::unitY);
-            const float3 pos              = lastDashStartPos + 2.5f * character->GetFrontDirection().Normalized();
-            const float4x4 decalTransform = float4x4::FromTRS(pos, rotation, scale);
-            dashDecal->SetLocalTransform(decalTransform);
-            dashDecalBufferTimer = dashDecalTimer;
-        }
-    }
-
-    void CuChulainn::PerformAttack()
-    {
-        if (isAttacking && state == CharacterStates::BASIC_ATTACK)
-        {
-            float currentVfxDelay = isRiastrad ? meleeVfxDelay / riastradAnimationsSpeedRatio : meleeVfxDelay;
-            float currentHitboxDelay =
-                isRiastrad ? attackHitboxDelay / riastradAnimationsSpeedRatio : attackHitboxDelay;
-            float currentHitboxDuration =
-                isRiastrad ? attackHitboxDuration / riastradAnimationsSpeedRatio : attackHitboxDuration;
-
-            if (attackTimer > currentVfxDelay)
+            else if (ultimateTimer >= currentHitboxDelay + currentHitboxDuration + currentAnimationDelay)
             {
-                GameObject* vfxHorizontal = nullptr;
-                GameObject* vfxVertical   = nullptr;
-                switch (comboCounter)
-                {
-                case 0:
-                    vfxHorizontal = attackVfxHorizontal1;
-                    vfxVertical   = attackVfxVertical1;
-                    break;
-                case 1:
-                    vfxHorizontal = attackVfxHorizontal2;
-                    vfxVertical   = attackVfxVertical2;
-                    break;
-                case 2:
-                    vfxVertical = attackVfxVertical3;
-                    break;
-                }
-
-                if (vfxHorizontal && !vfxHorizontal->IsEnabled())
-                {
-                    vfxHorizontal->SetEnabled(true);
-                    vfxHorizontal->GetComponent<MeshComponent*>()->SetEnabled(false);
-                    vfxHorizontal->GetComponent<ShaderScriptComponent*>()
-                        ->GetScriptByType<AttackVfxSpritesheet>()
-                        ->Reset();
-                }
-                if (vfxVertical && !vfxVertical->IsEnabled())
-                {
-                    vfxVertical->SetEnabled(true);
-                    vfxVertical->GetComponent<MeshComponent*>()->SetEnabled(false);
-                    vfxVertical->GetComponent<ShaderScriptComponent*>()->GetScriptByType<AttackVfxSpritesheet>()->Reset(
-                    );
-                }
-            }
-
-            if (attackTimer < currentHitboxDelay)
-            {
-                float distance = comboCounter == 2 ? 10.0f : 5.0f;
-                character->MoveTo(distance);
-            }
-            else if (!weaponCollider->GetEnabled() && attackTimer >= currentHitboxDelay &&
-                     attackTimer < currentHitboxDelay + currentHitboxDuration)
-            {
-                weaponCollider->SetEnabled(true);
-            }
-            else if (weaponCollider->GetEnabled() && attackTimer >= currentHitboxDelay + currentHitboxDuration)
-            {
-                weaponCollider->SetEnabled(false);
-            }
-        }
-        else if (state == CharacterStates::ULTIMATE)
-        {
-            float currentHitboxDelay =
-                isRiastrad ? ultimateHitboxDelay / riastradAnimationsSpeedRatio : ultimateHitboxDelay;
-            float currentHitboxDuration =
-                isRiastrad ? ultimateHitboxDuration / riastradAnimationsSpeedRatio : ultimateHitboxDuration;
-            float currentAnimationDelay =
-                isRiastrad ? ultimateAnimationDelay / riastradAnimationsSpeedRatio : ultimateAnimationDelay;
-
-            if (!ultimateObject->IsEnabled() && ultimateTimer >= currentAnimationDelay)
-            {
-                ultimateObject->GetComponent<AnimationComponent*>()->OnStop();
-                ultimateObject->GetComponent<AnimationComponent*>()->OnPlay(false);
-                ultimateObject->GetComponent<AnimationComponent*>()->GetAnimationController()->SetTime(0.0f);
-                ultimateObject->SetEnabled(true);
-                ultimateObject->GetComponent<AnimationComponent*>()->Update(0.0f);
+                ultimateObject->SetEnabled(false);
                 ultimateObject->GetComponent<SphereColliderComponent*>()->SetEnabled(false);
-
-                UpdateUltimateVfx();
-            }
-            else if (ultimateObject->IsEnabled())
-            {
-                if (ultimateSpikes) // Control spikes animation appearance
-                {
-                    AnimationComponent* ac = ultimateObject->GetComponent<AnimationComponent*>();
-                    if (ac && ac->GetCurrentAnimation())
-                    {
-                        const float dur  = ac->GetCurrentAnimation()->GetDuration();
-                        const float t    = ac->GetAnimationController()->GetTime();
-                        const float norm = (dur > 0.0f) ? (t / dur) : 0.0f;
-
-                        ultimateSpikes->SetEnabled(norm >= 0.15f);
-                        if (ultimateCrack) ultimateCrack->SetEnabled(norm >= 0.15f);
-                    }
-                }
-                if (ultimateTimer >= currentHitboxDelay + currentAnimationDelay &&
-                    ultimateTimer < currentHitboxDelay + currentHitboxDuration + currentAnimationDelay)
-                {
-                    ultimateObject->GetComponent<SphereColliderComponent*>()->SetEnabled(true);
-                }
-                else if (ultimateTimer >= currentHitboxDelay + currentHitboxDuration + currentAnimationDelay)
-                {
-                    ultimateObject->SetEnabled(false);
-                    ultimateObject->GetComponent<SphereColliderComponent*>()->SetEnabled(false);
-                    ultimateObject->GetComponent<AnimationComponent*>()->OnStop();
-                    ultimateTimer = 0.f;
-                    if (meleeTrailObject) meleeTrailObject->SetEnabled(false);
-                }
-            }
-        }
-        else if (state == CharacterStates::CHARGED_ATTACK)
-        {
-            float currentHitboxDelay =
-                isRiastrad ? chargedAttackHitboxDelay / riastradAnimationsSpeedRatio : chargedAttackHitboxDelay;
-            float currentHitboxDuration =
-                isRiastrad ? chargedAttackHitboxDuration / riastradAnimationsSpeedRatio : chargedAttackHitboxDuration;
-
-            if (!chargedAttackCollider->IsEnabled() && chargedAttackTimer >= currentHitboxDelay &&
-                chargedAttackTimer < currentHitboxDelay + currentHitboxDuration)
-            {
-                chargedAttackCollider->SetEnabled(true);
-            }
-            else if (chargedAttackCollider->IsEnabled() &&
-                     chargedAttackTimer >= currentHitboxDelay + currentHitboxDuration)
-            {
-                chargedAttackCollider->SetEnabled(false);
+                ultimateObject->GetComponent<AnimationComponent*>()->OnStop();
+                ultimateTimer = 0.f;
+                if (meleeTrailObject) meleeTrailObject->SetEnabled(false);
             }
         }
     }
+    else if (state == CharacterStates::CHARGED_ATTACK)
+    {
+        float currentHitboxDelay =
+            isRiastrad ? chargedAttackHitboxDelay / riastradAnimationsSpeedRatio : chargedAttackHitboxDelay;
+        float currentHitboxDuration =
+            isRiastrad ? chargedAttackHitboxDuration / riastradAnimationsSpeedRatio : chargedAttackHitboxDuration;
 
+        if (!chargedAttackCollider->IsEnabled() && chargedAttackTimer >= currentHitboxDelay &&
+            chargedAttackTimer < currentHitboxDelay + currentHitboxDuration)
+        {
+            chargedAttackCollider->SetEnabled(true);
+        }
+        else if (chargedAttackCollider->IsEnabled() && chargedAttackTimer >= currentHitboxDelay + currentHitboxDuration)
+        {
+            chargedAttackCollider->SetEnabled(false);
+        }
+    }
+}
 
 void CuChulainn::Attack(float deltaTime)
 {
@@ -1367,7 +1360,7 @@ void CuChulainn::UpdateUltimateVfx()
     if (ultimateBlur)
     {
         ultimateBlur->SetEnabled(true);
-        //ultimateBlur->GetComponent<MeshComponent*>()->SetEnabled(false);
+        // ultimateBlur->GetComponent<MeshComponent*>()->SetEnabled(false);
         if (ultimateBlur->GetComponent<ShaderScriptComponent*>())
             ultimateBlur->GetComponent<ShaderScriptComponent*>()->GetScriptByType<MovingUVTransparent>()->Reset();
     }
@@ -1509,8 +1502,6 @@ void CuChulainn::TakeDamage(int amount)
 {
     if (godMode || isRiastrad || state == CharacterStates::ULTIMATE) return;
     Character::TakeDamage(amount);
-  
-   
 }
 
 bool CuChulainn::TakeMushroom()
@@ -1735,11 +1726,15 @@ void CuChulainn::AddRiastrad(int amount)
 
 void CuChulainn::OnEnemyHit()
 {
+    AppEngine->GetGameTimer()->SetTimeScale(0.0f);
+    timeStopTimer = hitTimeStopDuration;
     AddRiastrad(riastradOnHit);
 }
 
 void CuChulainn::OnEnemyDefeated()
 {
+    AppEngine->GetGameTimer()->SetTimeScale(0.0f);
+    timeStopTimer = deathTimeStopDuration;
     AddRiastrad(riastradOnEnemyDeath);
 }
 
@@ -1869,5 +1864,3 @@ const std::string CuChulainn::GetLogicStateName()
         break;
     }
 }
-
-

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -41,6 +41,9 @@
 #include "SDL.h"
 #include "Wwise_IDs.h"
 
+extern "C" void GO_RequestGameOver();
+extern bool gGameOverActive;
+
 CharacterControllerComponent* character = nullptr;
 CuChulainn* playerScript                = nullptr;
 
@@ -214,6 +217,7 @@ bool CuChulainn::Init()
     arrowHitVfxObject = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(arrowHitVfxName);
     if (!arrowHitVfxObject) GLOG("[WARNING] No arrow Hit particles found for Hits in CuChulain")
     else arrowHitVfxObject->SetEnabled(false);
+
     attackVfxHorizontal1 = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(attackVfxHorizontal1Name);
     if (!attackVfxHorizontal1) GLOG("[WARNING] No melee VFX 1 found for melee attack in CuChulain")
     else attackVfxHorizontal1->SetEnabled(false);
@@ -237,9 +241,6 @@ bool CuChulainn::Init()
     attackVfxVertical3 = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(attackVfxVertical3Name);
     if (!attackVfxVertical3) GLOG("[WARNING] No melee VFX 3 found for melee attack in CuChulain")
     else attackVfxVertical3->SetEnabled(false);
-    arrowHitVfxObject = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(arrowHitVfxName);
-    if (!arrowHitVfxObject) GLOG("[WARNING] No arrow Hit particles found for Hits in CuChulain")
-    else arrowHitVfxObject->SetEnabled(false);
 
     dashTrail = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(dashTrailName);
     if (!dashTrail) GLOG("[WARNING] No dash trail found for CuChulain")
@@ -375,8 +376,6 @@ bool CuChulainn::Init()
     audio = parent->GetComponent<AudioSourceComponent*>();
     if (!audio) GLOG("[WARNING] CuChulainn: No audio component found");
 
-    if (!riastradBar) GLOG("[WARNING] CuChulainn: No riastard bar gameObject found");
-
     // Ultimate
     ultimateGlow =
         AppEngine->GetSceneModule()->GetScene()->GetGameObjectByParentNameAndTargetName(ultimateName, ultimateGlowName);
@@ -436,7 +435,6 @@ bool CuChulainn::Init()
         GLOG("Player collider enabled: %s", playerCollider->GetEnabled() ? "true" : "false");
         GLOG("Player name: %s", parent->GetName().c_str());
 
-        // Verificar tags
         if (parent->HasTag(HashString("Player")))
         {
             GLOG("Player has 'Player' tag: YES");
@@ -456,6 +454,8 @@ bool CuChulainn::Init()
     const std::string projectPath = AppEngine->GetProjectModule()->GetLoadedProjectPath();
     const std::string savePath    = SavePlayerData::MakeSavePath(projectPath);
 
+    spawnPos                      = parent->GetGlobalTransform().TranslatePart();
+
     if (gNewGame)
     {
         gNewGame = false;
@@ -474,8 +474,19 @@ void CuChulainn::Update(float deltaTime)
 {
     if (state == CharacterStates::DEATH)
     {
-        deathTimer += deltaTime;
-        if (deathTimer > 4.0f) Respawn();
+        deathTimer                   += deltaTime;
+
+        const bool deathAnimDone      = (animComponent && animComponent->IsFinished());
+        constexpr float kGO_MinDelay  = 1.6f;
+        constexpr float kGO_MaxDelay  = 3.5f;
+
+        if (pendingGameOver && ((deathAnimDone && deathTimer >= kGO_MinDelay) || (deathTimer >= kGO_MaxDelay)))
+        {
+            pendingGameOver = false;
+            GO_RequestGameOver();
+        }
+
+        if (deathTimer > 4.0f && !gGameOverActive) Respawn();
     }
 
     if (isDead || !character) return;
@@ -533,14 +544,17 @@ void CuChulainn::OnDestroy()
 
 void CuChulainn::OnDeath()
 {
-    // TODO: include death sound for the character
     isAttacking = false;
     deathTimer  = 0.0f;
     if (meleeTrailObject) meleeTrailObject->SetEnabled(false);
     if (state == CharacterStates::AIM && camera) camera->EnableAimOffset(false);
     character->EnableMovement(false);
-    state = CharacterStates::DEATH;
+
+    state  = CharacterStates::DEATH;
+    isDead = true;
+
     if (animComponent) animComponent->UseTrigger("Death");
+    pendingGameOver = true;
 }
 
 void CuChulainn::OnDamageTaken(int amount)
@@ -1484,11 +1498,15 @@ void CuChulainn::SetPosition(const float3& position)
 
 void CuChulainn::Respawn()
 {
+    GLOG("[PLAYER] Respawn()");
     Character::Restart();
 
-    isDead        = false;
-    currentHealth = reservedHealth;
-    state         = CharacterStates::RESPAWN;
+    isDead         = false;
+    deathTimer     = 0.0f;
+
+    currentHealth  = maxHealth;
+    reservedHealth = maxHealth;
+    state          = CharacterStates::RESPAWN;
 
     if (healthBar) healthBar->SetFillAmount(static_cast<float>(currentHealth) / static_cast<float>(maxHealth));
     if (damageMask) damageMask->SetLife(static_cast<float>(currentHealth));
@@ -1496,11 +1514,20 @@ void CuChulainn::Respawn()
     SetPosition(spawnPos);
     if (animComponent) animComponent->UseTrigger("Respawn");
     character->EnableMovement(false);
+
+    GLOG("[PLAYER] -> state=RESPAWN hp=%d", currentHealth);
 }
+
 
 void CuChulainn::TakeDamage(int amount)
 {
-    if (godMode || isRiastrad || state == CharacterStates::ULTIMATE) return;
+    int prev = currentHealth;
+    GLOG("[PLAYER] TakeDamage(%d) hpBefore=%d state=%s", amount, prev, GetLogicStateName().c_str());
+    if (godMode || isRiastrad || state == CharacterStates::ULTIMATE)
+    {
+        GLOG("[PLAYER] TakeDamage -> INVULNERABLE (ignorat)");
+        return;
+    }
     Character::TakeDamage(amount);
 }
 
@@ -1863,4 +1890,19 @@ const std::string CuChulainn::GetLogicStateName()
         return "MISSING!";
         break;
     }
+}
+
+bool CuChulainn::ConsumeJustDied()
+{
+    if (justDied)
+    {
+        justDied = false; // reset the flag after consuming
+        return true;
+    }
+    return false; // nothing to consume
+}
+
+bool CuChulainn::IsGameOverCondition() const
+{
+    return isDead || state == CharacterStates::DEATH || currentHealth <= 0;
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
@@ -79,7 +79,10 @@ class CuChulainn : public Character
 
     void ExportState(PlayerState& playerState) const;
     void ApplySavedState(const PlayerState& playerState);
+    bool ConsumeJustDied();
+    bool IsGameOverCondition() const;
 
+    
   private:
     void OnDeath() override;
     void OnDamageTaken(int amount) override;
@@ -291,6 +294,8 @@ class CuChulainn : public Character
     float idleTimer                      = 0.0f;
     float runTimer                       = 0.0f;
     float stepTime                       = 0.367f;
+    bool justDied                         = false;
+    bool pendingGameOver                  = false;
 
     int mushrooms                        = 0;
     int mushroomHeal                     = 2;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
@@ -67,19 +67,19 @@ class CuChulainn : public Character
     void RemoveEnemy()
     {
         if (enemiesCont != 0) enemiesCont--;
-        GLOG("Enemy out. Total unique enemies colliding: %zu",  enemiesCont);
+        GLOG("Enemy out. Total unique enemies colliding: %zu", enemiesCont);
     }
     void OnEnemyHit();
     void OnEnemyDefeated();
 
     void ActivateAbility(std::string abilityName);
     void OnArrowHit();
-  
+
     void StartCurse();
-    
+
     void ExportState(PlayerState& playerState) const;
     void ApplySavedState(const PlayerState& playerState);
-    
+
   private:
     void OnDeath() override;
     void OnDamageTaken(int amount) override;
@@ -121,15 +121,13 @@ class CuChulainn : public Character
     void SetPosition(const float3& position);
     const std::string GetLogicStateName();
 
-    
-
   private:
     CharacterStates state                = CharacterStates::IDLE;
 
-    int enemiesCont                   = 0;
-    std::string cameraName             = "Camera Pivot";
-    GameObject* cameraObject           = nullptr;
-    CameraMovement* camera             = nullptr;
+    int enemiesCont                      = 0;
+    std::string cameraName               = "Camera Pivot";
+    GameObject* cameraObject             = nullptr;
+    CameraMovement* camera               = nullptr;
 
     std::string spearName                = "SpearProjectile";
     std::string spearNameMesh             = "WP_Spear_Cu_Chu";
@@ -177,14 +175,13 @@ class CuChulainn : public Character
     float comboBufferTimer               = 0.0f;
     float meleeVfxDelay                  = 0.1f;
 
-    //Arrow Hit VFX 
-    GameObject* arrowHitVfxObject         = nullptr;
-    std::string arrowHitVfxName           = "";
-    float arrowHitVfxDuration             = 0.2f;
-    float arrowHitVfxTimer                = 0.0f;
-    bool arrowVfxIsActive                 = false;
+    // Arrow Hit VFX
+    GameObject* arrowHitVfxObject        = nullptr;
+    std::string arrowHitVfxName          = "";
+    float arrowHitVfxDuration            = 0.2f;
+    float arrowHitVfxTimer               = 0.0f;
+    bool arrowVfxIsActive                = false;
 
-  
     // Charged attack
     std::string chargedAttackName        = "Charged";
     GameObject* chargedAttackCollider    = nullptr;
@@ -320,8 +317,8 @@ class CuChulainn : public Character
     float healTimer                      = 0.0f;
     float healKnockbackDelay             = 0.0f;
 
-    std::string damageMaskName         = "DamageMask";
-    DamageMask* damageMask             = nullptr;
+    std::string damageMaskName           = "DamageMask";
+    DamageMask* damageMask               = nullptr;
 
     // Curse
     bool isCursed                        = false;
@@ -329,6 +326,10 @@ class CuChulainn : public Character
     float curseDuration                  = 5.0f;
     float curseTimer                     = 0.0f;
     UID playerMaterial                   = 0;
+
+    float timeStopTimer                  = 0.0f;
+    float hitTimeStopDuration            = 0.05f;
+    float deathTimeStopDuration          = 0.1f;
 };
 
 extern CharacterControllerComponent* character;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/GameOverNavigatorScript.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/GameOverNavigatorScript.cpp
@@ -1,0 +1,313 @@
+#include "pch.h"
+
+#include "GameOverNavigatorScript.h"
+
+#include <algorithm> // std::clamp
+#include <cmath>
+
+#include "Application.h"
+#include "GameObject.h"
+#include "GameOverScript.h"
+#include "InputModule.h"
+#include "ProjectModule.h"
+#include "SDL.h"
+#include "Scene.h"
+#include "SceneModule.h"
+#include "ScriptComponent.h"
+#include "Standalone/UI/ButtonComponent.h"
+
+// Need the complete type for Respawn()
+#include "CuChulainn.h"
+
+// global player declared in CuChulainn.cpp
+extern CuChulainn* playerScript;
+
+bool GameOverNavigatorScript::Init()
+{
+    LocateGameOverScript();
+    CachePanel();
+
+    builtOnce     = false;
+    selectedIndex = 0;
+
+    lastMs        = GetCurrentTimeMs();
+    repeatMs      = 0;
+    lastDir       = 0;
+    acceptWas     = false;
+    upPrev = downPrev = accPrev = false;
+    stickPrev                   = 0;
+
+    return true;
+}
+
+void GameOverNavigatorScript::Update(float)
+{
+    CachePanel();
+    if (!panelRoot || !panelRoot->IsEnabled())
+    {
+        builtOnce = false;
+        return;
+    }
+
+    if (!builtOnce)
+    {
+        BuildFromPanel();
+        selectedIndex = 0;
+        UpdateSelection();
+        builtOnce = true;
+        // GLOG: first time build completed
+        // GLOG("[GONAV] Built -> items=%zu arrows=%zu", menuItems.size(), arrowImages.size());
+    }
+
+    // ensure exactly one arrow is enabled
+    int on = 0;
+    for (auto* a : arrowImages)
+        if (a && a->IsEnabled()) ++on;
+    if (on != 1) UpdateSelection();
+
+    // Input
+    bool upHeld = false, downHeld = false, accHeld = false;
+    int stickDir = 0;
+    ReadInputs(upHeld, downHeld, accHeld, stickDir);
+
+    const bool upEdge        = upHeld && !upPrev;
+    const bool downEdge      = downHeld && !downPrev;
+    const bool accEdge       = accHeld && !accPrev;
+    const bool stickUpEdge   = (stickDir == -1 && stickPrev == 0);
+    const bool stickDownEdge = (stickDir == +1 && stickPrev == 0);
+
+    int dir                  = 0;
+    if (downEdge || stickDownEdge) dir = +1;
+    else if (upEdge || stickUpEdge) dir = -1;
+    else
+    {
+        int heldDir        = downHeld ? +1 : (upHeld ? -1 : 0);
+        const uint64_t now = GetCurrentTimeMs();
+        if (heldDir != 0)
+        {
+            if (lastDir != heldDir)
+            {
+                lastDir  = heldDir;
+                repeatMs = 230; // initial delay
+                lastMs   = now;
+            }
+            else
+            {
+                const uint32_t el = (uint32_t)(now - lastMs);
+                if (el >= repeatMs)
+                {
+                    dir      = heldDir;
+                    repeatMs = 140; // repeat interval
+                    lastMs   = now;
+                }
+            }
+        }
+        else
+        {
+            lastDir  = 0;
+            repeatMs = 0;
+        }
+    }
+
+    if (dir != 0 && !menuItems.empty())
+    {
+        const int n   = (int)menuItems.size();
+        selectedIndex = (selectedIndex + (dir > 0 ? +1 : -1) + n) % n;
+        UpdateSelection();
+        // GLOG: navigation moved selection
+        // GLOG("[GONAV] Nav -> sel=%d", selectedIndex);
+    }
+
+    if (accEdge && !menuItems.empty())
+    {
+        GameObject* item       = menuItems[selectedIndex];
+        const std::string name = item ? item->GetName() : "(null)";
+        // GLOG: accept pressed on current item
+        // GLOG("[GONAV] Accept on '%s'", name.c_str());
+
+        if (name == "MenuItem_Continue")
+        {
+            if (goController) goController->Close();
+            if (playerScript) playerScript->Respawn(); // immediate respawn
+            builtOnce = false;
+            return;
+        }
+        else if (name == "MenuItem_Menu")
+        {
+            if (goController) goController->Close();
+            AppEngine->GetSceneModule()->GetScene()->SetStopPlaying(true);
+            std::string path =
+                AppEngine->GetProjectModule()->GetLoadedProjectPath() + SCENES_PATH + "SCENE_MainMenu.scene";
+            AppEngine->GetSceneModule()->RequestSceneLoad(path);
+            builtOnce = false;
+            return;
+        }
+        else
+        {
+            if (auto* btn = item->GetComponent<ButtonComponent*>()) btn->OnClick();
+        }
+    }
+
+    // save previous states
+    upPrev    = upHeld;
+    downPrev  = downHeld;
+    accPrev   = accHeld;
+    stickPrev = stickDir;
+    acceptWas = accHeld;
+}
+
+// ================= Helpers =================
+
+void GameOverNavigatorScript::CachePanel()
+{
+    if (panelRoot && panelRoot->GetName() == panelName) return;
+
+    Scene* scene = AppEngine->GetSceneModule()->GetScene();
+    if (!scene)
+    {
+        panelRoot = nullptr;
+        return;
+    }
+
+    if (GameObject* byName = scene->GetGameObjectByName(panelName))
+    {
+        panelRoot = byName;
+        return;
+    }
+
+    // fallback: first GO with children named "MenuItem_"
+    const auto& objects = scene->GetAllGameObjects();
+    for (const auto& [uid, go] : objects)
+    {
+        if (!go) continue;
+        bool hasMenuChild = false;
+        for (UID cid : go->GetChildren())
+        {
+            GameObject* ch = scene->GetGameObjectByUID(cid);
+            if (ch && ch->GetName().find("MenuItem_") != std::string::npos)
+            {
+                hasMenuChild = true;
+                break;
+            }
+        }
+        if (hasMenuChild)
+        {
+            panelRoot = go;
+            return;
+        }
+    }
+}
+
+void GameOverNavigatorScript::BuildFromPanel()
+{
+    if (!panelRoot) return;
+
+    menuItems.clear();
+    arrowImages.clear();
+
+    Scene* s = AppEngine->GetSceneModule()->GetScene();
+    for (UID cid : panelRoot->GetChildren())
+    {
+        GameObject* child = s->GetGameObjectByUID(cid);
+        if (!child) continue;
+
+        if (child->GetName().find("MenuItem_") != std::string::npos)
+        {
+            menuItems.push_back(child);
+            for (UID gcid : child->GetChildren())
+            {
+                GameObject* arrow = s->GetGameObjectByUID(gcid);
+                if (arrow && arrow->GetName().find("Arrow") != std::string::npos) arrowImages.push_back(arrow);
+            }
+        }
+    }
+
+    for (auto* a : arrowImages)
+        if (a) a->SetEnabled(false);
+
+    selectedIndex = std::clamp(selectedIndex, 0, (int)menuItems.size() - 1);
+    UpdateSelection();
+
+    // GLOG: items discovered for navigation
+    // GLOG("[GONAV] BuildFromPanel: items=%zu arrows=%zu", menuItems.size(), arrowImages.size());
+}
+
+void GameOverNavigatorScript::UpdateSelection()
+{
+    if (menuItems.empty()) return;
+    selectedIndex = std::clamp(selectedIndex, 0, (int)menuItems.size() - 1);
+
+    Scene* s      = AppEngine->GetSceneModule()->GetScene();
+    for (size_t i = 0; i < menuItems.size(); ++i)
+    {
+        for (UID uid : menuItems[i]->GetChildren())
+        {
+            GameObject* child = s->GetGameObjectByUID(uid);
+            if (child && child->GetName().find("Arrow") != std::string::npos)
+                child->SetEnabled(i == (size_t)selectedIndex);
+        }
+    }
+    // GLOG: selection updated
+    // GLOG("[GONAV] UpdateSelection -> sel=%d", selectedIndex);
+}
+
+void GameOverNavigatorScript::LocateGameOverScript()
+{
+    Scene* s = AppEngine->GetSceneModule()->GetScene();
+    if (!s) return;
+
+    if (GameObject* ctrl = s->GetGameObjectByName("GameOverController"))
+        if (auto* sc = ctrl->GetComponent<ScriptComponent*>())
+            if (auto* go = sc->GetScriptByType<GameOverScript>())
+            {
+                goController = go;
+                return;
+            }
+
+    const auto& all = s->GetAllGameObjects();
+    for (const auto& kv : all)
+    {
+        GameObject* g = s->GetGameObjectByUID(kv.first);
+        if (!g) continue;
+        if (auto* sc = g->GetComponent<ScriptComponent*>())
+            if (auto* go = sc->GetScriptByType<GameOverScript>())
+            {
+                goController = go;
+                return;
+            }
+    }
+}
+
+uint64_t GameOverNavigatorScript::GetCurrentTimeMs() const
+{
+    const uint64_t c = (uint64_t)SDL_GetPerformanceCounter();
+    const uint64_t f = (uint64_t)SDL_GetPerformanceFrequency();
+    return (f > 0) ? (c * 1000ull) / f : 0ull;
+}
+
+void GameOverNavigatorScript::ReadInputs(bool& up, bool& down, bool& acc, int& stickDir)
+{
+    SDL_PumpEvents();
+    SDL_GameControllerUpdate();
+
+    // keyboard state
+    const Uint8* kb          = SDL_GetKeyboardState(nullptr);
+    const bool kUp           = (kb[SDL_SCANCODE_UP] != 0) || (kb[SDL_SCANCODE_W] != 0);
+    const bool kDown         = (kb[SDL_SCANCODE_DOWN] != 0) || (kb[SDL_SCANCODE_S] != 0);
+    const bool kEnt          = (kb[SDL_SCANCODE_RETURN] != 0) || (kb[SDL_SCANCODE_KP_ENTER] != 0);
+    const bool kSpc          = (kb[SDL_SCANCODE_SPACE] != 0);
+
+    // gamepad via InputModule
+    const InputModule* input = AppEngine->GetInputModule();
+    const KeyState* buttons  = input ? input->GetControllerButtons() : nullptr;
+    const bool padUpHeld     = buttons ? (buttons[SDL_CONTROLLER_BUTTON_DPAD_UP] != KEY_IDLE) : false;
+    const bool padDownHeld   = buttons ? (buttons[SDL_CONTROLLER_BUTTON_DPAD_DOWN] != KEY_IDLE) : false;
+    const bool padAHeld      = buttons ? (buttons[SDL_CONTROLLER_BUTTON_A] != KEY_IDLE) : false;
+    const float2& ls         = input ? input->GetLeftStick() : float2 {0.f, 0.f};
+
+    up                       = kUp || padUpHeld || (ls.y < -0.5f);
+    down                     = kDown || padDownHeld || (ls.y > 0.5f);
+    acc                      = kEnt || kSpc || padAHeld;
+
+    stickDir                 = (ls.y > 0.5f) ? +1 : ((ls.y < -0.5f) ? -1 : 0);
+}

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/GameOverNavigatorScript.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/GameOverNavigatorScript.h
@@ -1,0 +1,55 @@
+#pragma once
+#include "Script.h"
+#include <cstdint>
+#include <string>
+#include <vector>
+
+class GameObject;
+class GameOverScript;
+
+class GameOverNavigatorScript : public Script
+{
+  public:
+    GameOverNavigatorScript(GameObject* parent) : Script(parent) {}
+
+    bool Init() override;
+    void Update(float dt) override;
+    void Inspector() override {}
+
+  private:
+    // Config (Game Over panel name)
+    std::string panelName = "GameOverPanel";
+
+    // Panel state
+    GameObject* panelRoot = nullptr;
+    std::vector<GameObject*> menuItems;
+    std::vector<GameObject*> arrowImages;
+
+    // Reference to GameOverScript (to call Close)
+    GameOverScript* goController = nullptr;
+
+    // Navigation state
+    int selectedIndex            = 0;
+    bool builtOnce               = false;
+
+    // Debounce / autorepeat
+    uint64_t lastMs              = 0;
+    uint32_t repeatMs            = 0;
+    int lastDir                  = 0;
+    bool acceptWas               = false;
+
+    // Previous input edges
+    bool upPrev                  = false;
+    bool downPrev                = false;
+    bool accPrev                 = false;
+    int stickPrev                = 0;
+
+  private:
+    // Helpers
+    void CachePanel();
+    void BuildFromPanel();
+    void UpdateSelection();
+    void LocateGameOverScript();
+    void ReadInputs(bool& upHeld, bool& downHeld, bool& acceptHeld, int& stickDir);
+    uint64_t GetCurrentTimeMs() const;
+};

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/GameOverScript.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/GameOverScript.cpp
@@ -1,14 +1,55 @@
 ﻿#include "pch.h"
 
 #include "Application.h"
-#include "CuChulainn.h"
 #include "EditorUIModule.h"
 #include "GameObject.h"
 #include "GameOverScript.h"
 #include "GameTimer.h"
+#include "Globals.h"
+#include "ProjectModule.h"
+#include "SDL.h"
 #include "Scene.h"
 #include "SceneModule.h"
+#include "ScriptComponent.h"
+#include "Standalone/UI/ButtonComponent.h"
 
+#include <algorithm>
+#include <cstring>
+
+bool gGameOverActive = false;
+
+// -------- C entry point to request Game Over --------
+extern "C" void GO_RequestGameOver()
+{
+    Scene* s = AppEngine->GetSceneModule()->GetScene();
+    if (!s) return;
+
+    if (GameObject* ctrl = s->GetGameObjectByName("GameOverController"))
+        if (auto* sc = ctrl->GetComponent<ScriptComponent*>())
+            if (auto* go = sc->GetScriptByType<GameOverScript>())
+            {
+                // GLOG: trigger requested through controller
+                // GLOG("[GAMEOVER] GO_RequestGameOver -> instance=%p owner='%s'", go, ctrl->GetName().c_str());
+                go->TriggerGameOver();
+                return;
+            }
+
+    // fallback: search all objects
+    const auto& all = s->GetAllGameObjects();
+    for (const auto& kv : all)
+    {
+        GameObject* g = s->GetGameObjectByUID(kv.first);
+        if (!g) continue;
+        if (auto* sc = g->GetComponent<ScriptComponent*>())
+            if (auto* go = sc->GetScriptByType<GameOverScript>())
+            {
+                // GLOG: trigger requested through fallback search
+                // GLOG("[GAMEOVER] GO_RequestGameOver (fallback) -> instance=%p owner='%s'", go, g->GetName().c_str());
+                go->TriggerGameOver();
+                return;
+            }
+    }
+}
 
 GameOverScript::GameOverScript(GameObject* parent) : Script(parent)
 {
@@ -17,60 +58,200 @@ GameOverScript::GameOverScript(GameObject* parent) : Script(parent)
 
 bool GameOverScript::Init()
 {
+    gGameOverActive = false;
+
     CachePanel();
-    if (cachedTarget) cachedTarget->SetEnabledRecursive(false);
+    if (panelRoot) panelRoot->SetEnabledRecursive(false);
+
+    builtOnce     = false;
+    gameOverShown = false;
+    selectedIndex = 0;
     return true;
 }
 
-void GameOverScript::Update(float)
+void GameOverScript::Inspector()
 {
-    if (gameOverShown && cachedTarget && !cachedTarget->IsEnabled()) gameOverShown = false;
+    ImGui::SetCurrentContext(AppEngine->GetEditorUIModule()->GetImGuiContext());
+    AppEngine->GetEditorUIModule()->DrawScriptInspector(
+        [this]()
+        {
+            char buffer[128];
+            strncpy_s(buffer, sizeof(buffer), panelToShowName.c_str(), _TRUNCATE);
+            buffer[sizeof(buffer) - 1] = '\0';
+            if (ImGui::InputText("Panel To Show", buffer, sizeof(buffer)))
+            {
+                panelToShowName = buffer;
+                panelRoot       = nullptr;
+                builtOnce       = false;
+            }
+        }
+    );
+}
 
-    if (gameOverShown) return;
+void GameOverScript::Update(float dt)
+{
+    if (!panelRoot) CachePanel();
+    if (!gameOverShown || !panelRoot) return;
 
-    if (!cachedTarget) CachePanel();
-    if (playerScript && playerScript->IsDead()) TriggerGameOver();
+    if (!panelRoot->IsEnabled())
+    {
+        builtOnce = false;
+        return;
+    }
+
+    if (!builtOnce)
+    {
+        BuildFromPanel();
+        selectedIndex = 0;
+        UpdateSelection();
+        builtOnce = true;
+        // GLOG: menu constructed (first time build)
+        // GLOG("[GAMEOVER] Menu built -> items=%zu", menuItems.size());
+    }
+
+    // ensure exactly one arrow is enabled
+    int on = 0;
+    for (auto* a : arrowImages)
+        if (a && a->IsEnabled()) ++on;
+    if (on != 1) UpdateSelection();
 }
 
 void GameOverScript::TriggerGameOver()
 {
     if (gameOverShown) return;
-    ShowPanel();
-    PauseGame();
-    gameOverShown = true;
-}
 
-void GameOverScript::CachePanel()
-{
-    if (cachedTarget) return;
-    const auto& gos = AppEngine->GetSceneModule()->GetScene()->GetAllGameObjects();
-    for (const auto& [uid, go] : gos)
-        if (go && go->GetName() == panelToShowName)
-        {
-            cachedTarget = go;
-            break;
-        }
-}
-
-void GameOverScript::ShowPanel()
-{
     CachePanel();
-    if (!cachedTarget) return;
-    cachedTarget->SetEnabledRecursive(true);
-    cachedTarget->UpdateTransformForGOBranch();
-}
+    if (panelRoot)
+    {
+        panelRoot->SetEnabledRecursive(true);
+        panelRoot->UpdateTransformForGOBranch();
 
-void GameOverScript::PauseGame()
-{
-    if (auto* t = AppEngine->GetGameTimer()) t->TogglePause();
+        BuildFromPanel();
+        selectedIndex = 0;
+        DisableAllArrows();
+        UpdateSelection();
+        // GLOG: first paint with initial selection
+        // GLOG("[GAMEOVER] First paint -> sel=%d (items=%zu)", selectedIndex, menuItems.size());
+    }
+
+    if (auto* t = AppEngine->GetGameTimer(); t && !t->IsPaused()) t->TogglePause();
+
+    gGameOverActive = true;
+    gameOverShown   = true;
+
+    // GLOG: game over triggered, panel activated
+    // GLOG("[GAMEOVER] TriggerGameOver -> panel '%s' activated", panelRoot ? panelRoot->GetName().c_str() : "(null)");
 }
 
 void GameOverScript::Close()
 {
-    if (cachedTarget) cachedTarget->SetEnabledRecursive(false);
+    if (panelRoot) panelRoot->SetEnabledRecursive(false);
+    if (auto* timer = AppEngine->GetGameTimer(); timer && timer->IsPaused()) timer->TogglePause();
 
-    GameTimer* timer = AppEngine->GetGameTimer();
-    if (timer && timer->IsPaused()) timer->TogglePause();
+    gGameOverActive = false;
+    gameOverShown   = false;
+    builtOnce       = false;
+}
 
-    gameOverShown = false;
+void GameOverScript::CachePanel()
+{
+    Scene* scene = AppEngine->GetSceneModule()->GetScene();
+    if (!scene) return;
+
+    auto hasMenuChildren = [&](GameObject* go) -> bool
+    {
+        if (!go) return false;
+        for (UID cid : go->GetChildren())
+        {
+            GameObject* ch = scene->GetGameObjectByUID(cid);
+            if (ch && ch->GetName().find("MenuItem_") != std::string::npos) return true;
+        }
+        return false;
+    };
+
+    if (hasMenuChildren(parent)) panelRoot = parent;
+
+    if (!panelRoot && !panelToShowName.empty())
+        if (GameObject* byName = scene->GetGameObjectByName(panelToShowName)) panelRoot = byName;
+
+    if (!panelRoot)
+    {
+        const auto& objects = scene->GetAllGameObjects();
+        for (const auto& kv : objects)
+        {
+            GameObject* go = scene->GetGameObjectByUID(kv.first);
+            if (!go) continue;
+            if (hasMenuChildren(go))
+            {
+                panelRoot = go;
+                break;
+            }
+        }
+    }
+
+    if (panelRoot)
+    {
+        // GLOG: cache panel found
+        // GLOG("[GAMEOVER] CachePanel -> %s (target='%s')", panelRoot->GetName().c_str(), panelToShowName.c_str());
+    }
+    else
+    {
+        // GLOG: cache panel not found
+        // GLOG("[GAMEOVER] CachePanel -> NOT FOUND (target='%s')", panelToShowName.c_str());
+    }
+}
+
+void GameOverScript::BuildFromPanel()
+{
+    if (!panelRoot) return;
+
+    menuItems.clear();
+    arrowImages.clear();
+
+    Scene* scene = AppEngine->GetSceneModule()->GetScene();
+    for (UID cid : panelRoot->GetChildren())
+    {
+        GameObject* child = scene->GetGameObjectByUID(cid);
+        if (!child) continue;
+
+        if (child->GetName().find("MenuItem_") != std::string::npos)
+        {
+            menuItems.push_back(child);
+            for (UID gcid : child->GetChildren())
+            {
+                GameObject* arrow = scene->GetGameObjectByUID(gcid);
+                if (arrow && arrow->GetName().find("Arrow") != std::string::npos) arrowImages.push_back(arrow);
+            }
+        }
+    }
+
+    DisableAllArrows();
+    // GLOG: menu items and arrows found
+    // GLOG("[GAMEOVER] BuildFromPanel: items=%zu arrows=%zu", menuItems.size(), arrowImages.size());
+}
+
+void GameOverScript::DisableAllArrows()
+{
+    for (auto* a : arrowImages)
+        if (a) a->SetEnabled(false);
+}
+
+void GameOverScript::UpdateSelection()
+{
+    if (menuItems.empty()) return;
+
+    selectedIndex = std::clamp(selectedIndex, 0, (int)menuItems.size() - 1);
+
+    Scene* scene  = AppEngine->GetSceneModule()->GetScene();
+    for (size_t i = 0; i < menuItems.size(); ++i)
+    {
+        for (UID uid : menuItems[i]->GetChildren())
+        {
+            GameObject* child = scene->GetGameObjectByUID(uid);
+            if (child && child->GetName().find("Arrow") != std::string::npos)
+                child->SetEnabled(i == (size_t)selectedIndex);
+        }
+    }
+    // GLOG: selection changed
+    // GLOG("[GAMEOVER] UpdateSelection -> sel=%d", selectedIndex);
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/GameOverScript.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/GameOverScript.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "Script.h"
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -11,20 +12,46 @@ class GameOverScript : public Script
     GameOverScript(GameObject* parent);
 
     bool Init() override;
-    void Update(float) override;
+    void Update(float dt) override;
+    void Inspector() override;
+
+    // Open / close
+    void TriggerGameOver();
     void Close();
 
-  private:
-    void TriggerGameOver();
-    void CachePanel();
-    void ShowPanel();
-    void PauseGame();
+    // Accessors (for external navigation)
+    GameObject* GetPanelRoot() const { return panelRoot; }
+    int GetSelectedIndex() const { return selectedIndex; }
+    void SetSelectedIndex(int idx)
+    {
+        selectedIndex = idx;
+        UpdateSelection();
+    }
 
+  private:
+    void CachePanel();
+    void BuildFromPanel();
+    void DisableAllArrows();
+    void UpdateSelection();
+
+    // Inspector-exposed fields
     std::string panelToShowName = "GameOverPanel";
     std::vector<InspectorField> fields {
         {"Panel To Show", InspectorField::FieldType::InputText, &panelToShowName}
     };
 
-    GameObject* cachedTarget = nullptr;
-    bool gameOverShown       = false;
+    // UI state
+    GameObject* panelRoot = nullptr;
+    std::vector<GameObject*> menuItems;
+    std::vector<GameObject*> arrowImages;
+
+    int selectedIndex  = 0;
+    bool builtOnce     = false;
+    bool gameOverShown = false;
 };
+
+// Global flag
+extern bool gGameOverActive;
+
+// C bridge
+extern "C" void GO_RequestGameOver();

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MainMenuSelectorScript.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MainMenuSelectorScript.cpp
@@ -1,10 +1,10 @@
 #include "pch.h"
 
 #include "Application.h"
-#include "CuChulainn.h"
 #include "GameObject.h"
 #include "GameOverScript.h"
 #include "GameTimer.h"
+#include "Globals.h"
 #include "InputModule.h"
 #include "MainMenuSelectorScript.h"
 #include "PauseMenuScript.h"
@@ -13,43 +13,19 @@
 #include "SceneModule.h"
 #include "ScriptComponent.h"
 #include "Standalone/UI/ButtonComponent.h"
+#include <algorithm>
+#include <cmath>
 
 bool MainMenuSelectorScript::Init()
 {
-    menuItems.clear();
-    arrowImages.clear();
-    selectedIndex                    = 0;
+    CachePanel();
 
-    const std::vector<UID>& children = parent->GetChildren();
-    for (UID childUID : children)
-    {
-        GameObject* child = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByUID(childUID);
-        if (!child) continue;
-
-        if (child->GetName().find("MenuItem_") != std::string::npos)
-        {
-            menuItems.push_back(child);
-
-            const std::vector<UID>& itemChildren = child->GetChildren();
-            for (UID arrowUID : itemChildren)
-            {
-                GameObject* arrow = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByUID(arrowUID);
-                if (arrow && arrow->GetName().find("Arrow") != std::string::npos)
-                {
-                    arrowImages.push_back(arrow);
-                    arrow->SetEnabled(false);
-                }
-            }
-        }
-    }
-
+    // find Pause/GameOver controllers walking up from this script's GO
     Scene* scene     = AppEngine->GetSceneModule()->GetScene();
-    GameObject* node = parent; // start with the object that owns this script
-
+    GameObject* node = parent;
     while (node && (!pauseCtrl || !gameOverCtrl))
     {
-        ScriptComponent* sc = node->GetComponent<ScriptComponent*>();
-        if (sc)
+        if (auto* sc = node->GetComponent<ScriptComponent*>())
         {
             if (!pauseCtrl) pauseCtrl = sc->GetScriptByType<PauseMenuScript>();
             if (!gameOverCtrl) gameOverCtrl = sc->GetScriptByType<GameOverScript>();
@@ -57,74 +33,187 @@ bool MainMenuSelectorScript::Init()
         node = scene->GetGameObjectByUID(node->GetParent());
     }
 
-    UpdateSelection();
+    // ensure initial state
+    stickMoved = false;
+
+    if (panelRoot && panelRoot->IsEnabled())
+    {
+        BuildFromPanel();
+        UpdateSelection();
+        builtOnce = true;
+    }
+
     return true;
 }
 
-void MainMenuSelectorScript::Update(float deltaTime)
+void MainMenuSelectorScript::CachePanel()
 {
-    int arrowsEnabled = 0;
-    for (GameObject* arrow : arrowImages)
-    {
-        if (arrow && arrow->IsEnabled())
+    if (panelRoot) return;
+
+    Scene* scene        = AppEngine->GetSceneModule()->GetScene();
+    const auto& objects = scene->GetAllGameObjects();
+
+    // 1) Try exact name from inspector
+    for (const auto& [uid, go] : objects)
+        if (go && go->GetName() == panelName)
         {
-            ++arrowsEnabled;
+            panelRoot = go;
+            break;
+        }
+
+    // 2) Fallback: first GO that has children named "MenuItem_*"
+    if (!panelRoot)
+    {
+        for (const auto& [uid, go] : objects)
+        {
+            if (!go) continue;
+            bool hasMenuChild = false;
+            for (UID cid : go->GetChildren())
+            {
+                GameObject* ch = scene->GetGameObjectByUID(cid);
+                if (ch && ch->GetName().find("MenuItem_") != std::string::npos)
+                {
+                    hasMenuChild = true;
+                    break;
+                }
+            }
+            if (hasMenuChild)
+            {
+                panelRoot = go;
+                break;
+            }
         }
     }
 
-    if (arrowsEnabled > 1)
+    // GLOG: cache result
+    // GLOG("[SEL] CachePanel -> %s (name=%s)", panelRoot ? "FOUND" : "NOT FOUND", panelName.c_str());
+}
+
+void MainMenuSelectorScript::BuildFromPanel()
+{
+    if (!panelRoot) return;
+
+    menuItems.clear();
+    arrowImages.clear();
+
+    Scene* scene = AppEngine->GetSceneModule()->GetScene();
+
+    for (UID cid : panelRoot->GetChildren())
     {
-        UpdateSelection();
+        GameObject* child = scene->GetGameObjectByUID(cid);
+        if (!child) continue;
+
+        if (child->GetName().find("MenuItem_") != std::string::npos)
+        {
+            menuItems.push_back(child);
+
+            for (UID gcid : child->GetChildren())
+            {
+                GameObject* arrow = scene->GetGameObjectByUID(gcid);
+                if (arrow && arrow->GetName().find("Arrow") != std::string::npos) arrowImages.push_back(arrow);
+            }
+        }
     }
 
-    const KeyState* keys           = AppEngine->GetInputModule()->GetKeyboard();
-    const KeyState* gamepadButtons = AppEngine->GetInputModule()->GetControllerButtons();
-    const float2& leftStick        = AppEngine->GetInputModule()->GetLeftStick();
+    // turn all arrows off; UpdateSelection() will light the selected one
+    for (auto* a : arrowImages)
+        if (a) a->SetEnabled(false);
 
-    bool moveDown                  = keys[SDL_SCANCODE_DOWN] == KEY_DOWN ||
-                    gamepadButtons[SDL_CONTROLLER_BUTTON_DPAD_DOWN] == KEY_DOWN || (leftStick.y > 0.5f && !stickMoved);
+    // GLOG: discovered items/arrows
+    // GLOG("[SEL] BuildFromPanel: items=%zu arrows=%zu", menuItems.size(), arrowImages.size());
+}
 
-    bool moveUp = keys[SDL_SCANCODE_UP] == KEY_DOWN || gamepadButtons[SDL_CONTROLLER_BUTTON_DPAD_UP] == KEY_DOWN ||
-                  (leftStick.y < -0.5f && !stickMoved);
+void MainMenuSelectorScript::UpdateSelection()
+{
+    if (menuItems.empty()) return;
+
+    selectedIndex = std::clamp(selectedIndex, 0, (int)menuItems.size() - 1);
+
+    Scene* scene  = AppEngine->GetSceneModule()->GetScene();
+    for (size_t i = 0; i < menuItems.size(); ++i)
+    {
+        for (UID uid : menuItems[i]->GetChildren())
+        {
+            GameObject* child = scene->GetGameObjectByUID(uid);
+            if (child && child->GetName().find("Arrow") != std::string::npos)
+                child->SetEnabled(i == (size_t)selectedIndex);
+        }
+    }
+    // GLOG: selection updated
+    // GLOG("[SEL] UpdateSelection -> sel=%d", selectedIndex);
+}
+
+void MainMenuSelectorScript::Update(float)
+{
+    if (!panelRoot) CachePanel();
+    if (!panelRoot) return;
+
+    const bool panelEnabled = panelRoot->IsEnabled();
+
+    // if panel just turned off, mark for rebuild and bail
+    if (!panelEnabled)
+    {
+        builtOnce = false;
+        return;
+    }
+
+    // build on first open / first tick
+    if (!builtOnce)
+    {
+        BuildFromPanel();
+        selectedIndex = 0;
+        UpdateSelection();
+        builtOnce = true;
+    }
+
+    if (menuItems.empty()) return;
+
+    // self-correct: ensure exactly one arrow ON
+    int arrowsOn = 0;
+    for (auto* a : arrowImages)
+        if (a && a->IsEnabled()) ++arrowsOn;
+    if (arrowsOn != 1) UpdateSelection();
+
+    const InputModule* input   = AppEngine->GetInputModule();
+    const KeyState* keys       = input->GetKeyboard();
+    const KeyState* padButtons = input->GetControllerButtons();
+    const float2& leftStick    = input->GetLeftStick();
+
+    const bool moveDown        = keys[SDL_SCANCODE_DOWN] == KEY_DOWN ||
+                          padButtons[SDL_CONTROLLER_BUTTON_DPAD_DOWN] == KEY_DOWN ||
+                          (leftStick.y > 0.5f && !stickMoved);
+
+    const bool moveUp = keys[SDL_SCANCODE_UP] == KEY_DOWN || padButtons[SDL_CONTROLLER_BUTTON_DPAD_UP] == KEY_DOWN ||
+                        (leftStick.y < -0.5f && !stickMoved);
 
     if (moveDown)
     {
-        selectedIndex = (selectedIndex + 1) % menuItems.size();
+        selectedIndex = (selectedIndex + 1) % (int)menuItems.size();
         UpdateSelection();
         stickMoved = true;
     }
     else if (moveUp)
     {
-        selectedIndex = (selectedIndex - 1 + menuItems.size()) % static_cast<int>(menuItems.size());
+        selectedIndex = (selectedIndex - 1 + (int)menuItems.size()) % (int)menuItems.size();
         UpdateSelection();
         stickMoved = true;
     }
 
-    if (fabs(leftStick.y) < 0.3f)
-    {
-        stickMoved = false;
-    }
+    if (std::fabs(leftStick.y) < 0.3f) stickMoved = false;
 
-    if (keys[SDL_SCANCODE_RETURN] == KEY_DOWN || keys[SDL_SCANCODE_SPACE] == KEY_DOWN ||
-        gamepadButtons[SDL_CONTROLLER_BUTTON_A] == KEY_DOWN)
+    const bool accept = keys[SDL_SCANCODE_RETURN] == KEY_DOWN || keys[SDL_SCANCODE_SPACE] == KEY_DOWN ||
+                        padButtons[SDL_CONTROLLER_BUTTON_A] == KEY_DOWN;
+
+    if (accept)
     {
         GameObject* selectedItem = menuItems[selectedIndex];
 
         if (selectedItem->GetName() == "MenuItem_Continue")
         {
-            if (gameOverCtrl)
-            {
-                gameOverCtrl->Close();
-                if (playerScript) playerScript->Respawn();
-            }
-            else if (pauseCtrl)
-            {
-                pauseCtrl->Close();
-            }
-
+            if (gameOverCtrl) gameOverCtrl->Close();
+            else if (pauseCtrl) pauseCtrl->Close();
             return;
         }
-
         else if (selectedItem->GetName() == "MenuItem_Menu")
         {
             if (pauseCtrl) pauseCtrl->Close();
@@ -136,23 +225,7 @@ void MainMenuSelectorScript::Update(float deltaTime)
         }
         else
         {
-            ButtonComponent* button = selectedItem->GetComponent<ButtonComponent*>();
-            if (button) button->OnClick();
-        }
-    }
-}
-
-void MainMenuSelectorScript::UpdateSelection()
-{
-    for (size_t i = 0; i < menuItems.size(); ++i)
-    {
-        for (UID childUID : menuItems[i]->GetChildren())
-        {
-            GameObject* child = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByUID(childUID);
-            if (child && child->GetName().find("Arrow") != std::string::npos)
-            {
-                child->SetEnabled(i == selectedIndex);
-            }
+            if (auto* button = selectedItem->GetComponent<ButtonComponent*>()) button->OnClick();
         }
     }
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MainMenuSelectorScript.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MainMenuSelectorScript.h
@@ -1,27 +1,44 @@
 ﻿#pragma once
 #include "Script.h"
+#include <string>
 #include <vector>
 
+class GameObject;
 class PauseMenuScript;
 class GameOverScript;
 
 class MainMenuSelectorScript : public Script
 {
   public:
-    MainMenuSelectorScript(GameObject* parent) : Script(parent) {}
+    MainMenuSelectorScript(GameObject* parent) : Script(parent)
+    {
+        fields.push_back({"Panel Name", InspectorField::FieldType::InputText, &panelName});
+    }
 
     bool Init() override;
     void Update(float deltaTime) override;
     void Inspector() override {}
 
   private:
+    // Inspector-configurable
+    std::string panelName = "PauseMenuPanel";
+
+    // Cached panel & UI elements
+    GameObject* panelRoot = nullptr;
     std::vector<GameObject*> menuItems;
     std::vector<GameObject*> arrowImages;
+
+    // Navigation state
     int selectedIndex            = 0;
     bool stickMoved              = false;
+    bool builtOnce               = false;
 
+    // Controllers (used to close Pause/GameOver)
     PauseMenuScript* pauseCtrl   = nullptr;
     GameOverScript* gameOverCtrl = nullptr;
 
+    // Helpers
+    void CachePanel();
+    void BuildFromPanel();
     void UpdateSelection();
 };

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MirageBossDash.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MirageBossDash.cpp
@@ -15,7 +15,7 @@
 #include "Standalone/Physics/CapsuleColliderComponent.h"
 
 MirageBossDash::MirageBossDash(GameObject* parent)
-    : Character(parent, 60, 1, 0.5f, 1.0f, 1.0f, 3.0f, 15.0f, 20.0f, CharacterType::Boss)
+    : Character(parent, 60, 1, 0.5f, 1.0f, 1.0f, 3.0f, 15.0f, 20.0f, CharacterType::Mirage)
 {
     fields.push_back({InspectorField::FieldType::Text, (void*)"Ferdiad specific"});
     fields.push_back({InspectorField::FieldType::Text, (void*)"Colliders"});

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/PauseMenuScript.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/PauseMenuScript.cpp
@@ -1,42 +1,75 @@
 #include "pch.h"
 
 #include "Application.h"
-#include "CuChulainn.h"
 #include "GameObject.h"
 #include "GameTimer.h"
+#include "Globals.h"
 #include "InputModule.h"
 #include "PauseMenuScript.h"
+#include "ProjectModule.h"
+#include "SDL.h"
 #include "Scene.h"
 #include "SceneModule.h"
 #include "ScriptComponent.h"
+#include "Standalone/UI/ButtonComponent.h"
+#include <algorithm>
+
+extern bool gGameOverActive; // block pause if Game Over is active
 
 bool PauseMenuScript::Init()
 {
     CachePanel();
     if (cachedTarget) cachedTarget->SetEnabledRecursive(false);
-    isOpen = false;
+
+    isOpen        = false;
+    builtOnce     = false;
+    selectedIndex = 0;
+
+    lastMs        = GetCurrentTimeMs();
+    repeatMs      = 0;
+    lastDir       = 0;
+    acceptWas     = false;
+    upPrev = downPrev = accPrev = false;
+
     return true;
 }
 
 void PauseMenuScript::Show()
 {
+    if (gGameOverActive) return; // do not open pause on Game Over
     if (isOpen) return;
+
     CachePanel();
     if (cachedTarget)
     {
         cachedTarget->SetEnabledRecursive(true);
         cachedTarget->UpdateTransformForGOBranch();
+
+        // initial render/setup
+        BuildFromPanel();
+        selectedIndex = 0;
+        DisableAllArrows();
+        UpdateSelection();
     }
+
     if (auto* t = AppEngine->GetGameTimer(); t && !t->IsPaused()) t->TogglePause();
-    isOpen = true;
+    isOpen    = true;
+    builtOnce = true;
+
+    //GLOG("[PAUSE] Show -> panel='%s'", cachedTarget ? cachedTarget->GetName().c_str() : "(null)");
 }
 
 void PauseMenuScript::Close()
 {
     if (!isOpen) return;
+
     if (cachedTarget) cachedTarget->SetEnabledRecursive(false);
     if (auto* t = AppEngine->GetGameTimer(); t && t->IsPaused()) t->TogglePause();
-    isOpen = false;
+
+    isOpen    = false;
+    builtOnce = false;
+
+    //GLOG("[PAUSE] Close");
 }
 
 void PauseMenuScript::Toggle()
@@ -46,9 +79,34 @@ void PauseMenuScript::Toggle()
 
 void PauseMenuScript::Update(float)
 {
-    const KeyState* k = AppEngine->GetInputModule()->GetKeyboard();
-    if (k[SDL_SCANCODE_ESCAPE] == KEY_DOWN) Toggle();
+    if (gGameOverActive) return;
+
+    const InputModule* in = AppEngine->GetInputModule();
+    const KeyState* pad   = in ? in->GetControllerButtons() : nullptr;
+
+    bool padToggleHeld    = false;
+    if (pad)
+    {
+        const bool startHeld = (pad[SDL_CONTROLLER_BUTTON_START] != KEY_IDLE);
+        const bool backHeld  = (pad[SDL_CONTROLLER_BUTTON_BACK] != KEY_IDLE);
+        const bool bHeld     = (isOpen && (pad[SDL_CONTROLLER_BUTTON_B] != KEY_IDLE));
+        padToggleHeld        = startHeld || backHeld || bHeld;
+    }
+
+    static bool padTogglePrev = false;
+    const bool padToggleEdge  = padToggleHeld && !padTogglePrev;
+    padTogglePrev             = padToggleHeld;
+
+    const KeyState* k         = AppEngine->GetInputModule()->GetKeyboard();
+    if (padToggleEdge || (k[SDL_SCANCODE_ESCAPE] == KEY_DOWN))
+    {
+        Toggle();
+        return;
+    }
+
+    if (isOpen) HandleInput();
 }
+
 
 void PauseMenuScript::Save(rapidjson::Value& out, rapidjson::Document::AllocatorType& a)
 {
@@ -64,18 +122,204 @@ void PauseMenuScript::CachePanel()
 {
     if (cachedTarget != nullptr) return;
 
-    Scene* scene        = AppEngine->GetSceneModule()->GetScene();
-    const auto& objects = scene->GetAllGameObjects();
+    Scene* scene = AppEngine->GetSceneModule()->GetScene();
+    if (!scene) return;
 
+    // exact name
+    if (GameObject* go = scene->GetGameObjectByName(panelToShowName))
+    {
+        cachedTarget = go;
+        //GLOG("[PAUSE] CachePanel -> %s", cachedTarget->GetName().c_str());
+        return;
+    }
+
+    // fallback: first GO with children named "MenuItem_"
+    const auto& objects = scene->GetAllGameObjects();
     for (const auto& [uid, go] : objects)
     {
-        if (go == nullptr)
-            continue;
-
-        if (go->GetName() == panelToShowName)
+        if (!go) continue;
+        bool hasMenuChild = false;
+        for (UID cid : go->GetChildren())
         {
-            cachedTarget = go; 
-            return;            
+            GameObject* ch = scene->GetGameObjectByUID(cid);
+            if (ch && ch->GetName().find("MenuItem_") != std::string::npos)
+            {
+                hasMenuChild = true;
+                break;
+            }
+        }
+        if (hasMenuChild)
+        {
+            cachedTarget = go;
+            break;
         }
     }
+    // GLOG("[PAUSE] CachePanel -> %s", cachedTarget ? cachedTarget->GetName().c_str() : "NOT FOUND");
+}
+
+void PauseMenuScript::BuildFromPanel()
+{
+    if (!cachedTarget) return;
+
+    menuItems.clear();
+    arrowImages.clear();
+
+    Scene* s = AppEngine->GetSceneModule()->GetScene();
+    for (UID cid : cachedTarget->GetChildren())
+    {
+        GameObject* child = s->GetGameObjectByUID(cid);
+        if (!child) continue;
+
+        if (child->GetName().find("MenuItem_") != std::string::npos)
+        {
+            menuItems.push_back(child);
+            for (UID gcid : child->GetChildren())
+            {
+                GameObject* arrow = s->GetGameObjectByUID(gcid);
+                if (arrow && arrow->GetName().find("Arrow") != std::string::npos) arrowImages.push_back(arrow);
+            }
+        }
+    }
+
+    DisableAllArrows();
+    // GLOG("[PAUSE] BuildFromPanel: items=%zu arrows=%zu", menuItems.size(), arrowImages.size());
+}
+
+void PauseMenuScript::DisableAllArrows()
+{
+    for (auto* a : arrowImages)
+        if (a) a->SetEnabled(false);
+}
+
+void PauseMenuScript::UpdateSelection()
+{
+    if (menuItems.empty()) return;
+
+    selectedIndex = std::clamp(selectedIndex, 0, (int)menuItems.size() - 1);
+
+    Scene* s      = AppEngine->GetSceneModule()->GetScene();
+    for (size_t i = 0; i < menuItems.size(); ++i)
+    {
+        for (UID uid : menuItems[i]->GetChildren())
+        {
+            GameObject* child = s->GetGameObjectByUID(uid);
+            if (child && child->GetName().find("Arrow") != std::string::npos)
+                child->SetEnabled(i == (size_t)selectedIndex);
+        }
+    }
+    //GLOG("[PAUSE] UpdateSelection -> sel=%d", selectedIndex);
+}
+
+uint64_t PauseMenuScript::GetCurrentTimeMs() const
+{
+    const uint64_t c = (uint64_t)SDL_GetPerformanceCounter();
+    const uint64_t f = (uint64_t)SDL_GetPerformanceFrequency();
+    return (f > 0) ? (c * 1000ull) / f : 0ull;
+}
+
+void PauseMenuScript::ReadInputs(bool& up, bool& down, bool& acc, int& stickDir)
+{
+    // keyboard
+    const Uint8* kb          = SDL_GetKeyboardState(nullptr);
+    const bool kUp           = (kb[SDL_SCANCODE_UP] != 0) || (kb[SDL_SCANCODE_W] != 0);
+    const bool kDown         = (kb[SDL_SCANCODE_DOWN] != 0) || (kb[SDL_SCANCODE_S] != 0);
+    const bool kEnt          = (kb[SDL_SCANCODE_RETURN] != 0) || (kb[SDL_SCANCODE_KP_ENTER] != 0);
+    const bool kSpc          = (kb[SDL_SCANCODE_SPACE] != 0);
+
+    // gamepad via InputModule
+    const InputModule* input = AppEngine->GetInputModule();
+    const KeyState* buttons  = input ? input->GetControllerButtons() : nullptr;
+    const bool padUpHeld     = buttons ? (buttons[SDL_CONTROLLER_BUTTON_DPAD_UP] != KEY_IDLE) : false;
+    const bool padDownHeld   = buttons ? (buttons[SDL_CONTROLLER_BUTTON_DPAD_DOWN] != KEY_IDLE) : false;
+    const bool padAHeld      = buttons ? (buttons[SDL_CONTROLLER_BUTTON_A] != KEY_IDLE) : false;
+    const float2& ls         = input ? input->GetLeftStick() : float2 {0.f, 0.f};
+
+    up                       = kUp || padUpHeld || (ls.y < -0.5f);
+    down                     = kDown || padDownHeld || (ls.y > 0.5f);
+    acc                      = kEnt || kSpc || padAHeld;
+    stickDir                 = (ls.y > 0.5f) ? +1 : ((ls.y < -0.5f) ? -1 : 0);
+}
+
+void PauseMenuScript::HandleInput()
+{
+    bool upHeld = false, downHeld = false, accHeld = false;
+    int stickDir = 0;
+    ReadInputs(upHeld, downHeld, accHeld, stickDir);
+
+    const bool upEdge   = upHeld && !upPrev;
+    const bool downEdge = downHeld && !downPrev;
+    const bool accEdge  = accHeld && !accPrev;
+
+    // direction handling (edge + autorepeat)
+    int dir             = 0;
+    if (downEdge) dir = +1;
+    else if (upEdge) dir = -1;
+    else
+    {
+        int heldDir        = downHeld ? +1 : (upHeld ? -1 : 0);
+        const uint64_t now = GetCurrentTimeMs();
+        if (heldDir != 0)
+        {
+            if (lastDir != heldDir)
+            {
+                lastDir  = heldDir;
+                repeatMs = 230; // initial delay
+                lastMs   = now;
+            }
+            else
+            {
+                const uint32_t el = (uint32_t)(now - lastMs);
+                if (el >= repeatMs)
+                {
+                    dir      = heldDir;
+                    repeatMs = 140; // repeat interval
+                    lastMs   = now;
+                }
+            }
+        }
+        else
+        {
+            lastDir  = 0;
+            repeatMs = 0;
+        }
+    }
+
+    if (dir != 0 && !menuItems.empty())
+    {
+        const int n   = (int)menuItems.size();
+        selectedIndex = (selectedIndex + (dir > 0 ? +1 : -1) + n) % n;
+        UpdateSelection();
+        //GLOG("[PAUSE] Nav -> sel=%d", selectedIndex);
+    }
+
+    if (accEdge && !menuItems.empty())
+    {
+        GameObject* item       = menuItems[selectedIndex];
+        const std::string name = item ? item->GetName() : "(null)";
+        //GLOG("[PAUSE] Accept on '%s'", name.c_str());
+
+        if (name == "MenuItem_Continue")
+        {
+            Close();
+            return;
+        }
+        else if (name == "MenuItem_Menu")
+        {
+            Close();
+            AppEngine->GetSceneModule()->GetScene()->SetStopPlaying(true);
+            std::string path =
+                AppEngine->GetProjectModule()->GetLoadedProjectPath() + SCENES_PATH + "SCENE_MainMenu.scene";
+            AppEngine->GetSceneModule()->RequestSceneLoad(path);
+            return;
+        }
+        else
+        {
+            if (auto* btn = item->GetComponent<ButtonComponent*>()) btn->OnClick();
+        }
+    }
+
+    // save previous states
+    upPrev   = upHeld;
+    downPrev = downHeld;
+    accPrev  = accHeld;
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/PauseMenuScript.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/PauseMenuScript.h
@@ -1,7 +1,11 @@
 #pragma once
 
 #include "Script.h"
+#include <cstdint>
 #include <string>
+#include <vector>
+
+class GameObject;
 
 class PauseMenuScript : public Script
 {
@@ -10,7 +14,7 @@ class PauseMenuScript : public Script
 
     bool Init() override;
     void Update(float deltaTime) override;
-    void Inspector() override {};
+    void Inspector() override {}
     void Save(rapidjson::Value& targetState, rapidjson::Document::AllocatorType& allocator);
     void Load(const rapidjson::Value& initialState) override;
 
@@ -19,9 +23,35 @@ class PauseMenuScript : public Script
     void Toggle();
 
   private:
+    // Cache panel by name
     void CachePanel();
 
+    void BuildFromPanel();
+    void DisableAllArrows();
+    void UpdateSelection();
+    void HandleInput();
+    uint64_t GetCurrentTimeMs() const;
+    void ReadInputs(bool& upHeld, bool& downHeld, bool& acceptHeld, int& stickDir);
+
+  private:
     std::string panelToShowName = "PauseMenuPanel";
-    GameObject* cachedTarget    = nullptr;
-    bool isOpen                 = false;
+
+    GameObject* cachedTarget    = nullptr; // panel root
+    std::vector<GameObject*> menuItems;
+    std::vector<GameObject*> arrowImages;
+
+    bool isOpen       = false;
+    bool builtOnce    = false;
+    int selectedIndex = 0;
+
+    // input repeat/debounce state
+    uint64_t lastMs   = 0;
+    uint32_t repeatMs = 0;
+    int lastDir       = 0;
+    bool acceptWas    = false;
+
+    // previous input edges
+    bool upPrev       = false;
+    bool downPrev     = false;
+    bool accPrev      = false;
 };

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/ScriptExport.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/ScriptExport.cpp
@@ -44,6 +44,7 @@
 
 #include "AbilityIconFill.h"
 #include "AttackVfxSpritesheet.h"
+#include "ColorChange.h"
 #include "BarFill.h"
 #include "DamageMask.h"
 #include "MovingUVClipErode.h"
@@ -111,7 +112,7 @@ constexpr const char* scripts[] = {
 constexpr const char* shaderScripts[] = {
     "MovingUVPostScript", "MovingUVLight",         "MovingUVTransparent",  "HealGroundHalo", "HealVerticalPlanes",
     "HealSpikesBurst",    "HealGroundSpikesLight", "HealGroundSpikesDark", "HealLightBurst", "HealSpikesUp",
-    "RiastradBarFill",    "HealthBarFill",         "AbilityIconFill",      "DamageMask", "AttackVfxSpritesheet", "MovingUVClipErode"
+    "RiastradBarFill",    "HealthBarFill",         "AbilityIconFill",      "DamageMask", "AttackVfxSpritesheet", "MovingUVClipErode",  "ColorChange"
 };
 
 Application* AppEngine                = nullptr;
@@ -175,6 +176,7 @@ extern "C" SOBRASSADA_API Script* CreateScript(const std::string& scriptType, Ga
     if (scriptType == "MovingUVTransparent") return new MovingUVTransparent(parent);
     if (scriptType == "AttackVfxSpritesheet") return new AttackVfxSpritesheet(parent);
     if (scriptType == "DamageMask") return new DamageMask(parent);
+    if (scriptType == "ColorChange") return new ColorChange(parent);
     if (scriptType == "RiastradBarFill")
         return new BarFill(parent, "./EngineDefaults/Shader/Custom/Fragment/UI_RiastradBarFill.glsl");
     if (scriptType == "HealthBarFill")

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/ScriptExport.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/ScriptExport.cpp
@@ -15,6 +15,7 @@
 #include "FireballTrap.h"
 #include "FreeCamera.h"
 #include "FullscreenToggleScript.h"
+#include "GameOverNavigatorScript.h"
 #include "GameOverScript.h"
 #include "Globals.h"
 #include "GodMode.h"
@@ -106,7 +107,8 @@ constexpr const char* scripts[] = {
     "BossMirage",
     "Boss",
     "MirageBossDash",
-    "ArcherProjectile"
+    "ArcherProjectile",
+    "GameOverNavigatorScript"
 };
 
 constexpr const char* shaderScripts[] = {
@@ -169,6 +171,7 @@ extern "C" SOBRASSADA_API Script* CreateScript(const std::string& scriptType, Ga
     if (scriptType == "FreeCamera") return new FreeCamera(parent);
     if (scriptType == "MoveGOInSpline") return new MoveGOInSpline(parent);
     if (scriptType == "SwitchScriptTest") return new SwitchScriptTest(parent);
+    if (scriptType == "GameOverNavigatorScript") return new GameOverNavigatorScript(parent);
 
     /* Render Scripts */
     if (scriptType == "MovingUVPostScript") return new MovingUVPostScript(parent);

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj
@@ -342,8 +342,8 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>LinearMath_debug.lib;BulletCollision_debug.lib;BulletDynamics_debug.lib;avcodec.lib;avdevice.lib;avfilter.lib;avformat.lib;avutil.lib;postproc.lib;swresample.lib;swscale.lib;OptickCore.lib;DirectXTex.lib;glew32.lib;opengl32.lib;freetype.lib;SobrassadaEngine.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(SolutionDir)Libs\glew-2.1.0\lib;$(SolutionDir)Libs\freetype\lib;$(SolutionDir)Libs\bullet\lib;$(SolutionDir)DirectXTex\DirectXTex\Bin\Desktop_2022\$(Platform)\$(Configuration)\;$(SolutionDir)$(Platform)\$(Configuration);$(SolutionDir)Libs\ffmpeg\lib;$(SolutionDir)Libs\Optick_1.4.0\lib\LibDebug</AdditionalLibraryDirectories>
+      <AdditionalDependencies>LinearMath_debug.lib;BulletCollision_debug.lib;BulletDynamics_debug.lib;avcodec.lib;avdevice.lib;avfilter.lib;avformat.lib;avutil.lib;postproc.lib;swresample.lib;swscale.lib;SDL2.lib;SDL2main.lib;OptickCore.lib;DirectXTex.lib;glew32.lib;opengl32.lib;freetype.lib;SobrassadaEngine.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)Libs\glew-2.1.0\lib;$(SolutionDir)Libs\freetype\lib;$(SolutionDir)Libs\bullet\lib;$(SolutionDir)DirectXTex\DirectXTex\Bin\Desktop_2022\$(Platform)\$(Configuration)\;$(SolutionDir)$(Platform)\$(Configuration);$(SolutionDir)Libs\ffmpeg\lib;$(SolutionDir)Libs\Optick_1.4.0\lib\LibDebug;$(SolutionDir)Libs\SDL\lib</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Game Debug|x64'">
@@ -362,8 +362,8 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>LinearMath_debug.lib;BulletCollision_debug.lib;BulletDynamics_debug.lib;avcodec.lib;avdevice.lib;avfilter.lib;avformat.lib;avutil.lib;postproc.lib;swresample.lib;swscale.lib;OptickCore.lib;DirectXTex.lib;glew32.lib;opengl32.lib;freetype.lib;SobrassadaEngine.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(SolutionDir)Libs\glew-2.1.0\lib;$(SolutionDir)Libs\freetype\lib;$(SolutionDir)Libs\bullet\lib;$(SolutionDir)DirectXTex\DirectXTex\Bin\Desktop_2022\$(Platform)\$(Configuration)\;$(SolutionDir)$(Platform)\$(Configuration);$(SolutionDir)Libs\ffmpeg\lib;$(SolutionDir)Libs\Optick_1.4.0\lib\LibDebug</AdditionalLibraryDirectories>
+      <AdditionalDependencies>LinearMath_debug.lib;BulletCollision_debug.lib;BulletDynamics_debug.lib;avcodec.lib;avdevice.lib;avfilter.lib;avformat.lib;avutil.lib;postproc.lib;swresample.lib;swscale.lib;SDL2.lib;SDL2main.lib;OptickCore.lib;DirectXTex.lib;glew32.lib;opengl32.lib;freetype.lib;SobrassadaEngine.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)Libs\glew-2.1.0\lib;$(SolutionDir)Libs\freetype\lib;$(SolutionDir)Libs\bullet\lib;$(SolutionDir)DirectXTex\DirectXTex\Bin\Desktop_2022\$(Platform)\$(Configuration)\;$(SolutionDir)$(Platform)\$(Configuration);$(SolutionDir)Libs\ffmpeg\lib;$(SolutionDir)Libs\Optick_1.4.0\lib\LibDebug;$(SolutionDir)Libs\SDL\lib</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -387,8 +387,8 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>LinearMath_debug.lib;BulletCollision_debug.lib;BulletDynamics_debug.lib;avcodec.lib;avdevice.lib;avfilter.lib;avformat.lib;avutil.lib;postproc.lib;swresample.lib;swscale.lib;DirectXTex.lib;glew32.lib;opengl32.lib;freetype.lib;SobrassadaEngine.lib;SDL2.lib;SDL2main.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(SolutionDir)Libs\glew-2.1.0\lib;$(SolutionDir)Libs\freetype\lib;$(SolutionDir)Libs\bullet\lib;$(SolutionDir)DirectXTex\DirectXTex\Bin\Desktop_2022\$(Platform)\$(Configuration)\;$(SolutionDir)$(Platform)\$(Configuration);$(SolutionDir)Libs\ffmpeg\lib;$(SolutionDir)Libs\SDL\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>LinearMath_debug.lib;BulletCollision_debug.lib;BulletDynamics_debug.lib;avcodec.lib;avdevice.lib;avfilter.lib;avformat.lib;avutil.lib;postproc.lib;swresample.lib;swscale.lib;SDL2.lib;SDL2main.lib;DirectXTex.lib;glew32.lib;opengl32.lib;freetype.lib;SobrassadaEngine.lib;SDL2.lib;SDL2main.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)Libs\glew-2.1.0\lib;$(SolutionDir)Libs\freetype\lib;$(SolutionDir)Libs\bullet\lib;$(SolutionDir)DirectXTex\DirectXTex\Bin\Desktop_2022\$(Platform)\$(Configuration)\;$(SolutionDir)$(Platform)\$(Configuration);$(SolutionDir)Libs\ffmpeg\lib;$(SolutionDir)Libs\SDL\lib;%(AdditionalLibraryDirectories);$(SolutionDir)Libs\SDL\lib</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Profile|x64'">
@@ -411,8 +411,8 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>LinearMath_debug.lib;BulletCollision_debug.lib;BulletDynamics_debug.lib;avcodec.lib;avdevice.lib;avfilter.lib;avformat.lib;avutil.lib;postproc.lib;swresample.lib;swscale.lib;DirectXTex.lib;glew32.lib;opengl32.lib;freetype.lib;SobrassadaEngine.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(SolutionDir)Libs\glew-2.1.0\lib;$(SolutionDir)Libs\freetype\lib;$(SolutionDir)Libs\bullet\lib;$(SolutionDir)DirectXTex\DirectXTex\Bin\Desktop_2022\$(Platform)\$(Configuration)\;$(SolutionDir)$(Platform)\$(Configuration);$(SolutionDir)Libs\ffmpeg\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>LinearMath_debug.lib;BulletCollision_debug.lib;BulletDynamics_debug.lib;avcodec.lib;avdevice.lib;avfilter.lib;avformat.lib;avutil.lib;postproc.lib;swresample.lib;swscale.lib;SDL2.lib;SDL2main.lib;DirectXTex.lib;glew32.lib;opengl32.lib;freetype.lib;SobrassadaEngine.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)Libs\glew-2.1.0\lib;$(SolutionDir)Libs\freetype\lib;$(SolutionDir)Libs\bullet\lib;$(SolutionDir)DirectXTex\DirectXTex\Bin\Desktop_2022\$(Platform)\$(Configuration)\;$(SolutionDir)$(Platform)\$(Configuration);$(SolutionDir)Libs\ffmpeg\lib;%(AdditionalLibraryDirectories);$(SolutionDir)Libs\SDL\lib</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Game|x64'">
@@ -435,8 +435,8 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>LinearMath_debug.lib;BulletCollision_debug.lib;BulletDynamics_debug.lib;avcodec.lib;avdevice.lib;avfilter.lib;avformat.lib;avutil.lib;postproc.lib;swresample.lib;swscale.lib;DirectXTex.lib;glew32.lib;opengl32.lib;freetype.lib;SobrassadaEngine.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(SolutionDir)Libs\glew-2.1.0\lib;$(SolutionDir)Libs\freetype\lib;$(SolutionDir)Libs\bullet\lib;$(SolutionDir)DirectXTex\DirectXTex\Bin\Desktop_2022\$(Platform)\$(Configuration)\;$(SolutionDir)$(Platform)\$(Configuration);$(SolutionDir)Libs\ffmpeg\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>LinearMath_debug.lib;BulletCollision_debug.lib;BulletDynamics_debug.lib;avcodec.lib;avdevice.lib;avfilter.lib;avformat.lib;avutil.lib;postproc.lib;swresample.lib;swscale.lib;SDL2.lib;SDL2main.lib;DirectXTex.lib;glew32.lib;opengl32.lib;freetype.lib;SobrassadaEngine.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)Libs\glew-2.1.0\lib;$(SolutionDir)Libs\freetype\lib;$(SolutionDir)Libs\bullet\lib;$(SolutionDir)DirectXTex\DirectXTex\Bin\Desktop_2022\$(Platform)\$(Configuration)\;$(SolutionDir)$(Platform)\$(Configuration);$(SolutionDir)Libs\ffmpeg\lib;%(AdditionalLibraryDirectories);$(SolutionDir)Libs\SDL\lib</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Profile Game|x64'">
@@ -459,8 +459,8 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>LinearMath_debug.lib;BulletCollision_debug.lib;BulletDynamics_debug.lib;avcodec.lib;avdevice.lib;avfilter.lib;avformat.lib;avutil.lib;postproc.lib;swresample.lib;swscale.lib;DirectXTex.lib;glew32.lib;opengl32.lib;freetype.lib;SobrassadaEngine.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(SolutionDir)Libs\glew-2.1.0\lib;$(SolutionDir)Libs\freetype\lib;$(SolutionDir)Libs\bullet\lib;$(SolutionDir)DirectXTex\DirectXTex\Bin\Desktop_2022\$(Platform)\$(Configuration)\;$(SolutionDir)$(Platform)\$(Configuration);$(SolutionDir)Libs\ffmpeg\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>LinearMath_debug.lib;BulletCollision_debug.lib;BulletDynamics_debug.lib;avcodec.lib;avdevice.lib;avfilter.lib;avformat.lib;avutil.lib;postproc.lib;swresample.lib;swscale.lib;SDL2.lib;SDL2main.lib;DirectXTex.lib;glew32.lib;opengl32.lib;freetype.lib;SobrassadaEngine.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)Libs\glew-2.1.0\lib;$(SolutionDir)Libs\freetype\lib;$(SolutionDir)Libs\bullet\lib;$(SolutionDir)DirectXTex\DirectXTex\Bin\Desktop_2022\$(Platform)\$(Configuration)\;$(SolutionDir)$(Platform)\$(Configuration);$(SolutionDir)Libs\ffmpeg\lib;%(AdditionalLibraryDirectories);$(SolutionDir)Libs\SDL\lib</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj
@@ -490,6 +490,7 @@
     <ClInclude Include="framework.h" />
     <ClInclude Include="FreeCamera.h" />
     <ClInclude Include="FullscreenToggleScript.h" />
+    <ClInclude Include="GameOverNavigatorScript.h" />
     <ClInclude Include="GameOverScript.h" />
     <ClInclude Include="GameSession.h" />
     <ClInclude Include="HealVFXGround.h" />
@@ -2080,6 +2081,7 @@
     <ClCompile Include="FireballTrap.cpp" />
     <ClCompile Include="FreeCamera.cpp" />
     <ClCompile Include="FullscreenToggleScript.cpp" />
+    <ClCompile Include="GameOverNavigatorScript.cpp" />
     <ClCompile Include="GameOverScript.cpp" />
     <ClCompile Include="GameSession.cpp" />
     <ClCompile Include="HealVFXGround.cpp" />

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj
@@ -479,6 +479,7 @@
     <ClInclude Include="CameraMovement.h" />
     <ClInclude Include="Changeling.h" />
     <ClInclude Include="ChangeSceneScript.h" />
+    <ClInclude Include="ColorChange.h" />
     <ClInclude Include="DamageMask.h" />
     <ClInclude Include="Destructible.h" />
     <ClInclude Include="EnemySpawnerScript.h" />
@@ -2069,6 +2070,7 @@
     <ClCompile Include="Changeling.cpp" />
     <ClCompile Include="ChangeSceneScript.cpp" />
     <ClCompile Include="Character.cpp" />
+    <ClCompile Include="ColorChange.cpp" />
     <ClCompile Include="CuChulainn.cpp" />
     <ClCompile Include="DamageMask.cpp" />
     <ClCompile Include="Destructible.cpp" />

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj.filters
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj.filters
@@ -214,6 +214,9 @@
     <ClInclude Include="GameSession.h">
       <Filter>Utils</Filter>
     </ClInclude>
+    <ClInclude Include="GameOverNavigatorScript.h">
+      <Filter>UI</Filter>
+    </ClInclude>
     <ClInclude Include="ColorChange.h">
       <Filter>ShaderScripts</Filter>
     </ClInclude>
@@ -891,9 +894,6 @@
     <ClCompile Include="EnemySpawnerScript.cpp">
       <Filter>Characters\Enemies</Filter>
     </ClCompile>
-    <ClCompile Include="GameOverScript.cpp">
-      <Filter>UI</Filter>
-    </ClCompile>
     <ClCompile Include="PlayerLocationScript.cpp">
       <Filter>Environment</Filter>
     </ClCompile>
@@ -965,6 +965,12 @@
     </ClCompile>
     <ClCompile Include="GameSession.cpp">
       <Filter>Utils</Filter>
+    </ClCompile>
+    <ClCompile Include="GameOverNavigatorScript.cpp">
+      <Filter>UI</Filter>
+    </ClCompile>
+    <ClCompile Include="GameOverScript.cpp">
+      <Filter>UI</Filter>
     </ClCompile>
     <ClCompile Include="ColorChange.cpp">
       <Filter>ShaderScripts</Filter>

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj.filters
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj.filters
@@ -214,6 +214,9 @@
     <ClInclude Include="GameSession.h">
       <Filter>Utils</Filter>
     </ClInclude>
+    <ClInclude Include="ColorChange.h">
+      <Filter>ShaderScripts</Filter>
+    </ClInclude>
     <ClInclude Include="ArcherProjectile.h">
       <Filter>Characters</Filter>
     </ClInclude>
@@ -962,6 +965,9 @@
     </ClCompile>
     <ClCompile Include="GameSession.cpp">
       <Filter>Utils</Filter>
+    </ClCompile>
+    <ClCompile Include="ColorChange.cpp">
+      <Filter>ShaderScripts</Filter>
     </ClCompile>
     <ClCompile Include="ArcherProjectile.cpp">
       <Filter>Characters</Filter>

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.cpp
@@ -226,7 +226,7 @@ void Soldier::HandleState(float deltaTime)
 void Soldier::PatrolAI(float deltaTime)
 {
     const HashString& playerLocation = AppEngine->GetSceneModule()->GetScene()->GetPlayerLocation();
-    GLOG("Player location: %s", playerLocation.GetString().c_str());
+    //GLOG("Player location: %s", playerLocation.GetString().c_str());
     bool playerInLocation            = parent->HasTag(playerLocation);
 
     if (!playerScript->IsDead())

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Soldier.cpp
@@ -67,12 +67,18 @@ bool Soldier::Init()
 
 void Soldier::Update(float deltaTime)
 {
+    if (agentAI == nullptr) return;
+
     if (currentState == SoldierStates::DEATH && animComponent && animComponent->IsFinished())
     {
         parent->SetEnabled(false);
     }
 
-    if (currentState == SoldierStates::DEATH || agentAI == nullptr) return;
+    if (currentState == SoldierStates::DEATH)
+    {
+        Character::UpdateTimers(deltaTime);
+        return;
+    }
 
     if (isKnockback)
     {

--- a/SobrassadaEngine/Utils/Physics/BulletMotionState.cpp
+++ b/SobrassadaEngine/Utils/Physics/BulletMotionState.cpp
@@ -89,9 +89,9 @@ void BulletMotionState::setWorldTransform(const btTransform& physicsWorldTransfo
         gameObjectTransform.getOrigin().x(), gameObjectTransform.getOrigin().y(), gameObjectTransform.getOrigin().z()
     );
 
-    float4x4 newLocalMatrix = float4x4::FromTRS(newPosition, rotationMat, collider->GetParent()->GetScale());
+    float4x4 newLocalMatrix        = float4x4::FromTRS(newPosition, rotationMat, collider->GetParent()->GetScale());
 
-    collider->GetParent()->SetLocalTransform(newLocalMatrix);
-    collider->GetParent()->SetPosition(newPosition);
-    collider->GetParent()->UpdateTransformForGOBranch();
+    float4x4 parentGOInverseGlobal = collider->GetParent()->GetParentGlobalTransform().Inverted();
+
+    collider->GetParent()->SetLocalTransform(parentGOInverseGlobal * newLocalMatrix);
 }

--- a/SobrassadaEngine/Utils/RaycastController.cpp
+++ b/SobrassadaEngine/Utils/RaycastController.cpp
@@ -5,6 +5,7 @@
 #include "CameraModule.h"
 #include "FileSystem/Mesh.h"
 #include "GameObject.h"
+#include "PhysicsModule.h"
 #include "ResourceMesh.h"
 #include "SceneModule.h"
 #include "Standalone/BillboardComponent.h"
@@ -47,25 +48,23 @@ namespace RaycastController
             if (meshComponent != nullptr)
             {
                 const ResourceMesh* resourceMesh = meshComponent->GetResourceMesh();
-                if (!resourceMesh) continue;  
+                if (!resourceMesh) continue;
 
-                float4x4 globalTransform         = meshComponent->GetCombinedMatrix();
+                float4x4 globalTransform = meshComponent->GetCombinedMatrix();
                 globalTransform.Inverse();
                 localRay.Transform(globalTransform);
 
                 const std::vector<unsigned int>& indices = resourceMesh->GetIndices();
                 const std::vector<Vertex>& vertices      = resourceMesh->GetLocalVertices();
-                if (indices.size() < 3 || vertices.empty())
-                    continue;
+                if (indices.size() < 3 || vertices.empty()) continue;
 
-                for (size_t i = 2; i < indices.size(); i += 3) 
+                for (size_t i = 2; i < indices.size(); i += 3)
                 {
                     unsigned int indexA = indices[i - 2];
                     unsigned int indexB = indices[i - 1];
                     unsigned int indexC = indices[i];
 
-                    if (indexA >= vertices.size() || indexB >= vertices.size() || indexC >= vertices.size())
-                        continue; 
+                    if (indexA >= vertices.size() || indexB >= vertices.size() || indexC >= vertices.size()) continue;
 
                     const float3& firstVertex  = vertices[indexA].position;
                     const float3& secondVertex = vertices[indexB].position;
@@ -183,5 +182,14 @@ namespace RaycastController
             selectedGameObject->UpdateOpenNodeHierarchy(true);
 
         return selectedGameObject;
+    }
+
+    BulletUserPointer* GetRayIntersectionPhysics(const math::LineSegment& ray)
+    {
+        PhysicsModule* physicsModule = App->GetPhysicsModule();
+
+        if (!physicsModule) return nullptr;
+
+        return physicsModule->RaycastToWorld(ray);
     }
 } // namespace RaycastController

--- a/SobrassadaEngine/Utils/RaycastController.h
+++ b/SobrassadaEngine/Utils/RaycastController.h
@@ -12,11 +12,14 @@ namespace math
 }
 
 class GameObject;
+struct BulletUserPointer;
 
 namespace RaycastController
 {
     SOBRASADA_API_ENGINE GameObject*
     GetRayIntersectionObject(const math::LineSegment& ray, const std::vector<GameObject*>& queriedGameObjects);
+
+    BulletUserPointer* GetRayIntersectionPhysics(const math::LineSegment& ray);
 
     template <typename... Tree> GameObject* GetRayIntersectionTrees(const math::LineSegment& ray, const Tree*... trees)
     {


### PR DESCRIPTION
This PR scares me. It solves problem with transparent objects covering other transparent objects. We solve it not writting on the z-buffer (we should not do it for transparency). Some meshes can have strange things now, for example, the boss phere in the boss is really transparent now, but we can solve it putting the sphere opaque, but it solves the general problem. 
Also solves the problem with some black pixels in transparent objects, not premultiplying the meshes.

<img width="846" height="456" alt="image" src="https://github.com/user-attachments/assets/0c6742f5-7262-4867-86b0-2a8fdf12c9bf" />
Things like this image wont happen again

<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/96d1c5dc-746d-4547-b1a6-cbb40397adaa" />
We will see it like that now