### PR TITLE
Adaptive music THO-1014

### DIFF
--- a/SobrassadaEngine/Modules/EditorUIModule.cpp
+++ b/SobrassadaEngine/Modules/EditorUIModule.cpp
@@ -1157,22 +1157,24 @@ void EditorUIModule::DrawScriptInspector(const std::vector<InspectorField>& fiel
         }
         case InspectorField::FieldType::Audio:
             uint32_t* audioData = static_cast<uint32_t*>(field.data);
-            ImGui::SeparatorText("Audio Source");
+            std::string name = "-";
             for (const auto& event : App->GetAudioModule()->GetEventsMap())
             {
                 if (event.second == *audioData)
                 {
-                    ImGui::Text(event.first.GetString().c_str());
+                    name = event.first.GetString();
                     break;
                 }
             }
+            ImGui::Text(name.c_str());
             ImGui::SameLine();
-            if (ImGui::Button("Select default event"))
+            if (ImGui::Button(field.name.c_str()))
             {
-                ImGui::OpenPopup(CONSTANT_EVENT_SELECT_DIALOG_ID);
+                ImGui::OpenPopup((field.name + CONSTANT_EVENT_SELECT_DIALOG_ID).c_str());
             }
             *audioData = App->GetEditorUIModule()->RenderResourceSelectDialog<uint32_t>(
-                CONSTANT_EVENT_SELECT_DIALOG_ID, App->GetAudioModule()->GetEventsMap(), *audioData
+                (field.name + CONSTANT_EVENT_SELECT_DIALOG_ID).c_str(),
+                App->GetAudioModule()->GetEventsMap(), *audioData
             );
             break;
         }

--- a/SobrassadaEngine/Modules/EditorUIModule.cpp
+++ b/SobrassadaEngine/Modules/EditorUIModule.cpp
@@ -38,6 +38,7 @@
 #include "imgui_impl_sdl2.h"
 #include "imgui_internal.h"
 // imguizmo include after imgui
+#include "AudioModule.h"
 #include "ImGuizmo.h"
 #include <algorithm>
 #include <cstring>
@@ -1154,6 +1155,26 @@ void EditorUIModule::DrawScriptInspector(const std::vector<InspectorField>& fiel
                 curveEditorPoints[0].x = ImGui::CurveTerminator;
             }
         }
+        case InspectorField::FieldType::Audio:
+            uint32_t* audioData = static_cast<uint32_t*>(field.data);
+            ImGui::SeparatorText("Audio Source");
+            for (const auto& event : App->GetAudioModule()->GetEventsMap())
+            {
+                if (event.second == *audioData)
+                {
+                    ImGui::Text(event.first.GetString().c_str());
+                    break;
+                }
+            }
+            ImGui::SameLine();
+            if (ImGui::Button("Select default event"))
+            {
+                ImGui::OpenPopup(CONSTANT_EVENT_SELECT_DIALOG_ID);
+            }
+            *audioData = App->GetEditorUIModule()->RenderResourceSelectDialog<uint32_t>(
+                CONSTANT_EVENT_SELECT_DIALOG_ID, App->GetAudioModule()->GetEventsMap(), *audioData
+            );
+            break;
         }
     }
 }

--- a/SobrassadaEngine/Modules/EditorUIModule.cpp
+++ b/SobrassadaEngine/Modules/EditorUIModule.cpp
@@ -1157,7 +1157,7 @@ void EditorUIModule::DrawScriptInspector(const std::vector<InspectorField>& fiel
         }
         case InspectorField::FieldType::Audio:
             uint32_t* audioData = static_cast<uint32_t*>(field.data);
