### PR TITLE
Task/WeHateAssetsFolder-THO-900

### DIFF
--- a/SobrassadaEngine/FileSystem/FileSystem.cpp
+++ b/SobrassadaEngine/FileSystem/FileSystem.cpp
@@ -1,7 +1,7 @@
 #include "FileSystem.h"
 
-#include "rapidjson/istreamwrapper.h"
 #include "DetourAlloc.h"
+#include "rapidjson/istreamwrapper.h"
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -44,7 +44,7 @@ namespace FileSystem
             return 0;
         }
     }
-    //Needs special allocation and C-style loading
+    // Needs special allocation and C-style loading
     unsigned int LoadForDetour(const char* filePath, char** buffer)
     {
         std::ifstream file(filePath, std::ios::in | std::ios::ate | std::ios::binary);
@@ -80,7 +80,6 @@ namespace FileSystem
             return 0;
         }
     }
-
 
     bool LoadJSON(const char* scenePath, rapidjson::Document& doc)
     {
@@ -127,7 +126,7 @@ namespace FileSystem
         return size;
     }
 
-    bool Copy(const char* sourceFilePath, const char* destinationFilePath)
+    bool Copy(const char* sourceFilePath, const char* destinationFilePath, bool recursiveCopy)
     {
         if (!Exists(sourceFilePath))
         {
@@ -136,9 +135,11 @@ namespace FileSystem
         }
 
         std::error_code errorCode;
-        std::filesystem::copy(
-            sourceFilePath, destinationFilePath, std::filesystem::copy_options::update_existing, errorCode
-        );
+
+        auto options = std::filesystem::copy_options::update_existing;
+        if (recursiveCopy) options |= std::filesystem::copy_options::recursive;
+
+        std::filesystem::copy(sourceFilePath, destinationFilePath, options, errorCode);
 
         if (errorCode)
         {

--- a/SobrassadaEngine/FileSystem/FileSystem.h
+++ b/SobrassadaEngine/FileSystem/FileSystem.h
@@ -12,7 +12,7 @@ namespace FileSystem
     unsigned int LoadForDetour(const char* filePath, char** buffer);
     bool SOBRASADA_API_ENGINE LoadJSON(const char* scenePath, rapidjson::Document& doc);
     unsigned int Save(const char* filePath, const void* buffer, unsigned int size, bool asBinary = true, bool append = false);
-    bool Copy(const char* sourceFilePath, const char* destinationFilePath);
+    bool Copy(const char* sourceFilePath, const char* destinationFilePath, bool recursiveCopy = false);
 
     void GetDrives(std::vector<std::string>& drives);
     void SplitAccumulatedPath(const std::string& path, std::vector<std::string>& accPaths);

--- a/SobrassadaEngine/FileSystem/Importers/SceneImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/SceneImporter.cpp
@@ -60,8 +60,7 @@ namespace SceneImporter
             {
                 std::vector<std::pair<UID, UID>> primitives;
 
-                if (srcNode.mesh >= gltfMeshes.size())
-                    gltfMeshes.resize(srcNode.mesh + 1);
+                if (srcNode.mesh >= gltfMeshes.size()) gltfMeshes.resize(srcNode.mesh + 1);
                 const tinygltf::Mesh& srcMesh    = model.meshes[srcNode.mesh];
                 const float4x4& defaultTransform = MeshImporter::GetNodeTransform(srcNode);
                 int primitiveCounter             = 0;
@@ -75,7 +74,7 @@ namespace SceneImporter
                     matIndex   = primitive.material;
                     if (matIndex == -1)
                     {
-                        //GLOG("Material index invalid for mesh: %s. Using default material.", name.c_str());
+                        // GLOG("Material index invalid for mesh: %s. Using default material.", name.c_str());
                         matUID = DEFAULT_MATERIAL_UID;
                     }
                     else if (matIndices.find(matIndex) == matIndices.end())
@@ -95,14 +94,14 @@ namespace SceneImporter
                     primitiveCounter++;
 
                     primitives.emplace_back(meshUID, matUID);
-                    //GLOG("New primitive with mesh UID: %d and Material UID: %d", meshUID, matUID);
+                    // GLOG("New primitive with mesh UID: %d and Material UID: %d", meshUID, matUID);
                 }
 
                 gltfMeshes[srcNode.mesh] = primitives;
             }
         }
 
