### PR TITLE
Tutorial input device UI  THO-916

### DIFF
--- a/SobrassadaEngine/Modules/InputModule.cpp
+++ b/SobrassadaEngine/Modules/InputModule.cpp
@@ -278,6 +278,15 @@ void InputModule::OnControllerDisconnected()
     }
 }
 
+bool InputModule::IsPlaystationControllerConnected() const
+{
+    if (controllers[0] == nullptr) return false;
+
+    return SDL_GameControllerGetType(controllers[0]) == SDL_CONTROLLER_TYPE_PS3 ||
+           SDL_GameControllerGetType(controllers[0]) == SDL_CONTROLLER_TYPE_PS4 ||
+           SDL_GameControllerGetType(controllers[0]) == SDL_CONTROLLER_TYPE_PS5;
+}
+
 void InputModule::ClearTransientStates()
 {
     // KEY_DOWN and KEY_UP to KEY_IDLE

--- a/SobrassadaEngine/Modules/InputModule.h
+++ b/SobrassadaEngine/Modules/InputModule.h
@@ -49,9 +49,9 @@ class InputModule : public Module
     const std::pair<KeyState, float>& GetRightTrigger() const { return rightTrigger; }
 
     bool SOBRASADA_API_ENGINE IsControllerConnected() const { return controllers[0] != nullptr; }
+    bool SOBRASADA_API_ENGINE IsPlaystationControllerConnected() const;
     bool IsUsingKeyboard() const { return isUsingKeyboard; }
-    void SOBRASADA_API_ENGINE ClearTransientStates(); 
-
+    void SOBRASADA_API_ENGINE ClearTransientStates();
 
   private:
     void OnControllerConnected();
@@ -71,7 +71,7 @@ class InputModule : public Module
     std::pair<KeyState, float> leftTrigger;
     std::pair<KeyState, float> rightTrigger;
 
-    bool isUsingKeyboard = true;
+    bool isUsingKeyboard    = true;
     bool wasPausedLastFrame = false;
     bool skipNextInputFrame = false;
 };

--- a/SobrassadaEngine/Modules/InputModule.h
+++ b/SobrassadaEngine/Modules/InputModule.h
@@ -48,6 +48,7 @@ class InputModule : public Module
     const std::pair<KeyState, float>& GetLeftTrigger() const { return leftTrigger; }
     const std::pair<KeyState, float>& GetRightTrigger() const { return rightTrigger; }
 
+    bool SOBRASADA_API_ENGINE IsControllerConnected() const { return controllers[0] != nullptr; }
     bool IsUsingKeyboard() const { return isUsingKeyboard; }
     void SOBRASADA_API_ENGINE ClearTransientStates(); 
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SpawnUI.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SpawnUI.cpp
@@ -6,10 +6,15 @@
 #include "Standalone/UI/ImageComponent.h"
 #include "ScriptComponent.h"
 #include "CuChulainn.h"
+#include "InputModule.h"
 
 SpawnUI::SpawnUI(GameObject* parent) : Script(parent)
 {
     fields.push_back({"Object UI Name", InspectorField::FieldType::InputText, &objectUIName});
+    fields.push_back({"Alternative object UI Name", InspectorField::FieldType::InputText, &alternativeObjectUIName});
+    fields.push_back({"Trigger once", InspectorField::FieldType::Bool, &triggerOnce});
+    fields.push_back({"Hide ui after (s) (0 = don´t hide)", InspectorField::FieldType::Float, &hideAfterSeconds, 0.f, 30.f});
+    
     fields.push_back({"Unlock Ability", InspectorField::FieldType::Bool, &unlockAbility});
     fields.push_back({"Ability Name", InspectorField::FieldType::InputText, &nameAbility});
 }
@@ -19,8 +24,7 @@ bool SpawnUI::Init()
     trigger = parent->GetComponent<SphereColliderComponent*>();
     if (!trigger) GLOG("[WARNING] SpawnUI without sphere collider component.");
 