-            std::string name = "-";
+            std::string name    = "-";
             for (const auto& event : App->GetAudioModule()->GetEventsMap())
             {
                 if (event.second == *audioData)
@@ -1173,8 +1173,8 @@ void EditorUIModule::DrawScriptInspector(const std::vector<InspectorField>& fiel
                 ImGui::OpenPopup((field.name + CONSTANT_EVENT_SELECT_DIALOG_ID).c_str());
             }
             *audioData = App->GetEditorUIModule()->RenderResourceSelectDialog<uint32_t>(
-                (field.name + CONSTANT_EVENT_SELECT_DIALOG_ID).c_str(),
-                App->GetAudioModule()->GetEventsMap(), *audioData
+                (field.name + CONSTANT_EVENT_SELECT_DIALOG_ID).c_str(), App->GetAudioModule()->GetEventsMap(),
+                *audioData
             );
             break;
         }

--- a/SobrassadaEngine/Scene/Components/ScriptComponent.cpp
+++ b/SobrassadaEngine/Scene/Components/ScriptComponent.cpp
@@ -164,7 +164,10 @@ void ScriptComponent::Save(rapidjson::Value& targetState, rapidjson::Document::A
                 scriptData.AddMember(name, arr, allocator);
 
                 break;
-            }
+            };
+            case InspectorField::FieldType::Audio:
+                scriptData.AddMember(name, *(uint32_t*)field.data, allocator);
+                break;
             }
         }
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/GameOverNavigatorScript.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/GameOverNavigatorScript.cpp
@@ -20,6 +20,7 @@
 
 // Need the complete type for Respawn()
 #include "CuChulainn.h"
+#include "MusicManager.h"
 
 // global player declared in CuChulainn.cpp
 extern CuChulainn* playerScript;
@@ -133,7 +134,15 @@ void GameOverNavigatorScript::Update(float)
         if (name == "MenuItem_Continue")
         {
             if (goController) goController->Close();
-            if (playerScript) playerScript->Respawn(); // immediate respawn
+            if (playerScript)
+            {
+                GameObject* musicManager = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName("MusicManager");
+                if (musicManager != nullptr)
+                {
+                    musicManager->GetComponent<ScriptComponent*>()->GetScriptByType<MusicManager>()->OnPlayerRespawn();
+                }
+                playerScript->Respawn(); // immediate respawn
+            }
             builtOnce = false;
             return;
         }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MusicManager.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MusicManager.cpp
@@ -1,10 +1,11 @@
 
 #include "pch.h"
+
 #include "MusicManager.h"
 #include "GameObject.h"
 #include "Standalone/Audio/AudioSourceComponent.h"
 