-        //GLOG("Total .gltf meshes: %d", gltfMeshes.size());
+        // GLOG("Total .gltf meshes: %d", gltfMeshes.size());
 
         // Import Model
         ModelImporter::ImportModel(model, gltfMeshes, filePath, targetFilePath);
@@ -209,7 +208,7 @@ namespace SceneImporter
         if (!importOptions.IsObject()) return;
 
         tinygltf::Model model = LoadModelGLTF(filePath.c_str());
-         int animIndex = importOptions.HasMember("animationIndex") ? importOptions["animationIndex"].GetInt() : 0;
+        int animIndex = importOptions.HasMember("animationIndex") ? importOptions["animationIndex"].GetInt() : 0;
 
         // ONLY IMPORT ANIMATION IF INDEX IS INSIDE ANIMATION RANGE
         if (model.animations.size() > animIndex)
@@ -290,12 +289,21 @@ namespace SceneImporter
             }
         }
 
-        const std::string convertedNavmeshPath    = projectFilePath + NAVMESH_ASSETS_PATH;
+        const std::string convertedNavmeshPath = projectFilePath + NAVMESH_ASSETS_PATH;
         if (!FileSystem::IsDirectory(convertedNavmeshPath.c_str()))
         {
             if (!FileSystem::CreateDirectories(convertedNavmeshPath.c_str()))
             {
                 GLOG("Failed to create directory: %s", convertedNavmeshPath.c_str());
+            }
+        }
+
+        const std::string convertedAssetsLibraryPath = projectFilePath + METADATA_LIB_PATH;
+        if (!FileSystem::IsDirectory(convertedAssetsLibraryPath.c_str()))
+        {
+            if (!FileSystem::CreateDirectories(convertedAssetsLibraryPath.c_str()))
+            {
+                GLOG("Failed to create directory: %s", convertedAssetsLibraryPath.c_str());
             }
         }
 

--- a/SobrassadaEngine/FileSystem/Importers/SceneImporter.cpp
+++ b/SobrassadaEngine/FileSystem/Importers/SceneImporter.cpp
@@ -248,6 +248,7 @@ namespace SceneImporter
                 GLOG("Failed to create directory: %s", convertedAssetPath.c_str());
             }
         }
+
         const std::string convertedScenePath = projectFilePath + SCENES_PATH;
         if (!FileSystem::IsDirectory(convertedScenePath.c_str()))
         {
@@ -256,6 +257,7 @@ namespace SceneImporter
                 GLOG("Failed to create directory: %s", convertedScenePath.c_str());
             }
         }
+
         const std::string convertedModelAssetsPath = projectFilePath + MODELS_ASSETS_PATH;
         if (!FileSystem::IsDirectory(convertedModelAssetsPath.c_str()))
         {
@@ -264,6 +266,7 @@ namespace SceneImporter
                 GLOG("Failed to create directory: %s", convertedModelAssetsPath.c_str());
             }
         }
+
         const std::string convertedMetadataPath = projectFilePath + METADATA_PATH;
         if (!FileSystem::IsDirectory(convertedMetadataPath.c_str()))
         {
@@ -272,6 +275,7 @@ namespace SceneImporter
                 GLOG("Failed to create directory: %s", convertedMetadataPath.c_str());
             }
         }
+
         const std::string convertedPrefabAssetsPath = projectFilePath + PREFABS_ASSETS_PATH;
         if (!FileSystem::IsDirectory(convertedPrefabAssetsPath.c_str()))
         {
@@ -280,6 +284,7 @@ namespace SceneImporter
                 GLOG("Failed to create directory: %s", convertedPrefabAssetsPath.c_str());
             }
         }
