### PR TITLE
Destructibles V3 THO-1012

### DIFF
--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Destructible.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Destructible.cpp
@@ -16,8 +16,7 @@
 #include <Math/MathFunc.h>
 #include <random>
 
-Destructible::Destructible(GameObject* parent)
-    : Character(parent, 1, -1, -1, -1, -1, -1, -1, -1, CharacterType::Destructible)
+Destructible::Destructible(GameObject* parent): Script(parent)
 {
     fields.emplace_back("Destroyed mesh", InspectorField::FieldType::InputText, &destroyedMeshName);
     fields.emplace_back(
@@ -35,8 +34,6 @@ bool Destructible::Init()
 
     currentState = DestructibleStates::NORMAL;
 
-    Character::Init();
-
     if (isSetupCorrectly)
     {
         type = static_cast<DestructibleType>(destructibleTypeIndex);
@@ -49,19 +46,19 @@ bool Destructible::Init()
 
 void Destructible::Update(float deltaTime)
 {
-    if (!isDead && isSetupCorrectly && currentState == DestructibleStates::DESTROYED)
+    if (isSimulating && isSetupCorrectly && currentState == DestructibleStates::DESTROYED)
     {
         destructionSpawnDelayCounter -= deltaTime;
         if (destructionSpawnDelayCounter <= 0)
         {
             destroyedMesh->SetEnabled(true);
 
-            isDead = true;
+            isSimulating = false;
         }
     }
 }
 
-void Destructible::OnDeath()
+void Destructible::OnCollisionEnter(GameObject* otherObject, const float3 collisionNormal, ColliderLayer layer)
 {
     if (isSetupCorrectly)
     {
@@ -85,8 +82,6 @@ void Destructible::OnDeath()
         }
 
         defaultMesh->SetEnabled(false);
-
-        isDead = false;
     }
 }
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Destructible.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Destructible.cpp
@@ -60,7 +60,7 @@ void Destructible::Update(float deltaTime)
 
 void Destructible::OnCollisionEnter(GameObject* otherObject, const float3 collisionNormal, ColliderLayer layer)
 {
-    if (isSetupCorrectly)
+    if (isSetupCorrectly && currentState == DestructibleStates::NORMAL)
     {
         currentState                 = DestructibleStates::DESTROYED;
         destructionSpawnDelayCounter = destructionSpawnDelay;
@@ -82,6 +82,8 @@ void Destructible::OnCollisionEnter(GameObject* otherObject, const float3 collis
         }
 
         defaultMesh->SetEnabled(false);
+
+        isSimulating = true;
     }
 }
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Destructible.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Destructible.cpp
@@ -4,10 +4,13 @@
 
 #include "Application.h"
 #include "Destructible.h"
+
+#include "CuChulainn.h"
 #include "GameObject.h"
 #include "Globals.h"
 #include "ParticleSystemComponent.h"
 #include "ResourceStateMachine.h"
+#include "ScriptComponent.h"
 #include "Standalone/AIAgentComponent.h"
 #include "Standalone/Audio/AudioSourceComponent.h"
 #include "Standalone/MeshComponent.h"
@@ -62,6 +65,10 @@ void Destructible::OnCollisionEnter(GameObject* otherObject, const float3 collis
 {
     if (isSetupCorrectly && currentState == DestructibleStates::NORMAL)
     {
+        // Don´t accept the players hitbox as a hit
+        if (otherObject->GetComponent<ScriptComponent*>() != nullptr &&
+            otherObject->GetComponent<ScriptComponent*>()->GetScriptByType<CuChulainn>() != nullptr) return;
+        
         currentState                 = DestructibleStates::DESTROYED;
         destructionSpawnDelayCounter = destructionSpawnDelay;
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Destructible.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Destructible.cpp
@@ -15,6 +15,7 @@
 #include "Standalone/Audio/AudioSourceComponent.h"
 #include "Standalone/MeshComponent.h"
 #include "Wwise_IDs.h"
+#include "Standalone/Physics/CapsuleColliderComponent.h"
 
 #include <Math/MathFunc.h>
 #include <random>
@@ -88,6 +89,7 @@ void Destructible::OnCollisionEnter(GameObject* otherObject, const float3 collis
             break;
         }
 
+        parent->GetComponent<CapsuleColliderComponent*>()->SetEnabled(false);
         defaultMesh->SetEnabled(false);
 
         isSimulating = true;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Destructible.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Destructible.h
@@ -38,7 +38,7 @@ class Destructible : public Script
 
   private:
     bool isSetupCorrectly           = false;
-    bool isSimulating               = true;
+    bool isSimulating               = false;
 
     DestructibleStates currentState = DestructibleStates::NONE;
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Destructible.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Destructible.h
@@ -22,22 +22,23 @@ enum class DestructibleType
     CRYSTAL = 2,
 };
 
-class Destructible : public Character
+class Destructible : public Script
 {
   public:
     Destructible(GameObject* parent);
-    ~Destructible() noexcept override { parent = nullptr; };
+    ~Destructible() noexcept override { parent = nullptr; }
 
     bool Init() override;
     void Update(float deltaTime) override;
-
-    void OnDeath() override;
+    
+    void OnCollisionEnter(GameObject* otherObject, const float3 collisionNormal, ColliderLayer layer) override;
 
   private:
     void ValidateSetup();
 
   private:
     bool isSetupCorrectly           = false;
+    bool isSimulating               = true;
 
     DestructibleStates currentState = DestructibleStates::NONE;
 


### PR DESCRIPTION
This PR changes the base class of the destructible script from a character to a normal script to reduce complexity and increase performance. 

For testing, go to the same branch in the game repo and add the All_Tributes_Destructible prefab to a scene. The destructibles should work like normal while also playing sounds now