-MusicManager::MusicManager(GameObject* parent): Script(parent)
+MusicManager::MusicManager(GameObject* parent) : Script(parent)
 {
     fields.emplace_back("First audio event", InspectorField::FieldType::Audio, &firstRespawnAudioEvent);
     fields.emplace_back("Second audio event", InspectorField::FieldType::Audio, &secondRespawnAudioEvent);
@@ -27,7 +28,7 @@ bool MusicManager::Init()
 
 void MusicManager::OnPlayerRespawn() const
 {
-    for (UID childUID: parent->GetChildren())
+    for (UID childUID : parent->GetChildren())
     {
         AppEngine->GetSceneModule()->GetScene()->GetGameObjectByUID(childUID)->SetEnabled(true);
 
@@ -36,5 +37,3 @@ void MusicManager::OnPlayerRespawn() const
         if (thirdRespawnAudioEvent != 0) audioComp->EmitEvent(thirdRespawnAudioEvent);
     }
 }
-
-

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MusicManager.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MusicManager.cpp
@@ -2,14 +2,38 @@
 #include "pch.h"
 #include "MusicManager.h"
 #include "GameObject.h"
+#include "Standalone/Audio/AudioSourceComponent.h"
 
-MusicManager::MusicManager(GameObject* parent): Script(parent){}
+MusicManager::MusicManager(GameObject* parent): Script(parent)
+{
+    fields.emplace_back("First audio event", InspectorField::FieldType::Audio, &firstRespawnAudioEvent);
+    fields.emplace_back("Second audio event", InspectorField::FieldType::Audio, &secondRespawnAudioEvent);
+    fields.emplace_back("Third audio event", InspectorField::FieldType::Audio, &thirdRespawnAudioEvent);
+}
+
+bool MusicManager::Init()
+{
+    // Audio
+    audioComp = parent->GetComponent<AudioSourceComponent*>();
+    if (audioComp == nullptr)
+    {
+        isSetupCorrectly = false;
+        parent->SetEnabled(false);
+        GLOG("[ERROR] Script parent does not contain an audio component")
+        return false;
+    }
+    return true;
+}
 
 void MusicManager::OnPlayerRespawn() const
 {
     for (UID childUID: parent->GetChildren())
     {
         AppEngine->GetSceneModule()->GetScene()->GetGameObjectByUID(childUID)->SetEnabled(true);
+
+        if (firstRespawnAudioEvent != 0) audioComp->EmitEvent(firstRespawnAudioEvent);
+        if (secondRespawnAudioEvent != 0) audioComp->EmitEvent(secondRespawnAudioEvent);
+        if (thirdRespawnAudioEvent != 0) audioComp->EmitEvent(thirdRespawnAudioEvent);
     }
 }
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MusicManager.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MusicManager.cpp
@@ -1,0 +1,16 @@
+
+#include "pch.h"
+#include "MusicManager.h"
+#include "GameObject.h"
+
+MusicManager::MusicManager(GameObject* parent): Script(parent){}
+
+void MusicManager::OnPlayerRespawn() const
+{
+    for (UID childUID: parent->GetChildren())
+    {
+        AppEngine->GetSceneModule()->GetScene()->GetGameObjectByUID(childUID)->SetEnabled(true);
+    }
+}
+
+

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MusicManager.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MusicManager.h
@@ -1,14 +1,29 @@
 #pragma once
 #include "Script.h"
 
+#include <AK/SoundEngine/Common/AkTypes.h>
+
+class AudioSourceComponent;
+
 class MusicManager : public Script
 {
   public:
     MusicManager(GameObject* parent);
 
-    bool Init() override { return true; }
+    bool Init() override;
     void Update(float deltaTime) override {}
 
     void OnPlayerRespawn() const;
+
+private:
+
+    bool isSetupCorrectly               = false;
+    
+    // Audio
+    AudioSourceComponent* audioComp = nullptr;
+
+    AkUniqueID firstRespawnAudioEvent = 0;
+    AkUniqueID secondRespawnAudioEvent = 0;
+    AkUniqueID thirdRespawnAudioEvent = 0;
 
 };

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MusicManager.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MusicManager.h
@@ -15,15 +15,13 @@ class MusicManager : public Script
 
     void OnPlayerRespawn() const;
 
-private:
+  private:
+    bool isSetupCorrectly              = false;
 
-    bool isSetupCorrectly               = false;
-    
     // Audio
-    AudioSourceComponent* audioComp = nullptr;
+    AudioSourceComponent* audioComp    = nullptr;
 
-    AkUniqueID firstRespawnAudioEvent = 0;
+    AkUniqueID firstRespawnAudioEvent  = 0;
     AkUniqueID secondRespawnAudioEvent = 0;
-    AkUniqueID thirdRespawnAudioEvent = 0;
-
+    AkUniqueID thirdRespawnAudioEvent  = 0;
 };

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MusicManager.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MusicManager.h
@@ -1,0 +1,14 @@
+#pragma once
+#include "Script.h"
+
+class MusicManager : public Script
+{
+  public:
+    MusicManager(GameObject* parent);
+
+    bool Init() override { return true; }
+    void Update(float deltaTime) override {}
+
+    void OnPlayerRespawn() const;
+
+};

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MusicTrigger.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MusicTrigger.cpp
@@ -1,0 +1,40 @@
+
+#include "pch.h"
+
+#include "MusicTrigger.h"
+
+#include "CuChulainn.h"
+#include "GameObject.h"
+#include "ScriptComponent.h"
+#include "Wwise_IDs.h"
+#include "Standalone/Audio/AudioSourceComponent.h"
+
+MusicTrigger::MusicTrigger(GameObject* parent): Script(parent)
+{
+    fields.emplace_back("Audio to emit", InspectorField::FieldType::Audio, &audioToEmit);
+}
+
+bool MusicTrigger::Init()
+{
+    // Audio
+    audioComp = parent->GetComponent<AudioSourceComponent*>();
+    if (audioComp == nullptr)
+    {
+        isSetupCorrectly = false;
+        parent->SetEnabled(false);
+        GLOG("[ERROR] Script parent does not contain an audio component")
+        return false;
+    }
+   return true;
+}
+
+void MusicTrigger::OnCollisionEnter(GameObject* otherObject, const float3 collisionNormal, ColliderLayer layer)
+{
+    if (otherObject->GetComponent<ScriptComponent*>() != nullptr &&
+        otherObject->GetComponent<ScriptComponent*>()->GetScriptByType<CuChulainn>() != nullptr)
+    {
+        audioComp->EmitEvent(audioToEmit);
+        parent->SetEnabled(false);
+    }
+}
+

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MusicTrigger.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MusicTrigger.cpp
@@ -11,7 +11,9 @@
 
 MusicTrigger::MusicTrigger(GameObject* parent): Script(parent)
 {
-    fields.emplace_back("Audio to emit", InspectorField::FieldType::Audio, &audioToEmit);
+    fields.emplace_back("First audio event", InspectorField::FieldType::Audio, &firstAudioEvent);
+    fields.emplace_back("Second audio event", InspectorField::FieldType::Audio, &secondAudioEvent);
+    fields.emplace_back("Third audio event", InspectorField::FieldType::Audio, &thirdAudioEvent);
 }
 
 bool MusicTrigger::Init()