+
         const std::string convertedStateMachinePath = projectFilePath + STATEMACHINES_ASSETS_PATH;
         if (!FileSystem::IsDirectory(convertedStateMachinePath.c_str()))
         {
@@ -315,14 +320,7 @@ namespace SceneImporter
                 GLOG("Failed to create directory: %s", convertedAnimationsPath.c_str());
             }
         }
-        const std::string convertedAudioPath = projectFilePath + AUDIO_PATH;
-        if (!FileSystem::IsDirectory(convertedAudioPath.c_str()))
-        {
-            if (!FileSystem::CreateDirectories(convertedAudioPath.c_str()))
-            {
-                GLOG("Failed to create directory: %s", convertedAudioPath.c_str());
-            }
-        }
+
         const std::string convertedBonesPath = projectFilePath + MODELS_LIB_PATH;
         if (!FileSystem::IsDirectory(convertedBonesPath.c_str()))
         {
@@ -331,6 +329,7 @@ namespace SceneImporter
                 GLOG("Failed to create directory: %s", convertedBonesPath.c_str());
             }
         }
+
         const std::string convertedMeshesPath = projectFilePath + MESHES_PATH;
         if (!FileSystem::IsDirectory(convertedMeshesPath.c_str()))
         {
@@ -339,6 +338,7 @@ namespace SceneImporter
                 GLOG("Failed to create directory: %s", convertedMeshesPath.c_str());
             }
         }
+
         const std::string convertedPlayScenePath = projectFilePath + SCENES_PLAY_PATH;
         if (!FileSystem::IsDirectory(convertedPlayScenePath.c_str()))
         {
@@ -347,6 +347,7 @@ namespace SceneImporter
                 GLOG("Failed to create directory: %s", convertedPlayScenePath.c_str());
             }
         }
+
         const std::string convertedTexturesPath = projectFilePath + TEXTURES_PATH;
         if (!FileSystem::IsDirectory(convertedTexturesPath.c_str()))
         {
@@ -355,6 +356,7 @@ namespace SceneImporter
                 GLOG("Failed to create directory: %s", convertedTexturesPath.c_str());
             }
         }
+
         const std::string convertedMaterialsPath = projectFilePath + MATERIALS_PATH;
         if (!FileSystem::IsDirectory(convertedMaterialsPath.c_str()))
         {
@@ -363,6 +365,7 @@ namespace SceneImporter
                 GLOG("Failed to create directory: %s", convertedMaterialsPath.c_str());
             }
         }
+
         const std::string convertedPrefabLibraryPath = projectFilePath + PREFABS_LIB_PATH;
         if (!FileSystem::IsDirectory(convertedPrefabLibraryPath.c_str()))
         {
@@ -371,6 +374,7 @@ namespace SceneImporter
                 GLOG("Failed to create directory: %s", convertedPrefabLibraryPath.c_str());
             }
         }
+
         const std::string convertedStateMachineLibraryPath = projectFilePath + STATEMACHINES_LIB_PATH;
         if (!FileSystem::IsDirectory(convertedStateMachineLibraryPath.c_str()))
         {
@@ -379,6 +383,7 @@ namespace SceneImporter
                 GLOG("Failed to create directory: %s", convertedStateMachineLibraryPath.c_str());
             }
         }
+
         const std::string convertedFontsPath = projectFilePath + FONTS_PATH;
         if (!FileSystem::IsDirectory(convertedFontsPath.c_str()))
         {
@@ -387,6 +392,7 @@ namespace SceneImporter
                 GLOG("Failed to create directory: %s", convertedFontsPath.c_str());
             }
         }