-    GameObject* objectUI = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(objectUIName);
-    if (objectUI)
+    if (const GameObject* objectUI = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(objectUIName))
     {
         imageUI = objectUI->GetComponent<ImageComponent*>();
         if (imageUI) imageUI->SetEnabled(false);
@@ -28,25 +32,56 @@ bool SpawnUI::Init()
     }
     else GLOG("[WARNING] No UI game object found by the name: %s", objectUIName.c_str());
 
+    if (const GameObject* alternativeObjectUI = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(alternativeObjectUIName))
+    {
+        alternativeImageUI = alternativeObjectUI->GetComponent<ImageComponent*>();
+        if (alternativeImageUI) alternativeImageUI->SetEnabled(false);
+    }
+
     return true;
 }
 
 void SpawnUI::Update(float deltaTime)
 {
-    if (!trigger || !imageUI) return;
-
-    if (!onCollision && !unlockAbility) imageUI->SetEnabled(false);
-
-    onCollision = false;
+    if (!updating || !trigger || !imageUI) return;
+    if (hideAfterSeconds > 0.f)
+    {
+        timer -= deltaTime;
+        if (timer <= 0.f)
+        {
+            if (imageUI != nullptr && !unlockAbility) imageUI->SetEnabled(false);
+            if (alternativeImageUI != nullptr) alternativeImageUI->SetEnabled(false);
+            updating = false;
+        }
+    }
 }
 
-void SpawnUI::OnCollision(GameObject* otherObject, const float3 collisionNormal, ColliderLayer layer)
+void SpawnUI::OnCollisionEnter(GameObject* otherObject, const float3 collisionNormal, ColliderLayer layer)
 {
     // triggers only collision with Player
-    if (imageUI) imageUI->SetEnabled(true);
-    onCollision = true;
-    GameObject* engineGO = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByUID(otherObject->GetUID());
+    
+    if (imageUI != nullptr)
+    {
+        if (alternativeImageUI != nullptr && AppEngine->GetInputModule()->IsControllerConnected())
+            alternativeImageUI->SetEnabled(true);
+        else 
+            imageUI->SetEnabled(true);
+    }
+
+    timer = hideAfterSeconds;
     
     if (unlockAbility) 
-        engineGO->GetComponent<ScriptComponent*>()->GetScriptByType<CuChulainn>()->ActivateAbility(nameAbility);
+        otherObject->GetComponent<ScriptComponent*>()->GetScriptByType<CuChulainn>()->ActivateAbility(nameAbility);
+
+    updating = true;
 }
+
+void SpawnUI::OnCollisionExit(GameObject* otherObject, ColliderLayer layer)
+{
+    if (hideAfterSeconds == 0 && imageUI != nullptr) imageUI->SetEnabled(false);
+    if (hideAfterSeconds == 0 && alternativeImageUI != nullptr) alternativeImageUI->SetEnabled(false);
+    if (triggerOnce) trigger->SetEnabled(false);
+
+    if (hideAfterSeconds == 0) updating = false;
+}
+

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SpawnUI.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SpawnUI.cpp
@@ -1,20 +1,27 @@
 #include "pch.h"
 
+#include "CuChulainn.h"
 #include "GameObject.h"
+#include "InputModule.h"
+#include "ScriptComponent.h"
 #include "SpawnUI.h"
 #include "Standalone/Physics/SphereColliderComponent.h"
 #include "Standalone/UI/ImageComponent.h"