@@ -33,7 +35,10 @@ void MusicTrigger::OnCollisionEnter(GameObject* otherObject, const float3 collis
     if (otherObject->GetComponent<ScriptComponent*>() != nullptr &&
         otherObject->GetComponent<ScriptComponent*>()->GetScriptByType<CuChulainn>() != nullptr)
     {
-        audioComp->EmitEvent(audioToEmit);
+        if (firstAudioEvent != 0) audioComp->EmitEvent(firstAudioEvent);
+        if (secondAudioEvent != 0) audioComp->EmitEvent(secondAudioEvent);
+        if (thirdAudioEvent != 0) audioComp->EmitEvent(thirdAudioEvent);
+        
         parent->SetEnabled(false);
     }
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MusicTrigger.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MusicTrigger.cpp
@@ -6,10 +6,9 @@
 #include "CuChulainn.h"
 #include "GameObject.h"
 #include "ScriptComponent.h"
-#include "Wwise_IDs.h"
 #include "Standalone/Audio/AudioSourceComponent.h"
 
-MusicTrigger::MusicTrigger(GameObject* parent): Script(parent)
+MusicTrigger::MusicTrigger(GameObject* parent) : Script(parent)
 {
     fields.emplace_back("First audio event", InspectorField::FieldType::Audio, &firstAudioEvent);
     fields.emplace_back("Second audio event", InspectorField::FieldType::Audio, &secondAudioEvent);
@@ -27,7 +26,7 @@ bool MusicTrigger::Init()
         GLOG("[ERROR] Script parent does not contain an audio component")
         return false;
     }
-   return true;
+    return true;
 }
 
 void MusicTrigger::OnCollisionEnter(GameObject* otherObject, const float3 collisionNormal, ColliderLayer layer)
@@ -38,8 +37,7 @@ void MusicTrigger::OnCollisionEnter(GameObject* otherObject, const float3 collis
         if (firstAudioEvent != 0) audioComp->EmitEvent(firstAudioEvent);
         if (secondAudioEvent != 0) audioComp->EmitEvent(secondAudioEvent);
         if (thirdAudioEvent != 0) audioComp->EmitEvent(thirdAudioEvent);
-        
+
         parent->SetEnabled(false);
     }
 }