+
         const std::string convertedNavmeshesPath = projectFilePath + NAVMESHES_PATH;
         if (!FileSystem::IsDirectory(convertedNavmeshesPath.c_str()))
         {

--- a/SobrassadaEngine/FileSystem/Meta/MetaFile.cpp
+++ b/SobrassadaEngine/FileSystem/Meta/MetaFile.cpp
@@ -44,4 +44,11 @@ void MetaFile::Save(const std::string& name, const std::string& assetPath) const
         (unsigned int)FileSystem::Save(savePath.c_str(), buffer.GetString(), (unsigned int)buffer.GetSize(), false);
 
     if (bytesWritten == 0) GLOG("Failed to save meta file: %s", assetPath.c_str());
+
+    savePath = App->GetProjectModule()->GetLoadedProjectPath() + METADATA_LIB_PATH + std::to_string(prefix) +
+               FILENAME_SEPARATOR + name + META_EXTENSION;
+    bytesWritten =
+        (unsigned int)FileSystem::Save(savePath.c_str(), buffer.GetString(), (unsigned int)buffer.GetSize(), false);
+
+    if (bytesWritten == 0) GLOG("Failed to save meta file: %s", assetPath.c_str());
 }

--- a/SobrassadaEngine/Modules/LibraryModule.cpp
+++ b/SobrassadaEngine/Modules/LibraryModule.cpp
@@ -33,8 +33,12 @@ bool LibraryModule::Init()
     if (App->GetProjectModule()->IsProjectLoaded())
     {
         const std::string& engineDefaultPath = ENGINE_DEFAULT_ASSETS;
+#ifndef GAME
         SceneImporter::CreateLibraryDirectories(App->GetProjectModule()->GetLoadedProjectPath());
         SceneImporter::CreateLibraryDirectories(engineDefaultPath);
+#endif
+        CopyMetadata(App->GetProjectModule()->GetLoadedProjectPath());
+        CopyMetadata(engineDefaultPath);
         LoadLibraryMaps(App->GetProjectModule()->GetLoadedProjectPath());
         LoadLibraryMaps(engineDefaultPath);
     }
