### PR TITLE
Player ultimate & SFXs

### DIFF
--- a/SobrassadaEngine/Scene/Components/Standalone/AnimationComponent.h
+++ b/SobrassadaEngine/Scene/Components/Standalone/AnimationComponent.h
@@ -46,6 +46,7 @@ class SOBRASADA_API_ENGINE AnimationComponent : public Component
     bool IsPlaying() const;
     bool IsFinished() const;
 
+    void SetDefaultPlaybackSpeed(float s) { defaultTime = s; }
     void SetAnimationResource(UID animResource);
     void UpdateBoneHierarchy(GameObject* bone);
     void SetBoneMapping();

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -1555,7 +1555,7 @@ void CuChulainn::PerformAttack()
             AnimationComponent* vfxUltimateAnim = ultimateObject->GetComponent<AnimationComponent*>();
             vfxTimeUnscaledSec                  += AppEngine->GetGameTimer()->GetUnscaledDeltaTime() / 1000.0f;
 
-             if (ultimateHoldEnabled && playerAnimHeld) //control cuchulainn stop animation
+            if (ultimateHoldEnabled && playerAnimHeld) //control cuchulainn stop animation
             {
                 float timeLimit = (vfxUltimateAnim && vfxUltimateAnim->GetAnimationController())
                             ? vfxUltimateAnim->GetAnimationController()->GetTime()
@@ -1573,13 +1573,10 @@ void CuChulainn::PerformAttack()
             if (ultimateSpikes) // Control spikes animation appearance
             {
                 const bool animReady = vfxUltimateAnim && vfxUltimateAnim->GetCurrentAnimation() && !vfxUltimateAnim->IsFinished();
-                //const float vfxLocalTimer = max(0.0f, ultimateTimer - currentAnimationDelay);
-                bool show = false;
-                bool blurShow = false;
+                bool show, blurShow, warningShow = false;
 
                 if (animReady)
                 {
-                   //const float vfxTimeAnim = vfxUltimateAnim->GetAnimationController()->GetTime();
                    const float vfxLenAnim        = vfxUltimateAnim->GetCurrentAnimation()->GetDuration();
 
                    const float spikesOff         = min(2.12f, vfxLenAnim - 0.05f) / ultimateSpeed;
@@ -1587,11 +1584,13 @@ void CuChulainn::PerformAttack()
                    
                    show = (vfxLocalTimer >= 0.40f / ultimateSpeed) && (vfxLocalTimer < spikesOff);
                    blurShow = vfxLocalTimer >= 0.19f / ultimateSpeed;
+                   warningShow                   = vfxLocalTimer <= 0.4f / ultimateSpeed;
                 }
 
                 if (ultimateSpikes->IsEnabled() != show) ultimateSpikes->SetEnabled(show);
                 if (ultimateCrack && ultimateCrack->IsEnabled() != show) ultimateCrack->SetEnabled(show);
                 if (blurShow) ultimateBlur->GetComponent<ShaderScriptComponent*>()->SetEnabled(true);
+                if (!warningShow) ultimateWarning->SetEnabled(false);
             }
             if (ultimateTimer >= currentHitboxDelay + currentAnimationDelay &&
                 ultimateTimer < currentHitboxDelay + currentHitboxDuration + currentAnimationDelay)

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -549,7 +549,17 @@ bool CuChulainn::Init()
 
     ultimateSpikes = scene->GetGameObjectByParentNameAndTargetName(ultimateName, ultimateSpikesName);
     if (!ultimateSpikes) GLOG("[WARNING] No ultimate spikes VFX found for CuChulain")
-    else ultimateSpikes->SetEnabled(false); 
+    else ultimateSpikes->SetEnabled(false);
+
+    ultimateExplosion      = scene->GetGameObjectByName(ultimateExplosionName);
+    ultimateExplosion->SetEnabled(true);
+    if (ultimateExplosion)
+    {
+        ultimateSmoke = ultimateExplosion->GetComponent<ShaderScriptComponent*>();
+    }
+    if (ultimateSmoke) ultimateSmoke->SetEnabled(false);
+    if (ultimateExplosion->GetComponent<MeshComponent*>())
+        ultimateExplosion->GetComponent<MeshComponent*>()->SetEnabled(false);
 
     CapsuleColliderComponent* playerCollider = parent->GetComponent<CapsuleColliderComponent*>();
     if (playerCollider)
@@ -1547,8 +1557,7 @@ void CuChulainn::PerformAttack()
                 animComponent->OnPause();
                 playerAnimHeld = true;
             }