-

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MusicTrigger.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MusicTrigger.h
@@ -1,0 +1,26 @@
+#pragma once
+#include "Script.h"
+
+#include <AK/SoundEngine/Common/AkTypes.h>
+
+class AudioSourceComponent;
+
+class MusicTrigger : public Script
+{
+  public:
+    MusicTrigger(GameObject* parent);
+
+    bool Init() override;
+    void Update(float deltaTime) override {}
+    
+    void OnCollisionEnter(GameObject* otherObject, const float3 collisionNormal, ColliderLayer layer) override;
+
+  private:
+    
+    bool isSetupCorrectly               = false;
+    
+    // Audio
+    AudioSourceComponent* audioComp = nullptr;
+
+    AkUniqueID audioToEmit;
+};

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MusicTrigger.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MusicTrigger.h
@@ -22,5 +22,7 @@ class MusicTrigger : public Script
     // Audio
     AudioSourceComponent* audioComp = nullptr;
 
-    AkUniqueID audioToEmit;
+    AkUniqueID firstAudioEvent = 0;
+    AkUniqueID secondAudioEvent = 0;
+    AkUniqueID thirdAudioEvent = 0;
 };

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MusicTrigger.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MusicTrigger.h
@@ -12,17 +12,16 @@ class MusicTrigger : public Script
 
     bool Init() override;
     void Update(float deltaTime) override {}
-    
+
     void OnCollisionEnter(GameObject* otherObject, const float3 collisionNormal, ColliderLayer layer) override;
 
   private:
-    
-    bool isSetupCorrectly               = false;
-    
+    bool isSetupCorrectly           = false;
+
     // Audio
     AudioSourceComponent* audioComp = nullptr;
 
-    AkUniqueID firstAudioEvent = 0;
-    AkUniqueID secondAudioEvent = 0;
-    AkUniqueID thirdAudioEvent = 0;
+    AkUniqueID firstAudioEvent      = 0;
+    AkUniqueID secondAudioEvent     = 0;
+    AkUniqueID thirdAudioEvent      = 0;
 };

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Script.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Script.cpp
@@ -101,6 +101,12 @@ void Script::Load(const rapidjson::Value& initialState)
                 }
             }
             break;
+        case InspectorField::FieldType::Audio:
+            if (value.IsUint64())
+            {
+                *(uint32_t*)field.data = value.GetUint64();
+            }
+            break;
         }
     }
 }
@@ -166,6 +172,9 @@ void Script::CloneFields(const std::vector<InspectorField>& otherFields)
 
             break;
         }
+        case InspectorField::FieldType::Audio:
+            *(uint32_t*)fields[i].data = *(uint32_t*)otherFields[i].data;
+            break;
         }
     }
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Script.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Script.h
@@ -37,6 +37,7 @@ struct InspectorField
         Resource,
         Spacing,
         CurveEditor,
+        Audio
     };
 
     std::string name;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/ScriptExport.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/ScriptExport.cpp
@@ -62,6 +62,8 @@
 #include "Mirage.h"
 #include "MirageBossDash.h"
 #include "BossSpouts.h"
+#include "MusicManager.h"
+#include "MusicTrigger.h"
 
 #include <string>
 