@@ -136,7 +140,7 @@ bool LibraryModule::LoadScene(const char* file, bool reload) const
 
 bool LibraryModule::LoadLibraryMaps(const std::string& projectPath)
 {
-    for (const auto& entry : std::filesystem::recursive_directory_iterator(projectPath + METADATA_PATH))
+    for (const auto& entry : std::filesystem::recursive_directory_iterator(projectPath + METADATA_LIB_PATH))
     {
         if (entry.is_regular_file() && (FileSystem::GetFileExtension(entry.path().string()) == META_EXTENSION))
         {
@@ -318,6 +322,12 @@ void LibraryModule::DeletePrefabFiles(UID prefabUID)
 
     FileSystem::Delete(metaPath.c_str());
 
+    const std::string metaLibPath = App->GetProjectModule()->GetLoadedProjectPath() + METADATA_LIB_PATH +
+                                    std::to_string((int)ResourceType::Prefab) + FILENAME_SEPARATOR +
+                                    GetResourceName(prefabUID) + META_EXTENSION;
+
+    FileSystem::Delete(metaLibPath.c_str());
+
     const std::string assetPath = App->GetProjectModule()->GetLoadedProjectPath() + PREFABS_ASSETS_PATH +
                                   GetResourceName(prefabUID) + PREFAB_EXTENSION;
 
@@ -481,7 +491,7 @@ const std::string& LibraryModule::GetResourcePath(UID resourceID) const
 
 void LibraryModule::CreateCacheForMetadata(const std::string& path)
 {
-    for (const auto& entry : std::filesystem::recursive_directory_iterator(path + METADATA_PATH))
+    for (const auto& entry : std::filesystem::recursive_directory_iterator(path + METADATA_LIB_PATH))
     {
         if (entry.is_regular_file() && (FileSystem::GetFileExtension(entry.path().string()) == META_EXTENSION))
         {
@@ -497,6 +507,14 @@ void LibraryModule::CreateCacheForMetadata(const std::string& path)
             }
         }
     }
+}
+
+void LibraryModule::CopyMetadata(const std::string& path)
+{
+    const std::string source      = path + METADATA_PATH;
+    const std::string destination = path + METADATA_LIB_PATH;
+
+    FileSystem::Copy(source.c_str(), destination.c_str(), true);
 }
 
 const std::string& LibraryModule::GetResourceName(UID resourceID) const

--- a/SobrassadaEngine/Modules/LibraryModule.cpp
+++ b/SobrassadaEngine/Modules/LibraryModule.cpp
@@ -33,10 +33,9 @@ bool LibraryModule::Init()
     if (App->GetProjectModule()->IsProjectLoaded())
     {
         const std::string& engineDefaultPath = ENGINE_DEFAULT_ASSETS;
-#ifndef GAME
         SceneImporter::CreateLibraryDirectories(App->GetProjectModule()->GetLoadedProjectPath());
         SceneImporter::CreateLibraryDirectories(engineDefaultPath);
-#endif
+        CopyScenes(App->GetProjectModule()->GetLoadedProjectPath());
         CopyMetadata(App->GetProjectModule()->GetLoadedProjectPath());
         CopyMetadata(engineDefaultPath);
         LoadLibraryMaps(App->GetProjectModule()->GetLoadedProjectPath());
@@ -91,7 +90,8 @@ bool LibraryModule::SaveScene(const char* path, SaveMode saveMode) const
             sceneFilePath = App->GetProjectModule()->GetLoadedProjectPath() + SCENES_PLAY_PATH +
                             std::to_string(sceneUID) + SCENE_EXTENSION;
         else
-            sceneFilePath = App->GetProjectModule()->GetLoadedProjectPath() + SCENES_PATH + sceneName + SCENE_EXTENSION;
+            sceneFilePath =
+                App->GetProjectModule()->GetLoadedProjectPath() + SCENES_PATH + sceneName + SCENE_EXTENSION;
 
         unsigned int bytesWritten = (unsigned int
         )FileSystem::Save(sceneFilePath.c_str(), buffer.GetString(), (unsigned int)buffer.GetSize(), false);
@@ -100,6 +100,8 @@ bool LibraryModule::SaveScene(const char* path, SaveMode saveMode) const
             GLOG("Failed to save scene file: %s", sceneName.c_str());
             return false;
         }
+
+        if (saveMode != SaveMode::SavePlayMode) CopyScene(sceneFilePath);
 
         // GLOG("%s saved as scene", sceneName.c_str());
         return true;
@@ -114,9 +116,7 @@ bool LibraryModule::LoadScene(const char* file, bool reload) const
 {
     rapidjson::Document doc;
 
-    std::string path;
-    if (reload) path = App->GetProjectModule()->GetLoadedProjectPath() + SCENES_PLAY_PATH;
-    else path = App->GetProjectModule()->GetLoadedProjectPath() + SCENES_PATH;
+    const std::string path = App->GetProjectModule()->GetLoadedProjectPath() + SCENES_PLAY_PATH;
 
     bool loaded = FileSystem::LoadJSON((path + std::string(file)).c_str(), doc);
 
@@ -509,12 +509,27 @@ void LibraryModule::CreateCacheForMetadata(const std::string& path)
     }
 }
 
-void LibraryModule::CopyMetadata(const std::string& path)
+void LibraryModule::CopyMetadata(const std::string& path) const
 {
     const std::string source      = path + METADATA_PATH;
     const std::string destination = path + METADATA_LIB_PATH;
 
     FileSystem::Copy(source.c_str(), destination.c_str(), true);
+}
+
+void LibraryModule::CopyScenes(const std::string& path) const
+{
+    const std::string source      = path + SCENES_PATH;
+    const std::string destination = path + SCENES_PLAY_PATH;
+
+    FileSystem::Copy(source.c_str(), destination.c_str(), true);
+}
+
+void LibraryModule::CopyScene(const std::string& pathFile) const
+{
+    const std::string destination = App->GetProjectModule()->GetLoadedProjectPath() + SCENES_PLAY_PATH;
+
+    FileSystem::Copy(pathFile.c_str(), destination.c_str());
 }
 
 const std::string& LibraryModule::GetResourceName(UID resourceID) const

--- a/SobrassadaEngine/Modules/LibraryModule.h
+++ b/SobrassadaEngine/Modules/LibraryModule.h
@@ -88,6 +88,7 @@ class SOBRASADA_API_ENGINE LibraryModule : public Module
 
   private:
     void CreateCacheForMetadata(const std::string& path);
+    void CopyMetadata(const std::string& path);
 
     std::unordered_map<UID, std::string> cachedMetadataDocuments;
 

--- a/SobrassadaEngine/Modules/LibraryModule.h
+++ b/SobrassadaEngine/Modules/LibraryModule.h
@@ -88,7 +88,9 @@ class SOBRASADA_API_ENGINE LibraryModule : public Module
 
   private:
     void CreateCacheForMetadata(const std::string& path);
-    void CopyMetadata(const std::string& path);
+    void CopyMetadata(const std::string& path) const;
+    void CopyScenes(const std::string& path) const;
+    void CopyScene(const std::string& path) const;
 
     std::unordered_map<UID, std::string> cachedMetadataDocuments;
 

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/AsyncSceneLoading.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/AsyncSceneLoading.cpp
@@ -23,7 +23,7 @@ bool AsyncSceneLoading::Init()
     }
 
     fullScenePath =