-#include "ScriptComponent.h"
-#include "CuChulainn.h"
-#include "InputModule.h"
 
 SpawnUI::SpawnUI(GameObject* parent) : Script(parent)
 {
     fields.push_back({"Object UI Name", InspectorField::FieldType::InputText, &objectUIName});
-    fields.push_back({"Alternative object UI Name", InspectorField::FieldType::InputText, &alternativeObjectUIName});
+    fields.push_back(
+        {"Alternative object UI Name (XBox)", InspectorField::FieldType::InputText, &xboxAlternativeObjectUIName}
+    );
+    fields.push_back(
+        {"Alternative object UI Name (PS)", InspectorField::FieldType::InputText, &psAlternativeObjectUIName}
+    );
     fields.push_back({"Trigger once", InspectorField::FieldType::Bool, &triggerOnce});
-    fields.push_back({"Hide ui after (s) (0 = don´t hide)", InspectorField::FieldType::Float, &hideAfterSeconds, 0.f, 30.f});
-    
+    fields.push_back(
+        {"Hide ui after (s) (0 = don´t hide)", InspectorField::FieldType::Float, &hideAfterSeconds, 0.f, 30.f}
+    );
+
     fields.push_back({"Unlock Ability", InspectorField::FieldType::Bool, &unlockAbility});
     fields.push_back({"Ability Name", InspectorField::FieldType::InputText, &nameAbility});
 }
@@ -32,10 +39,18 @@ bool SpawnUI::Init()
     }
     else GLOG("[WARNING] No UI game object found by the name: %s", objectUIName.c_str());
 
-    if (const GameObject* alternativeObjectUI = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(alternativeObjectUIName))
+    if (const GameObject* alternativeObjectUI =
+            AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(xboxAlternativeObjectUIName))
     {
-        alternativeImageUI = alternativeObjectUI->GetComponent<ImageComponent*>();
-        if (alternativeImageUI) alternativeImageUI->SetEnabled(false);
+        xboxAlternativeImageUI = alternativeObjectUI->GetComponent<ImageComponent*>();
+        if (xboxAlternativeImageUI) xboxAlternativeImageUI->SetEnabled(false);
+    }
+
+    if (const GameObject* alternativeObjectUI =
+            AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(psAlternativeObjectUIName))
+    {
+        psAlternativeImageUI = alternativeObjectUI->GetComponent<ImageComponent*>();
+        if (psAlternativeImageUI) psAlternativeImageUI->SetEnabled(false);
     }
 
     return true;
@@ -50,7 +65,8 @@ void SpawnUI::Update(float deltaTime)
         if (timer <= 0.f)
         {
             if (imageUI != nullptr && !unlockAbility) imageUI->SetEnabled(false);
-            if (alternativeImageUI != nullptr) alternativeImageUI->SetEnabled(false);
+            if (xboxAlternativeImageUI != nullptr && !unlockAbility) xboxAlternativeImageUI->SetEnabled(false);
+            if (psAlternativeImageUI != nullptr && !unlockAbility) psAlternativeImageUI->SetEnabled(false);
             updating = false;
         }
     }