@@ -117,7 +119,9 @@ constexpr const char* scripts[] = {
     "GameOverNavigatorScript",
     "HighlightCharacter",
     "AsyncSceneLoading",
-    "BossSpouts"
+    "BossSpouts",
+    "MusicManager",
+    "MusicTrigger"
 };
 
 constexpr const char* shaderScripts[] = {"MovingUVPostScript",    "MovingUVLight",        "MovingUVTransparent",
@@ -175,6 +179,8 @@ extern "C" SOBRASSADA_API Script* CreateScript(const std::string& scriptType, Ga
     if (scriptType == "MagicBarrier") return new MagicBarrier(parent);
     if (scriptType == "WallCollision") return new WallCollision(parent);
     if (scriptType == "CoverPointTrigger") return new CoverPointTrigger(parent);
+    if (scriptType == "MusicManager") return new MusicManager(parent);
+    if (scriptType == "MusicTrigger") return new MusicTrigger(parent);
 
     /* Utils */
     if (scriptType == "RotateGameObjectScript") return new RotateGameObject(parent);

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj
@@ -511,6 +511,8 @@
     <ClInclude Include="MovingUVTransparent.h" />
     <ClInclude Include="MovingUVClipErode.h" />
     <ClInclude Include="Mushroom.h" />
+    <ClInclude Include="MusicManager.h" />
+    <ClInclude Include="MusicTrigger.h" />
     <ClInclude Include="OptionsMenuSwitcherScript.h" />
     <ClInclude Include="PauseMenuScript.h" />
     <ClInclude Include="GodMode.h" />
@@ -2108,6 +2110,8 @@
     <ClCompile Include="MovingUVTransparent.cpp" />
     <ClCompile Include="MovingUVClipErode.cpp" />
     <ClCompile Include="Mushroom.cpp" />
+    <ClCompile Include="MusicManager.cpp" />
+    <ClCompile Include="MusicTrigger.cpp" />
     <ClCompile Include="OptionsMenuSwitcherScript.cpp" />
     <ClCompile Include="PauseMenuScript.cpp" />
     <ClCompile Include="GodMode.cpp" />

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj.filters
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/SobrassadaScripts.vcxproj.filters
@@ -237,9 +237,15 @@
     </ClInclude>
     <ClInclude Include="BossSpouts.h">
       <Filter>Characters\Boss</Filter>
-	  </ClInclude>
+    </ClInclude>
     <ClInclude Include="MirageVFX.h">
       <Filter>ShaderScripts</Filter>
+    </ClInclude>
+    <ClInclude Include="MusicManager.h">
+      <Filter>Environment</Filter>
+    </ClInclude>
+    <ClInclude Include="MusicTrigger.h">
+      <Filter>Environment</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -1010,9 +1016,15 @@
     </ClCompile>
     <ClCompile Include="BossSpouts.cpp">
       <Filter>Characters\Boss</Filter>
-	</ClCompile>
+    </ClCompile>
     <ClCompile Include="MirageVFX.cpp">
       <Filter>ShaderScripts</Filter>
+    </ClCompile>
+    <ClCompile Include="MusicManager.cpp">
+      <Filter>Environment</Filter>
+    </ClCompile>
+    <ClCompile Include="MusicTrigger.cpp">
+      <Filter>Environment</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Wwise_IDs.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Wwise_IDs.h
@@ -109,6 +109,7 @@ namespace AK
                 static const AkUniqueID COMBAT = 2764240573U;
                 static const AkUniqueID EXPLORING = 1823678183U;
                 static const AkUniqueID MENU = 2607556080U;
+                static const AkUniqueID NONE = 748895195U;
                 static const AkUniqueID RIASTRAD = 3083217571U;
             } // namespace STATE
         } // namespace GAMESTATE
@@ -124,6 +125,7 @@ namespace AK
                 static const AkUniqueID LEVEL2OUTSKIRTS = 1927850271U;
                 static const AkUniqueID LEVEL2WATERFALL = 1545618385U;
                 static const AkUniqueID MAINMENU = 3604647259U;