-
-            
+ 
         }
         else if (ultimateObject->IsEnabled())
         {
@@ -1740,6 +1749,18 @@ void CuChulainn::UltimateAttack()
 
 void CuChulainn::UpdateUltimateVfx()
 {
+    if (ultimateSmoke)
+    {
+        /*const float3 characterPos =
+            parent->GetGlobalTransform().TranslatePart() - parent->GetParentGlobalTransform().TranslatePart();
+
+        const float3 offset = float3(-2.0f, 4.0f, 1.5f);
+
+        ultimateSmoke->GetParent()->SetLocalPosition(characterPos + offset);*/
+        ultimateSmoke->SetEnabled(true);
+        ultimateSmoke->GetScriptByType<AttackVfxSpritesheet>()->Reset();
+    }
+
     if (ultimateBlur)
     {
         ultimateBlur->SetEnabled(true);

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -81,6 +81,8 @@ CuChulainn::CuChulainn(GameObject* parent)
     fields.push_back({"Ultimate cooldown", InspectorField::FieldType::Float, &ultimateCd, 0.0f, 5.0f});
     fields.push_back({"Ultimate Animation delay", InspectorField::FieldType::Float, &ultimateAnimationDelay, 0.0f, 5.0f}
     );
+    fields.push_back({"Ultimate Animation speed", InspectorField::FieldType::Float, &ultimateSpeed, 0.1f, 5.0f}
+    );
     fields.push_back({"Ultimate hitbox delay", InspectorField::FieldType::Float, &ultimateHitboxDelay, 0.0f, 5.0f});
     fields.push_back({"Ultimate hitbox duration", InspectorField::FieldType::Float, &ultimateHitboxDuration, 0.0f, 5.0f}
     );
@@ -542,12 +544,12 @@ bool CuChulainn::Init()
     else ultimateCrack->SetEnabled(false);
 
     ultimateWarning = scene->GetGameObjectByParentNameAndTargetName(ultimateName, ultimateWarningName);
-    if (!ultimateWarning) GLOG("[WARNING] No ultimate Sphere VFX found for CuChulain")
+    if (!ultimateWarning) GLOG("[WARNING] No ultimate warning VFX found for CuChulain")
     else ultimateWarning->SetEnabled(false);
 
     ultimateSpikes = scene->GetGameObjectByParentNameAndTargetName(ultimateName, ultimateSpikesName);
-    if (!ultimateSpikes) GLOG("[WARNING] No ultimate Sphere VFX found for CuChulain")
-    else ultimateSpikes->SetEnabled(false);
+    if (!ultimateSpikes) GLOG("[WARNING] No ultimate spikes VFX found for CuChulain")
+    else ultimateSpikes->SetEnabled(false); 
 
     CapsuleColliderComponent* playerCollider = parent->GetComponent<CapsuleColliderComponent*>();
     if (playerCollider)
@@ -1348,7 +1350,7 @@ void CuChulainn::ThrowSpear()
 {
     if (camera) camera->EnableAimOffset(false);
     if (meleeTrailObject) meleeTrailObject->SetEnabled(false);
-    // if (audio) audio->EmitEvent(AK::EVENTS::PLAY_SFX_MC_DASH);
+    if (audio) audio->EmitEvent(AK::EVENTS::PLAY_SFX_MC_RANGEATTACK);
     if (animComponent) animComponent->UseTrigger("Ranged");
     aimTimer   = 0.0f;
 
@@ -1531,10 +1533,12 @@ void CuChulainn::PerformAttack()
 
         if (!ultimateObject->IsEnabled() && ultimateTimer >= currentAnimationDelay)
         {
+            ultimateObject->GetComponent<AnimationComponent*>()->SetDefaultPlaybackSpeed(ultimateSpeed);
             ultimateObject->GetComponent<AnimationComponent*>()->OnStop();
             ultimateObject->GetComponent<AnimationComponent*>()->OnPlay(false, false);
             ultimateObject->GetComponent<AnimationComponent*>()->GetAnimationController()->SetTime(0.0f);
             ultimateObject->SetEnabled(true);
+            UpdateUltimateVfx();
             ultimateObject->GetComponent<AnimationComponent*>()->Update(0.0f);
             ultimateObject->GetComponent<SphereColliderComponent*>()->SetEnabled(false);
             
@@ -1544,7 +1548,7 @@ void CuChulainn::PerformAttack()
                 playerAnimHeld = true;
             }
 
-            UpdateUltimateVfx();
+            
         }
         else if (ultimateObject->IsEnabled())
         {
@@ -1557,11 +1561,13 @@ void CuChulainn::PerformAttack()
                             ? vfxUltimateAnim->GetAnimationController()->GetTime()
                             : 0.0f;
 
-                if (!vfxUltimateAnim || vfxUltimateAnim->IsFinished() || timeLimit >= ultimateResumeVfxTime)
+                if (!vfxUltimateAnim || vfxUltimateAnim->IsFinished() ||
+                    timeLimit >= ultimateResumeVfxTime / ultimateSpeed)
                 {
                     animComponent->OnResume();
                     playerAnimHeld = false;
                 }
+
             }
             
             if (ultimateSpikes) // Control spikes animation appearance
@@ -1569,20 +1575,23 @@ void CuChulainn::PerformAttack()
                 const bool animReady = vfxUltimateAnim && vfxUltimateAnim->GetCurrentAnimation() && !vfxUltimateAnim->IsFinished();
                 //const float vfxLocalTimer = max(0.0f, ultimateTimer - currentAnimationDelay);
                 bool show = false;
+                bool blurShow = false;
 
                 if (animReady)
                 {
                    //const float vfxTimeAnim = vfxUltimateAnim->GetAnimationController()->GetTime();
                    const float vfxLenAnim        = vfxUltimateAnim->GetCurrentAnimation()->GetDuration();
 
-                   const float spikesOff = min(2.12f, vfxLenAnim - 0.05f);
+                   const float spikesOff         = min(2.12f, vfxLenAnim - 0.05f) / ultimateSpeed;
                    const float vfxLocalTimer     = vfxTimeUnscaledSec;
                    
-                   show                  = (vfxLocalTimer >= 0.40f) && (vfxLocalTimer < spikesOff);     
+                   show = (vfxLocalTimer >= 0.40f / ultimateSpeed) && (vfxLocalTimer < spikesOff);
+                   blurShow = vfxLocalTimer >= 0.19f / ultimateSpeed;
                 }
 
                 if (ultimateSpikes->IsEnabled() != show) ultimateSpikes->SetEnabled(show);
                 if (ultimateCrack && ultimateCrack->IsEnabled() != show) ultimateCrack->SetEnabled(show);
+                if (blurShow) ultimateBlur->GetComponent<ShaderScriptComponent*>()->SetEnabled(true);
             }
             if (ultimateTimer >= currentHitboxDelay + currentAnimationDelay &&
                 ultimateTimer < currentHitboxDelay + currentHitboxDuration + currentAnimationDelay)
@@ -1736,8 +1745,9 @@ void CuChulainn::UpdateUltimateVfx()
         ultimateBlur->SetEnabled(true);
         if (ultimateBlur->GetComponent<ShaderScriptComponent*>())
         {
-            //ultimateBlur->GetComponent<MeshComponent*>()->SetEnabled(false);
+            ultimateBlur->GetComponent<MeshComponent*>()->SetEnabled(false);
             ultimateBlur->GetComponent<ShaderScriptComponent*>()->GetScriptByType<MovingUVTransparent>()->Reset();
+            ultimateBlur->GetComponent<ShaderScriptComponent*>()->SetEnabled(false);
         }
     }
     if (ultimateBrust)

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -630,6 +630,7 @@ void CuChulainn::Update(float deltaTime)
             healParticles->SetEnabled(true);
             healParticles->GetComponent<ParticleSystemComponent*>()->SpawnAllInstances();
         }
