### PR TITLE
Task/bug game build video rendering

### DIFF
--- a/SobrassadaEngine/Scene/RenderPass.cpp
+++ b/SobrassadaEngine/Scene/RenderPass.cpp
@@ -250,7 +250,11 @@ void RenderPass::RenderScene(
 
         gbuffer->Unbind();
 
-        Bind();
+       #ifdef GAME
+        
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        glViewport(0, 0, width, height);
+        glClear(GL_COLOR_BUFFER_BIT);
 
         const unsigned int program = App->GetShaderModule()->GetQuadProgram();
         glUseProgram(program);
@@ -261,6 +265,17 @@ void RenderPass::RenderScene(
         glActiveTexture(GL_TEXTURE0);
         glBindTexture(GL_TEXTURE_2D, gbuffer->diffuseTexture);
         glDrawArrays(GL_TRIANGLES, 0, 3);
+#else
+       
+        Bind();
+        const unsigned int program = App->GetShaderModule()->GetQuadProgram();
+        glUseProgram(program);
+        unsigned int loc = glGetUniformLocation(program, "u_Texture");
+        glUniform1i(loc, 0);
+        glActiveTexture(GL_TEXTURE0);
+        glBindTexture(GL_TEXTURE_2D, gbuffer->diffuseTexture);
+        glDrawArrays(GL_TRIANGLES, 0, 3);
+#endif
 
         glPopDebugGroup();
         return;
@@ -879,7 +894,7 @@ void RenderPass::AntiAliasingPassRender(Framebuffer* framebuffer) const
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
     glViewport(0, 0, width, height);
 
-    fxaaTexture = framebuffer->GetTextureID();
+    fxaaTexture = framebuffer->GetColorTexture();
 #endif
 
     glDepthMask(GL_FALSE);

--- a/SobrassadaEngine/Scene/RenderPass.cpp
+++ b/SobrassadaEngine/Scene/RenderPass.cpp
@@ -250,7 +250,7 @@ void RenderPass::RenderScene(
 
         gbuffer->Unbind();
 
-       #ifdef GAME
+#ifdef GAME
         
         glBindFramebuffer(GL_FRAMEBUFFER, 0);
         glViewport(0, 0, width, height);


### PR DESCRIPTION
This fixes the issue of not rendering the video on the build. To test, play the game on release (this shouldnt have affected videos in engine) then make a game build. and when triggering the video it should now render like before.

For good measure clean and rebuild, in any case. 