+                static const AkUniqueID NONE = 748895195U;
                 static const AkUniqueID TUTORIAL = 3762955427U;
             } // namespace STATE
         } // namespace LEVEL

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Wwise_IDs.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Wwise_IDs.h
@@ -13,10 +13,7 @@ namespace AK
 {
     namespace EVENTS
     {
-        static const AkUniqueID PLAY_FIRST_THEME = 1086074370U;
-        static const AkUniqueID PLAY_FOREST = 207755397U;
-        static const AkUniqueID PLAY_LEVEL1_AMBIENT_THEME = 1262494734U;
-        static const AkUniqueID PLAY_LEVEL1_FIGHT_THEME = 2666170724U;
+        static const AkUniqueID PLAY_BACKGROUND_MUSIC = 65769146U;
         static const AkUniqueID PLAY_LOAD1 = 2715237991U;
         static const AkUniqueID PLAY_LOAD2 = 2715237988U;
         static const AkUniqueID PLAY_LOAD3 = 2715237989U;
@@ -74,9 +71,6 @@ namespace AK
         static const AkUniqueID PLAY_SFX_POOKA_HURT = 1906970548U;
         static const AkUniqueID PLAY_SFX_POOKA_UNDERGROUND = 2238694366U;
         static const AkUniqueID PLAY_SFX_SOLDIER_ATTACK = 3285336459U;
-        static const AkUniqueID PLAY_SFX_SOLDIER_DEATH = 3100543291U;
-        static const AkUniqueID PLAY_SFX_SOLDIER_DETECT = 1046414234U;
-        static const AkUniqueID PLAY_SFX_SOLDIER_HURT = 1754859444U;
         static const AkUniqueID PLAY_SFX_SOLDIER_SLASH_1 = 3272153282U;
         static const AkUniqueID PLAY_SFX_SOLDIER_SLASH_2 = 3272153281U;
         static const AkUniqueID PLAY_SFX_SOLDIER_THRUST = 1691226597U;
@@ -92,8 +86,49 @@ namespace AK
         static const AkUniqueID PLAY_SFX_WIND_01 = 4018713014U;
         static const AkUniqueID PLAY_SFX_WIND_02 = 4018713013U;
         static const AkUniqueID PLAY_TORCH = 2025845440U;
-        static const AkUniqueID PLAY_TUTORIAL_THEME = 1202310014U;
+        static const AkUniqueID SET_GAMESTATE_COMBAT = 2438311370U;
+        static const AkUniqueID SET_GAMESTATE_EXPLORING = 1734839042U;
+        static const AkUniqueID SET_GAMESTATE_MENU = 1779817015U;
+        static const AkUniqueID SET_GAMESTATE_RIASTRAD = 2841888884U;
+        static const AkUniqueID SET_LEVELSTATE_BOSS = 1134927265U;
+        static const AkUniqueID SET_LEVELSTATE_LEVEL1 = 3630582617U;
+        static const AkUniqueID SET_LEVELSTATE_LEVEL2OUTSKIRTS = 358656214U;
+        static const AkUniqueID SET_LEVELSTATE_LEVEL2WATERFALL = 2301017940U;
+        static const AkUniqueID SET_LEVELSTATE_MAINMENU = 327831964U;
+        static const AkUniqueID SET_LEVELSTATE_TUTORIAL = 3078324916U;
     } // namespace EVENTS
+
+    namespace STATES
+    {
+        namespace GAMESTATE
+        {
+            static const AkUniqueID GROUP = 4091656514U;
+
+            namespace STATE
+            {
+                static const AkUniqueID COMBAT = 2764240573U;
+                static const AkUniqueID EXPLORING = 1823678183U;
+                static const AkUniqueID MENU = 2607556080U;
+                static const AkUniqueID RIASTRAD = 3083217571U;
+            } // namespace STATE
+        } // namespace GAMESTATE
+
+        namespace LEVEL
+        {
+            static const AkUniqueID GROUP = 2782712965U;
+
+            namespace STATE
+            {
+                static const AkUniqueID BOSS = 1560169506U;
+                static const AkUniqueID LEVEL1 = 2678230382U;
+                static const AkUniqueID LEVEL2OUTSKIRTS = 1927850271U;
+                static const AkUniqueID LEVEL2WATERFALL = 1545618385U;
+                static const AkUniqueID MAINMENU = 3604647259U;
+                static const AkUniqueID TUTORIAL = 3762955427U;
+            } // namespace STATE
+        } // namespace LEVEL
+
+    } // namespace STATES
 
     namespace GAME_PARAMETERS
     {

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Wwise_IDs.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Wwise_IDs.h
@@ -73,6 +73,9 @@ namespace AK
         static const AkUniqueID PLAY_SFX_POOKA_HURT = 1906970548U;
         static const AkUniqueID PLAY_SFX_POOKA_UNDERGROUND = 2238694366U;
         static const AkUniqueID PLAY_SFX_SOLDIER_ATTACK = 3285336459U;
+        static const AkUniqueID PLAY_SFX_SOLDIER_DEATH = 3100543291U;
+        static const AkUniqueID PLAY_SFX_SOLDIER_DETECT = 1046414234U;
+        static const AkUniqueID PLAY_SFX_SOLDIER_HURT = 1754859444U;
         static const AkUniqueID PLAY_SFX_SOLDIER_SLASH_1 = 3272153282U;
         static const AkUniqueID PLAY_SFX_SOLDIER_SLASH_2 = 3272153281U;
         static const AkUniqueID PLAY_SFX_SOLDIER_THRUST = 1691226597U;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Wwise_IDs.h
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/Wwise_IDs.h
@@ -89,13 +89,16 @@ namespace AK
         static const AkUniqueID SET_GAMESTATE_COMBAT = 2438311370U;
         static const AkUniqueID SET_GAMESTATE_EXPLORING = 1734839042U;
         static const AkUniqueID SET_GAMESTATE_MENU = 1779817015U;
+        static const AkUniqueID SET_GAMESTATE_NONE = 112984344U;
         static const AkUniqueID SET_GAMESTATE_RIASTRAD = 2841888884U;
         static const AkUniqueID SET_LEVELSTATE_BOSS = 1134927265U;
         static const AkUniqueID SET_LEVELSTATE_LEVEL1 = 3630582617U;
         static const AkUniqueID SET_LEVELSTATE_LEVEL2OUTSKIRTS = 358656214U;
         static const AkUniqueID SET_LEVELSTATE_LEVEL2WATERFALL = 2301017940U;
         static const AkUniqueID SET_LEVELSTATE_MAINMENU = 327831964U;
+        static const AkUniqueID SET_LEVELSTATE_NONE = 2746918576U;
         static const AkUniqueID SET_LEVELSTATE_TUTORIAL = 3078324916U;
+        static const AkUniqueID STOP_BACKGROUND_MUSIC = 467769552U;
     } // namespace EVENTS
 
     namespace STATES
@@ -114,9 +117,9 @@ namespace AK
             } // namespace STATE
         } // namespace GAMESTATE
 