+        if (audio) audio->EmitEvent(AK::EVENTS::PLAY_SFX_MC_HEAL);
         Heal(mushroomHeal);
     }
 
@@ -728,6 +729,7 @@ void CuChulainn::OnDeath()
 
     if (state == CharacterStates::AIM && camera) camera->EnableAimOffset(false);
     if (animComponent) animComponent->UseTrigger("Death");
+    if (audio) audio->EmitEvent(AK::EVENTS::PLAY_SFX_MC_DEATH);
 
     isDead          = true;
     pendingGameOver = true;
@@ -740,7 +742,7 @@ void CuChulainn::OnDamageTaken(int amount)
 
     if (healthBar) healthBar->SetFillAmount(static_cast<float>(currentHealth) / static_cast<float>(maxHealth));
 
-    if (audio) audio->EmitEvent(AK::EVENTS::PLAY_SFX_MC_HURT);
+    if (audio && currentHealth >= 1) audio->EmitEvent(AK::EVENTS::PLAY_SFX_MC_HURT);
     AddRiastrad(riastradOnDamageTaken);
 
     if (arrowVfxIsActive && arrowHitVfxObject && !arrowHitVfxObject->IsEnabled())

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.cpp
@@ -549,17 +549,7 @@ bool CuChulainn::Init()
 
     ultimateSpikes = scene->GetGameObjectByParentNameAndTargetName(ultimateName, ultimateSpikesName);
     if (!ultimateSpikes) GLOG("[WARNING] No ultimate spikes VFX found for CuChulain")