-        AppEngine->GetProjectModule()->GetLoadedProjectPath() + SCENES_PATH + targetSceneName + SCENE_EXTENSION;
+        AppEngine->GetProjectModule()->GetLoadedProjectPath() + SCENES_PLAY_PATH + targetSceneName + SCENE_EXTENSION;
 
     videoComponent->Play();
     if (useAsyncLoading) AppEngine->GetSceneModule()->InitAsyncScenePreLoad(fullScenePath);

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/ChangeSceneScript.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/ChangeSceneScript.cpp
@@ -21,7 +21,7 @@ ChangeSceneScript::ChangeSceneScript(GameObject* parent) : Script(parent)
 bool ChangeSceneScript::Init()
 {
     player        = AppEngine->GetSceneModule()->GetScene()->GetGameObjectByName(playerName);
-    scenesPath    = AppEngine->GetProjectModule()->GetLoadedProjectPath() + SCENES_PATH;
+    scenesPath    = AppEngine->GetProjectModule()->GetLoadedProjectPath() + SCENES_PLAY_PATH;
     fullScenePath = scenesPath + targetSceneName + SCENE_EXTENSION;
 
     if (!player)

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/GameOverNavigatorScript.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/GameOverNavigatorScript.cpp
@@ -142,7 +142,7 @@ void GameOverNavigatorScript::Update(float)
             if (goController) goController->Close();
             AppEngine->GetSceneModule()->GetScene()->SetStopPlaying(true);
             std::string path =
-                AppEngine->GetProjectModule()->GetLoadedProjectPath() + SCENES_PATH + "SCENE_MainMenu.scene";
+                AppEngine->GetProjectModule()->GetLoadedProjectPath() + SCENES_PLAY_PATH + "SCENE_MainMenu.scene";
             AppEngine->GetSceneModule()->RequestSceneLoad(path);
             builtOnce = false;
             return;

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MainMenuSelectorScript.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MainMenuSelectorScript.cpp
@@ -228,7 +228,7 @@ void MainMenuSelectorScript::Update(float)
             if (pauseCtrl) pauseCtrl->Close();
             AppEngine->GetSceneModule()->GetScene()->SetStopPlaying(true);
             std::string path =
-                AppEngine->GetProjectModule()->GetLoadedProjectPath() + SCENES_PATH + "SCENE_MainMenu.scene";
+                AppEngine->GetProjectModule()->GetLoadedProjectPath() + SCENES_PLAY_PATH + "SCENE_MainMenu.scene";
             AppEngine->GetSceneModule()->RequestSceneLoad(path);
             return;
         }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MenuChangeSceneScript.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/MenuChangeSceneScript.cpp