@@ -59,18 +75,21 @@ void SpawnUI::Update(float deltaTime)
 void SpawnUI::OnCollisionEnter(GameObject* otherObject, const float3 collisionNormal, ColliderLayer layer)
 {
     // triggers only collision with Player
-    
+
     if (imageUI != nullptr)
     {
-        if (alternativeImageUI != nullptr && AppEngine->GetInputModule()->IsControllerConnected())
-            alternativeImageUI->SetEnabled(true);
-        else 
-            imageUI->SetEnabled(true);
+
+        if (AppEngine->GetInputModule()->IsControllerConnected())
+            if (psAlternativeImageUI != nullptr && AppEngine->GetInputModule()->IsPlaystationControllerConnected())
+                psAlternativeImageUI->SetEnabled(true);
+            else if (xboxAlternativeImageUI != nullptr) xboxAlternativeImageUI->SetEnabled(true);
+            else imageUI->SetEnabled(true);
+        else imageUI->SetEnabled(true);
     }
 
     timer = hideAfterSeconds;
-    
-    if (unlockAbility) 
+
+    if (unlockAbility)
         otherObject->GetComponent<ScriptComponent*>()->GetScriptByType<CuChulainn>()->ActivateAbility(nameAbility);
 
     updating = true;
@@ -79,9 +98,9 @@ void SpawnUI::OnCollisionEnter(GameObject* otherObject, const float3 collisionNo
 void SpawnUI::OnCollisionExit(GameObject* otherObject, ColliderLayer layer)
 {
     if (hideAfterSeconds == 0 && imageUI != nullptr) imageUI->SetEnabled(false);
-    if (hideAfterSeconds == 0 && alternativeImageUI != nullptr) alternativeImageUI->SetEnabled(false);
+    if (hideAfterSeconds == 0 && xboxAlternativeImageUI != nullptr) xboxAlternativeImageUI->SetEnabled(false);
+    if (hideAfterSeconds == 0 && psAlternativeImageUI != nullptr) psAlternativeImageUI->SetEnabled(false);
     if (triggerOnce) trigger->SetEnabled(false);
 
     if (hideAfterSeconds == 0) updating = false;
 }
-

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SpawnUI.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SpawnUI.h
@@ -12,13 +12,20 @@ class SpawnUI : public Script
     SpawnUI(GameObject* parent);
     bool Init() override;
     void Update(float deltaTime) override;
-    void OnCollision(GameObject* otherObject, const float3 collisionNormal, ColliderLayer layer) override;
+    void OnCollisionEnter(GameObject* otherObject, const float3 collisionNormal, ColliderLayer layer) override;
+    void OnCollisionExit(GameObject* otherObject, ColliderLayer layer) override;
 
   private:
     SphereColliderComponent* trigger = nullptr;
     ImageComponent* imageUI             = nullptr;
+    ImageComponent* alternativeImageUI        = nullptr;
+    bool triggerOnce = false;
+    float hideAfterSeconds = 0.f;
     std::string objectUIName         = "";
-    bool onCollision                 = false;
+    std::string alternativeObjectUIName; 
     bool unlockAbility                  = false;
     std::string nameAbility     = "";
+
+    float timer = 0.f;
+    bool updating;
 };

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SpawnUI.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SpawnUI.h
@@ -16,16 +16,19 @@ class SpawnUI : public Script
     void OnCollisionExit(GameObject* otherObject, ColliderLayer layer) override;
 
   private:
-    SphereColliderComponent* trigger = nullptr;
-    ImageComponent* imageUI             = nullptr;
-    ImageComponent* alternativeImageUI        = nullptr;
-    bool triggerOnce = false;
-    float hideAfterSeconds = 0.f;
-    std::string objectUIName         = "";
-    std::string alternativeObjectUIName; 
-    bool unlockAbility                  = false;
-    std::string nameAbility     = "";
+    SphereColliderComponent* trigger       = nullptr;
+    ImageComponent* imageUI                = nullptr;
+    ImageComponent* xboxAlternativeImageUI = nullptr;
+    ImageComponent* psAlternativeImageUI   = nullptr;
+    bool triggerOnce                       = false;
+    float hideAfterSeconds                 = 0.f;
+    std::string objectUIName;
+    std::string xboxAlternativeObjectUIName;
+    std::string psAlternativeObjectUIName;
 
-    float timer = 0.f;
+    bool unlockAbility      = false;
+    std::string nameAbility = "";
+
+    float timer             = 0.f;
     bool updating;
 };


### PR DESCRIPTION
This PR adds the functionality to change the tutorial UIs depending on the selected input devices. 
Supported are keyboard, dualshock and xbox, with the xbox ui showing for all controllers which aren´t dualshocks.
Also adds the option to show ui only once, and for it to disappear after x seconds.
I don´t have an xbox controller for testing, so at least one tester should test with that.

For testing, go to the same branch in the game repo. The movement tutorial works like previously, only showing the correct controls for the input device. The dash tutorial is triggered only once and disappears after 5 seconds

Known issues: 
There are ui elements in the main menu and health bar which are not showing the proper controls. These will be tackled with a later pr / change in the scene