-    else ultimateSpikes->SetEnabled(false);
-
-    ultimateExplosion      = scene->GetGameObjectByName(ultimateExplosionName);
-    ultimateExplosion->SetEnabled(true);
-    if (ultimateExplosion)
-    {
-        ultimateSmoke = ultimateExplosion->GetComponent<ShaderScriptComponent*>();
-    }
-    if (ultimateSmoke) ultimateSmoke->SetEnabled(false);
-    if (ultimateExplosion->GetComponent<MeshComponent*>())
-        ultimateExplosion->GetComponent<MeshComponent*>()->SetEnabled(false);
+    else ultimateSpikes->SetEnabled(false); 
 
     CapsuleColliderComponent* playerCollider = parent->GetComponent<CapsuleColliderComponent*>();
     if (playerCollider)
@@ -1557,7 +1547,8 @@ void CuChulainn::PerformAttack()
                 animComponent->OnPause();
                 playerAnimHeld = true;
             }
- 
+
+            
         }
         else if (ultimateObject->IsEnabled())
         {
@@ -1749,18 +1740,6 @@ void CuChulainn::UltimateAttack()
 
 void CuChulainn::UpdateUltimateVfx()
 {
-    if (ultimateSmoke)
-    {
-        /*const float3 characterPos =
-            parent->GetGlobalTransform().TranslatePart() - parent->GetParentGlobalTransform().TranslatePart();
-
-        const float3 offset = float3(-2.0f, 4.0f, 1.5f);
-
-        ultimateSmoke->GetParent()->SetLocalPosition(characterPos + offset);*/
-        ultimateSmoke->SetEnabled(true);
-        ultimateSmoke->GetScriptByType<AttackVfxSpritesheet>()->Reset();
-    }
-
     if (ultimateBlur)
     {
         ultimateBlur->SetEnabled(true);

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
@@ -247,8 +247,6 @@ class CuChulainn : public Character
     std::string ultimateCrackName                  = "ultimate_mesh_crack2";
     std::string ultimateWarningName                = "ultimate_mesh_warning";
     std::string ultimateSpikesName                 = "ult_spike";
-    std::string ultimateExplosionName                 = "UltimateExplosion";
-
     GameObject* ultimateObject                     = nullptr;
     GameObject* ultimateGlow                       = nullptr;
     GameObject* ultimateBlur                       = nullptr;
@@ -256,8 +254,6 @@ class CuChulainn : public Character
     GameObject* ultimateCrack                      = nullptr;
     GameObject* ultimateWarning                    = nullptr;
     GameObject* ultimateSpikes                     = nullptr;
-    GameObject* ultimateExplosion                     = nullptr;
-    ShaderScriptComponent* ultimateSmoke           = nullptr;
     bool desiredUltimate                           = false;
     int ultimateDamage                             = 0;
     float ultimateTimer                            = 0.0f;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
@@ -247,6 +247,8 @@ class CuChulainn : public Character
     std::string ultimateCrackName                  = "ultimate_mesh_crack2";
     std::string ultimateWarningName                = "ultimate_mesh_warning";
     std::string ultimateSpikesName                 = "ult_spike";
+    std::string ultimateExplosionName                 = "UltimateExplosion";
+
     GameObject* ultimateObject                     = nullptr;
     GameObject* ultimateGlow                       = nullptr;
     GameObject* ultimateBlur                       = nullptr;
@@ -254,6 +256,8 @@ class CuChulainn : public Character
     GameObject* ultimateCrack                      = nullptr;
     GameObject* ultimateWarning                    = nullptr;
     GameObject* ultimateSpikes                     = nullptr;
+    GameObject* ultimateExplosion                     = nullptr;
+    ShaderScriptComponent* ultimateSmoke           = nullptr;
     bool desiredUltimate                           = false;
     int ultimateDamage                             = 0;
     float ultimateTimer                            = 0.0f;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/CuChulainn.h
@@ -245,9 +245,6 @@ class CuChulainn : public Character
     std::string ultimateBlurName                   = "ultimate_mesh_blur";
     std::string ultimateBrustName                  = "ultimate_mesh_brust";
     std::string ultimateCrackName                  = "ultimate_mesh_crack2";
-    std::string ultimateHaloName                   = "mesh_halo";
-    std::string ultimateSmokeName                  = "mesh_outer_smoke";
-    std::string ultimateSphereName                 = "mesh_sphere_glow";
     std::string ultimateWarningName                = "ultimate_mesh_warning";
     std::string ultimateSpikesName                 = "ult_spike";
     GameObject* ultimateObject                     = nullptr;
@@ -255,9 +252,6 @@ class CuChulainn : public Character
     GameObject* ultimateBlur                       = nullptr;
     GameObject* ultimateBrust                      = nullptr;
     GameObject* ultimateCrack                      = nullptr;
-    GameObject* ultimateHalo                       = nullptr;
-    GameObject* ultimateSmoke                      = nullptr;
-    GameObject* ultimateSphere                     = nullptr;
     GameObject* ultimateWarning                    = nullptr;
     GameObject* ultimateSpikes                     = nullptr;
     bool desiredUltimate                           = false;
@@ -272,9 +266,10 @@ class CuChulainn : public Character
     bool ultimateUnlocked                          = false;
     bool playerAnimHeld                            = false;
     bool ultimateHoldEnabled                       = true;
-    float ultimateResumeVfxTime                    = 1.9f;
+    float ultimateResumeVfxTime                    = 2.0f;
     float vfxTimeUnscaledSec                       = 0.0f;
     bool ultimateSoundPlayed                       = false;
+    float ultimateSpeed                            = 1.3f;
 
     // Riastrad
     std::string riastradBarName                    = "BarFill";

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Projectile.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Projectile.cpp
@@ -11,8 +11,7 @@
 #include "ShaderScriptComponent.h"
 #include "Standalone/MeshComponent.h"
 #include "Standalone/Physics/CapsuleColliderComponent.h"
-#include "Standalone/Audio/AudioSourceComponent.h"
-#include "Wwise_IDs.h"
+
 
 #include "Math/Quat.h"
 
@@ -56,8 +55,6 @@ bool Projectile::Init()
         GLOG("[WARNING: Projectile Init()] Couldn't find the collider component");
         return false;
     }
-    audio                         = parent->GetComponent<AudioSourceComponent*>();
-    if (!audio) GLOG("[WARNING: Projectile Init()] Couldn't find the audio source component");
 
     GameObject* spritesheetObject = parent->GetChildGameObjectByName(spritesheetNameV);
     if (spritesheetObject)
@@ -101,7 +98,7 @@ void Projectile::Shoot(const float3& origin, const float3& direction)
     this->direction = direction.Normalized();
     frames          = 0;
     if (collider) collider->SetEnabled(false);
-    if (audio) audio->EmitEvent(AK::EVENTS::PLAY_SFX_MC_RANGEATTACK);
+    
 
     // Rotate spear object
     const float3 scale       = parent->GetLocalTransform().ExtractScale();

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Projectile.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Projectile.cpp
@@ -11,6 +11,8 @@
 #include "ShaderScriptComponent.h"
 #include "Standalone/MeshComponent.h"
 #include "Standalone/Physics/CapsuleColliderComponent.h"
+#include "Standalone/Audio/AudioSourceComponent.h"
+#include "Wwise_IDs.h"
 
 #include "Math/Quat.h"
 
@@ -54,6 +56,8 @@ bool Projectile::Init()
         GLOG("[WARNING: Projectile Init()] Couldn't find the collider component");
         return false;
     }
+    audio                         = parent->GetComponent<AudioSourceComponent*>();
+    if (!audio) GLOG("[WARNING: Projectile Init()] Couldn't find the audio source component");
 
     GameObject* spritesheetObject = parent->GetChildGameObjectByName(spritesheetNameV);
     if (spritesheetObject)
@@ -97,6 +101,7 @@ void Projectile::Shoot(const float3& origin, const float3& direction)
     this->direction = direction.Normalized();
     frames          = 0;
     if (collider) collider->SetEnabled(false);
+    if (audio) audio->EmitEvent(AK::EVENTS::PLAY_SFX_MC_RANGEATTACK);
 
     // Rotate spear object
     const float3 scale       = parent->GetLocalTransform().ExtractScale();

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Projectile.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Projectile.h
@@ -7,7 +7,6 @@
 class CapsuleColliderComponent;
 class MeshComponent;
 class AttackVfxSpritesheet;
-class AudioSourceComponent;
 
 class Projectile : public Script
 {
@@ -30,7 +29,6 @@ class Projectile : public Script
 
   private:
     CapsuleColliderComponent* collider = nullptr;
-    AudioSourceComponent* audio        = nullptr;
 
     std::string spritesheetNameV       = "RangedVFX_v";
     std::string spritesheetNameH       = "RangedVFX_h";

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Projectile.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Projectile.h
@@ -7,6 +7,7 @@
 class CapsuleColliderComponent;
 class MeshComponent;
 class AttackVfxSpritesheet;
+class AudioSourceComponent;
 
 class Projectile : public Script
 {
@@ -29,6 +30,7 @@ class Projectile : public Script
 
   private:
     CapsuleColliderComponent* collider = nullptr;
+    AudioSourceComponent* audio        = nullptr;
 
     std::string spritesheetNameV       = "RangedVFX_v";
     std::string spritesheetNameH       = "RangedVFX_h";


### PR DESCRIPTION
A new clean version of the ultimate attack. In this PR has been added:
- Ultimate polished animation.
- Adjusted shader script used in ultimate.
- SFX for heal, death & range attack.

How to test it:
- go to Player_ulti_sfx branch in game repository.
- Test in tutorial scene and check if it works correctly. (in other levels not implemented)

Note: any feedback is welcome in order to modify it in this PR or in a next one. Due to an error that I found while implementing, I tried include a spritesheet for the ultimate but didn't work. In the next PR will be included.