@@ -17,7 +17,7 @@ MenuChangeSceneScript::MenuChangeSceneScript(GameObject* parent) : Script(parent
 bool MenuChangeSceneScript::Init()
 {
     inputDelayFrames = 10;
-    scenesPath    = AppEngine->GetProjectModule()->GetLoadedProjectPath() + SCENES_PATH;
+    scenesPath    = AppEngine->GetProjectModule()->GetLoadedProjectPath() + SCENES_PLAY_PATH;
     fullScenePath = scenesPath + targetSceneName + SCENE_EXTENSION;
     return true;
 }

--- a/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/PauseMenuScript.cpp
+++ b/SobrassadaEngine/Scripting/SobrassadaScripts/SobrassadaScripts/PauseMenuScript.cpp
@@ -313,7 +313,7 @@ void PauseMenuScript::HandleInput()
             Close();
             AppEngine->GetSceneModule()->GetScene()->SetStopPlaying(true);
             std::string path =
-                AppEngine->GetProjectModule()->GetLoadedProjectPath() + SCENES_PATH + "SCENE_MainMenu.scene";
+                AppEngine->GetProjectModule()->GetLoadedProjectPath() + SCENES_PLAY_PATH + "SCENE_MainMenu.scene";
             AppEngine->GetSceneModule()->RequestSceneLoad(path);
             return;
         }

--- a/SobrassadaEngine/Utils/Globals.h
+++ b/SobrassadaEngine/Utils/Globals.h
@@ -100,6 +100,7 @@ constexpr const char* NAVMESH_ASSETS_PATH               = "Assets/Navmeshes/";
 constexpr const char* VIDEOS_ASSETS_PATH                = "Assets/Videos/";
 
 constexpr const char* LIBRARY_PATH                      = "Library/";
+constexpr const char* METADATA_LIB_PATH                = "Library/Metadata/";
 constexpr const char* ANIMATIONS_PATH                   = "Library/Animations/";
 constexpr const char* AUDIO_PATH                        = "Library/Audio/";
 constexpr const char* MODELS_LIB_PATH                   = "Library/Models/";

--- a/SobrassadaEngine/Utils/Globals.h
+++ b/SobrassadaEngine/Utils/Globals.h
@@ -97,12 +97,10 @@ constexpr const char* PREFABS_ASSETS_PATH               = "Assets/Prefabs/";
 constexpr const char* MODELS_ASSETS_PATH                = "Assets/Models/";
 constexpr const char* STATEMACHINES_ASSETS_PATH         = "Assets/StateMachines/";
 constexpr const char* NAVMESH_ASSETS_PATH               = "Assets/Navmeshes/";
-constexpr const char* VIDEOS_ASSETS_PATH                = "Assets/Videos/";
 
 constexpr const char* LIBRARY_PATH                      = "Library/";
-constexpr const char* METADATA_LIB_PATH                = "Library/Metadata/";
+constexpr const char* METADATA_LIB_PATH                 = "Library/Metadata/";
 constexpr const char* ANIMATIONS_PATH                   = "Library/Animations/";
-constexpr const char* AUDIO_PATH                        = "Library/Audio/";
 constexpr const char* MODELS_LIB_PATH                   = "Library/Models/";
 constexpr const char* MESHES_PATH                       = "Library/Meshes/";
 constexpr const char* SCENES_PLAY_PATH                  = "Library/Scenes/";