-        namespace LEVEL
+        namespace LEVELSTATE
         {
-            static const AkUniqueID GROUP = 2782712965U;
+            static const AkUniqueID GROUP = 3473087568U;
 
             namespace STATE
             {
@@ -128,7 +131,7 @@ namespace AK
                 static const AkUniqueID NONE = 748895195U;
                 static const AkUniqueID TUTORIAL = 3762955427U;
             } // namespace STATE
-        } // namespace LEVEL
+        } // namespace LEVELSTATE
 
     } // namespace STATES
 

--- a/SobrassadaEngine/Utils/Script.h
+++ b/SobrassadaEngine/Utils/Script.h
@@ -32,7 +32,8 @@ struct InspectorField
         Button,
         Resource,
         Spacing,
-        CurveEditor
+        CurveEditor,
+        Audio
     };
 
     std::string name;


### PR DESCRIPTION
This PR adds scripts to dynamically control which music track is played in which level and area. 
Once the player enters a dedicated collider the music will change smoothly. 

For testing. open the same branch in the game repo. When spawning, no music is playing. If you continue to walk through the level music will start, and then switch to different tracks once at the end of the fireball area and once at the tree of life behind the bridge. The associated colliders disappear once activated. They are all enabled again once the player respawns (Can no be tested directly as the ui is broken)

Known issues: If there are compile errors in the soldier script just comment out the lines for testing, this problem will disappear with the alpha 3 merge