@@ -112,6 +110,7 @@ constexpr const char* STATEMACHINES_LIB_PATH            = "Library/StateMachines
 constexpr const char* PREFABS_LIB_PATH                  = "Library/Prefabs/";
 constexpr const char* FONTS_PATH                        = "Library/Fonts/";
 constexpr const char* NAVMESHES_PATH                    = "Library/Navmeshes/";
+constexpr const char* VIDEOS_ASSETS_PATH                = "Library/Videos/";
 
 constexpr const char* ASSET_EXTENSION                   = ".gltf";
 constexpr const char* MESH_EXTENSION                    = ".sobrassada";
@@ -130,7 +129,7 @@ constexpr const char* VIDEOS_EXTENSION                  = ".mp4";
 constexpr int MAX_COMPONENT_NAME_LENGTH                 = 64;
 
 // Soundbanks
-constexpr const char* WINDOWS_BANKS_PATH                = "Assets\\Soundbanks\\Windows\\";
+constexpr const char* WINDOWS_BANKS_PATH                = "Library\\Soundbanks\\Windows\\";
 constexpr const wchar_t* BANKNAME_INIT                  = L"Init.bnk";
 constexpr const wchar_t* BANKNAME_MAIN                  = L"main.bnk";
 constexpr const char* BANKMETA_MAIN                     = "main.json";

--- a/SobrassadaEngine/Utils/Globals.h
+++ b/SobrassadaEngine/Utils/Globals.h
@@ -90,6 +90,7 @@ constexpr const char* DEBUG_DLL_PATH                    = "..\\SobrassadaEngine\
 constexpr const char* RELEASE_DLL_PATH                  = "..\\SobrassadaEngine\\x64\\Release\\SobrassadaScripts.dll";
 
 constexpr const char* ENGINE_DEFAULT_ASSETS             = "EngineDefaults/";
+constexpr const char* VIDEOS_ASSETS_PATH                = "Videos/";
 constexpr const char* ASSETS_PATH                       = "Assets/";
 constexpr const char* SCENES_PATH                       = "Assets/Scenes/";
 constexpr const char* METADATA_PATH                     = "Assets/Metadata/";
@@ -110,7 +111,6 @@ constexpr const char* STATEMACHINES_LIB_PATH            = "Library/StateMachines
 constexpr const char* PREFABS_LIB_PATH                  = "Library/Prefabs/";
 constexpr const char* FONTS_PATH                        = "Library/Fonts/";
 constexpr const char* NAVMESHES_PATH                    = "Library/Navmeshes/";
-constexpr const char* VIDEOS_ASSETS_PATH                = "Library/Videos/";
 
 constexpr const char* ASSET_EXTENSION                   = ".gltf";
 constexpr const char* MESH_EXTENSION                    = ".sobrassada";
@@ -129,7 +129,7 @@ constexpr const char* VIDEOS_EXTENSION                  = ".mp4";
 constexpr int MAX_COMPONENT_NAME_LENGTH                 = 64;
 
 // Soundbanks
-constexpr const char* WINDOWS_BANKS_PATH                = "Library\\Soundbanks\\Windows\\";
+constexpr const char* WINDOWS_BANKS_PATH                = "Soundbanks\\Windows\\";
 constexpr const wchar_t* BANKNAME_INIT                  = L"Init.bnk";
 constexpr const wchar_t* BANKNAME_MAIN                  = L"main.bnk";
 constexpr const char* BANKMETA_MAIN                     = "main.json";


### PR DESCRIPTION
No assets folder needed anymore for playing.
Now audio and videos need to be outside of assets folder. See the following image.
![image](https://github.com/user-attachments/assets/335834ee-4d4d-4583-9292-6d644c8e280f)

One thing to consider, when importing something that creates metadata, it is also created in library folder, but if assets folder is deleted, it will stay only in library and pushes to GitHub will not include these new metadata files.

How to test:
Build library running once, then stop engine, delete assets folders in hound of ulster and engine and running and playing the game.
Also, test moving things and saving the scene, or doing things with metadata.